### PR TITLE
feat: アニメーションライブラリをFramer Motionに移行

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       hono:
         specifier: ^4.7.0
         version: 4.11.8
+      motion:
+        specifier: ^12.33.0
+        version: 12.33.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -939,6 +942,20 @@ packages:
       picomatch:
         optional: true
 
+  framer-motion@12.33.0:
+    resolution: {integrity: sha512-ca8d+rRPcDP5iIF+MoT3WNc0KHJMjIyFAbtVLvM9eA7joGSpeqDfiNH/kCs1t4CHi04njYvWyj0jS4QlEK/rJQ==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1214,6 +1231,26 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  motion-dom@12.33.0:
+    resolution: {integrity: sha512-XRPebVypsl0UM+7v0Hr8o9UAj0S2djsQWRdHBd5iVouVpMrQqAI0C/rDAT3QaYnXnHuC5hMcwDHCboNeyYjPoQ==}
+
+  motion-utils@12.29.2:
+    resolution: {integrity: sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==}
+
+  motion@12.33.0:
+    resolution: {integrity: sha512-TcND7PijsrTeIA9SRVUB8TOJQ+6mJnJ5K4a9oAJZvyI0Zy47Gq5oofU+VkTxbLcvDoKXnHspQcII2mnk3TbFsQ==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1324,6 +1361,9 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -2098,6 +2138,15 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  framer-motion@12.33.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      motion-dom: 12.33.0
+      motion-utils: 12.29.2
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   fsevents@2.3.3:
     optional: true
 
@@ -2565,6 +2614,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  motion-dom@12.33.0:
+    dependencies:
+      motion-utils: 12.29.2
+
+  motion-utils@12.29.2: {}
+
+  motion@12.33.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      framer-motion: 12.33.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -2725,6 +2788,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@hono/node-server": "^1.14.0",
     "hono": "^4.7.0",
+    "motion": "^12.33.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -1,5 +1,5 @@
-import { createServer } from "node:http";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { createServer } from "node:http";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Hono } from "hono";

--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -1,3 +1,4 @@
+import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useState } from "react";
 import {
   type Feature,
@@ -9,6 +10,16 @@ import {
 import { MarkdownPane } from "./MarkdownPane";
 
 type LeftTab = "overview" | "source-info";
+
+const cardContainerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.06 } },
+};
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 12 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.4, ease: "easeOut" } },
+};
 
 export function AppView({ appName }: { appName: string }) {
   const [overview, setOverview] = useState("");
@@ -43,16 +54,30 @@ export function AppView({ appName }: { appName: string }) {
   if (loading) {
     return (
       <div className="flex h-full items-center justify-center">
-        <div className="flex flex-col items-center gap-3 animate-fade-in">
-          <div className="size-8 rounded-full border-2 border-indigo-200 border-t-indigo-500 animate-spin" />
+        <motion.div
+          className="flex flex-col items-center gap-3"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.3 }}
+        >
+          <motion.div
+            className="size-8 rounded-full border-2 border-indigo-200 border-t-indigo-500"
+            animate={{ rotate: 360 }}
+            transition={{ duration: 1, repeat: Number.POSITIVE_INFINITY, ease: "linear" }}
+          />
           <p className="text-xs text-gray-400">読み込み中...</p>
-        </div>
+        </motion.div>
       </div>
     );
   }
 
   return (
-    <div className="flex h-full animate-fade-in">
+    <motion.div
+      className="flex h-full"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+    >
       {/* 左ペイン: Overview / Source Info */}
       <div className="flex-1 flex flex-col min-w-0 border-r border-gray-200">
         {/* Tabs */}
@@ -70,9 +95,17 @@ export function AppView({ appName }: { appName: string }) {
         </div>
         {/* Content */}
         <div className="flex-1 overflow-y-auto custom-scrollbar p-6 bg-white">
-          <div className="animate-scale-in">
-            <MarkdownPane content={leftTab === "overview" ? overview : sourceInfo} />
-          </div>
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={leftTab}
+              initial={{ opacity: 0, scale: 0.98 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.98 }}
+              transition={{ duration: 0.25 }}
+            >
+              <MarkdownPane content={leftTab === "overview" ? overview : sourceInfo} />
+            </motion.div>
+          </AnimatePresence>
         </div>
       </div>
 
@@ -89,7 +122,12 @@ export function AppView({ appName }: { appName: string }) {
             label="Features"
           />
           {selectedFeature && (
-            <span className="flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium text-indigo-600 border-b-2 border-indigo-500 animate-slide-right">
+            <motion.span
+              className="flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium text-indigo-600 border-b-2 border-indigo-500"
+              initial={{ opacity: 0, x: -8 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ duration: 0.25 }}
+            >
               <svg
                 aria-hidden="true"
                 className="size-3"
@@ -105,91 +143,119 @@ export function AppView({ appName }: { appName: string }) {
                 />
               </svg>
               {features.find((f) => f.id === selectedFeature)?.title ?? selectedFeature}
-            </span>
+            </motion.span>
           )}
         </div>
         {/* Content */}
         <div className="flex-1 overflow-y-auto custom-scrollbar p-6 bg-white">
-          {selectedFeature ? (
-            <div className="animate-scale-in">
-              <button
-                type="button"
-                onClick={() => {
-                  setSelectedFeature(null);
-                  setFeatureContent("");
-                }}
-                className="group inline-flex items-center gap-1.5 mb-4 px-3 py-1.5 text-xs font-medium text-gray-500 bg-gray-100 rounded-full hover:bg-indigo-50 hover:text-indigo-600 transition-all duration-200"
+          <AnimatePresence mode="wait">
+            {selectedFeature ? (
+              <motion.div
+                key={selectedFeature}
+                initial={{ opacity: 0, scale: 0.98 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.98 }}
+                transition={{ duration: 0.25 }}
               >
-                <svg
-                  aria-hidden="true"
-                  className="size-3 transition-transform duration-200 group-hover:-translate-x-0.5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M15 19l-7-7 7-7"
-                  />
-                </svg>
-                一覧に戻る
-              </button>
-              <MarkdownPane content={featureContent} />
-            </div>
-          ) : (
-            <div className="space-y-2">
-              {features.map((f, i) => (
-                <button
+                <motion.button
                   type="button"
-                  key={f.id}
-                  style={{ animationDelay: `${i * 60}ms` }}
-                  className="
-                    group w-full flex items-start gap-4 p-4 rounded-xl border border-gray-100
-                    bg-white text-left transition-all duration-300
-                    hover:border-indigo-200 hover:shadow-lg hover:shadow-indigo-500/5 hover:-translate-y-0.5
-                    animate-slide-up opacity-0
-                  "
-                  onClick={() => setSelectedFeature(f.id)}
+                  onClick={() => {
+                    setSelectedFeature(null);
+                    setFeatureContent("");
+                  }}
+                  className="group inline-flex items-center gap-1.5 mb-4 px-3 py-1.5 text-xs font-medium text-gray-500 bg-gray-100 rounded-full"
+                  whileHover={{ backgroundColor: "#eef2ff", color: "#4f46e5" }}
+                  transition={{ duration: 0.2 }}
                 >
-                  {/* Number Badge */}
-                  <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-50 to-purple-50 text-indigo-600 text-xs font-bold transition-all duration-300 group-hover:from-indigo-100 group-hover:to-purple-100 group-hover:shadow-md group-hover:shadow-indigo-500/10">
-                    {f.id.split("_")[0]}
-                  </span>
-                  {/* Content */}
-                  <div className="min-w-0 flex-1">
-                    <h3 className="text-sm font-semibold text-gray-800 group-hover:text-indigo-700 transition-colors duration-200">
-                      {f.title}
-                    </h3>
-                    {f.summary && (
-                      <p className="mt-1 text-xs text-gray-500 leading-relaxed line-clamp-2">
-                        {f.summary}
-                      </p>
-                    )}
-                  </div>
-                  {/* Arrow */}
-                  <svg
+                  <motion.svg
                     aria-hidden="true"
-                    className="size-4 shrink-0 mt-0.5 text-gray-300 transition-all duration-200 group-hover:text-indigo-400 group-hover:translate-x-0.5"
+                    className="size-3"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
+                    whileHover={{ x: -2 }}
+                    transition={{ duration: 0.2 }}
                   >
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"
                       strokeWidth={2}
-                      d="M9 5l7 7-7 7"
+                      d="M15 19l-7-7 7-7"
                     />
-                  </svg>
-                </button>
-              ))}
-            </div>
-          )}
+                  </motion.svg>
+                  一覧に戻る
+                </motion.button>
+                <MarkdownPane content={featureContent} />
+              </motion.div>
+            ) : (
+              <motion.div
+                key="feature-list"
+                className="space-y-2"
+                variants={cardContainerVariants}
+                initial="hidden"
+                animate="visible"
+              >
+                {features.map((f) => (
+                  <motion.button
+                    type="button"
+                    key={f.id}
+                    variants={cardVariants}
+                    whileHover={{
+                      y: -2,
+                      boxShadow: "0 10px 25px -5px rgba(99, 102, 241, 0.08)",
+                      borderColor: "#c7d2fe",
+                    }}
+                    whileTap={{ scale: 0.995 }}
+                    className="group w-full flex items-start gap-4 p-4 rounded-xl border border-gray-100 bg-white text-left"
+                    onClick={() => setSelectedFeature(f.id)}
+                  >
+                    {/* Number Badge */}
+                    <motion.span
+                      className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-50 to-purple-50 text-indigo-600 text-xs font-bold"
+                      whileHover={{
+                        background: "linear-gradient(to bottom right, #e0e7ff, #ede9fe)",
+                        boxShadow: "0 4px 12px rgba(99, 102, 241, 0.15)",
+                      }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      {f.id.split("_")[0]}
+                    </motion.span>
+                    {/* Content */}
+                    <div className="min-w-0 flex-1">
+                      <h3 className="text-sm font-semibold text-gray-800 group-hover:text-indigo-700">
+                        {f.title}
+                      </h3>
+                      {f.summary && (
+                        <p className="mt-1 text-xs text-gray-500 leading-relaxed line-clamp-2">
+                          {f.summary}
+                        </p>
+                      )}
+                    </div>
+                    {/* Arrow */}
+                    <motion.svg
+                      aria-hidden="true"
+                      className="size-4 shrink-0 mt-0.5 text-gray-300"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      whileHover={{ x: 2, color: "#818cf8" }}
+                      transition={{ duration: 0.2 }}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 5l7 7-7 7"
+                      />
+                    </motion.svg>
+                  </motion.button>
+                ))}
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
       </div>
-    </div>
+    </motion.div>
   );
 }
 
@@ -206,19 +272,18 @@ function TabButton({
     <button
       type="button"
       className={`
-        relative px-3 py-2.5 text-xs font-medium transition-colors duration-200
+        relative px-3 py-2.5 text-xs font-medium
         ${active ? "text-indigo-600" : "text-gray-400 hover:text-gray-600"}
       `}
       onClick={onClick}
     >
       {label}
       {/* Animated underline */}
-      <span
-        className={`
-          absolute bottom-0 left-1/2 -translate-x-1/2 h-0.5 rounded-full bg-indigo-500
-          transition-all duration-300 ease-out
-          ${active ? "w-full" : "w-0"}
-        `}
+      <motion.span
+        className="absolute bottom-0 left-0 h-0.5 rounded-full bg-indigo-500"
+        initial={false}
+        animate={{ width: active ? "100%" : "0%", opacity: active ? 1 : 0 }}
+        transition={{ duration: 0.3, ease: "easeOut" }}
       />
     </button>
   );

--- a/viewer/src/components/MarkdownPane.tsx
+++ b/viewer/src/components/MarkdownPane.tsx
@@ -1,3 +1,4 @@
+import { motion } from "motion/react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -5,18 +6,34 @@ interface MarkdownPaneProps {
   content: string;
 }
 
+const skeletonVariants = {
+  pulse: {
+    opacity: [0.4, 1, 0.4],
+    transition: { duration: 1.5, repeat: Number.POSITIVE_INFINITY, ease: "easeInOut" },
+  },
+};
+
 export function MarkdownPane({ content }: MarkdownPaneProps) {
   if (!content) {
     return (
-      <div className="space-y-4 animate-pulse">
-        <div className="h-6 w-48 bg-gray-100 rounded-md" />
-        <div className="h-4 w-full bg-gray-100 rounded-md" />
-        <div className="h-4 w-5/6 bg-gray-100 rounded-md" />
-        <div className="h-4 w-4/6 bg-gray-100 rounded-md" />
-        <div className="h-20 w-full bg-gray-50 rounded-md mt-6" />
-        <div className="h-4 w-full bg-gray-100 rounded-md" />
-        <div className="h-4 w-3/4 bg-gray-100 rounded-md" />
-      </div>
+      <motion.div
+        className="space-y-4"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.3 }}
+      >
+        {[
+          "h-6 w-48 bg-gray-100 rounded-md",
+          "h-4 w-full bg-gray-100 rounded-md",
+          "h-4 w-5/6 bg-gray-100 rounded-md",
+          "h-4 w-4/6 bg-gray-100 rounded-md",
+          "h-20 w-full bg-gray-50 rounded-md mt-6",
+          "h-4 w-full bg-gray-100 rounded-md",
+          "h-4 w-3/4 bg-gray-100 rounded-md",
+        ].map((cls) => (
+          <motion.div key={cls} className={cls} variants={skeletonVariants} animate="pulse" />
+        ))}
+      </motion.div>
     );
   }
 

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -1,14 +1,31 @@
+import { motion } from "motion/react";
+
 interface SidebarProps {
   apps: string[];
   selected: string | null;
   onSelect: (name: string) => void;
 }
 
+const containerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.06 } },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, x: -8 },
+  visible: { opacity: 1, x: 0, transition: { duration: 0.3, ease: "easeOut" } },
+};
+
 export function Sidebar({ apps, selected, onSelect }: SidebarProps) {
   return (
     <aside className="w-64 shrink-0 flex flex-col bg-gradient-to-b from-gray-900 via-gray-900 to-gray-950 border-r border-gray-800">
       {/* Header */}
-      <div className="px-5 py-6 animate-fade-in">
+      <motion.div
+        className="px-5 py-6"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.4 }}
+      >
         <div className="flex items-center gap-3">
           <span className="inline-flex size-9 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
             R
@@ -20,22 +37,27 @@ export function Sidebar({ apps, selected, onSelect }: SidebarProps) {
             <p className="text-[10px] text-gray-500 font-medium">Viewer</p>
           </div>
         </div>
-      </div>
+      </motion.div>
 
       {/* Navigation */}
       <nav className="flex-1 overflow-y-auto dark-scrollbar px-3 pb-4">
         <p className="px-3 mb-2 text-[10px] font-semibold uppercase tracking-[0.15em] text-gray-600">
           Apps
         </p>
-        <div className="space-y-0.5">
-          {apps.map((app, i) => (
-            <button
+        <motion.div
+          className="space-y-0.5"
+          variants={containerVariants}
+          initial="hidden"
+          animate="visible"
+        >
+          {apps.map((app) => (
+            <motion.button
               type="button"
               key={app}
-              style={{ animationDelay: `${i * 60}ms` }}
+              variants={itemVariants}
+              whileHover={{ x: 2 }}
               className={`
                 group w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-[13px]
-                transition-all duration-200 animate-slide-right opacity-0
                 ${
                   selected === app
                     ? "bg-indigo-500/15 text-indigo-400 font-semibold shadow-lg shadow-indigo-500/5"
@@ -44,18 +66,20 @@ export function Sidebar({ apps, selected, onSelect }: SidebarProps) {
               `}
               onClick={() => onSelect(app)}
             >
-              <span
+              <motion.span
                 className={`
-                  size-1.5 rounded-full transition-all duration-300
+                  size-1.5 rounded-full
                   ${
                     selected === app
                       ? "bg-indigo-400 shadow-[0_0_6px_rgba(129,140,248,0.6)]"
                       : "bg-gray-700 group-hover:bg-gray-500"
                   }
                 `}
+                animate={selected === app ? { scale: [1, 1.4, 1] } : {}}
+                transition={{ duration: 0.3 }}
               />
               {app}
-            </button>
+            </motion.button>
           ))}
           {apps.length === 0 && (
             <div className="px-3 py-8 text-center">
@@ -78,7 +102,7 @@ export function Sidebar({ apps, selected, onSelect }: SidebarProps) {
               <p className="text-gray-600 text-xs">アプリがありません</p>
             </div>
           )}
-        </div>
+        </motion.div>
       </nav>
 
       {/* Footer */}

--- a/viewer/src/index.css
+++ b/viewer/src/index.css
@@ -1,56 +1,6 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
-/* === Custom Animations === */
-@theme {
-  --animate-fade-in: fade-in 0.4s ease-out forwards;
-  --animate-slide-up: slide-up 0.4s ease-out forwards;
-  --animate-slide-right: slide-right 0.3s ease-out forwards;
-  --animate-scale-in: scale-in 0.3s ease-out forwards;
-}
-
-@keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes slide-up {
-  from {
-    opacity: 0;
-    transform: translateY(12px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes slide-right {
-  from {
-    opacity: 0;
-    transform: translateX(-8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
-
-@keyframes scale-in {
-  from {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
 /* === Scrollbar === */
 .custom-scrollbar::-webkit-scrollbar {
   width: 6px;


### PR DESCRIPTION
## Summary

- CSSカスタムアニメーション(@keyframes, @theme)を全て削除し、`motion` パッケージ(Framer Motion v12)に移行
- 全コンポーネント(Sidebar, AppView, MarkdownPane)のアニメーションをFramer Motionで再実装
- CSSでのアニメーションは基本的に禁止とするIssueの方針に従い対応

Closes #6

## Changes

- `viewer/src/index.css`: CSS @keyframes / @theme アニメーション定義を全て削除
- `viewer/src/components/Sidebar.tsx`: motion.div/motion.button でスタガーアニメーション、whileHover、選択インジケーターのパルスアニメーション
- `viewer/src/components/AppView.tsx`: AnimatePresence でタブ切替・Feature一覧⇔詳細の遷移アニメーション、カードのwhileHover/whileTap、スピナー回転
- `viewer/src/components/MarkdownPane.tsx`: スケルトンローディングをmotion.divのopacity pulseアニメーションに変更
- `viewer/package.json`: `motion` v12.33.0 を追加

## Test plan

- [ ] `pnpm viewer` でサーバ起動し、http://localhost:3001/ でビューワーが表示されること
- [ ] サイドバーのアプリ一覧がスタガーアニメーションで表示されること
- [ ] Overview/Source Infoタブ切替時にフェードアニメーションが動作すること
- [ ] Feature一覧のカードホバーで浮き上がりアニメーションが動作すること
- [ ] Feature詳細の開閉でスケールアニメーションが動作すること
- [ ] スケルトンローディングがパルスアニメーションで表示されること
- [ ] `pnpm check` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)