### PR TITLE
feat: サイドバー折りたたみとFeaturesペインのスライドアニメーション

### DIFF
--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -6,6 +6,7 @@ import { Sidebar } from "./components/Sidebar";
 export function App() {
   const [apps, setApps] = useState<string[]>([]);
   const [selectedApp, setSelectedApp] = useState<string | null>(null);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   useEffect(() => {
     fetchApps().then(setApps);
@@ -19,7 +20,13 @@ export function App() {
 
   return (
     <div className="flex h-screen overflow-hidden bg-gray-50">
-      <Sidebar apps={apps} selected={selectedApp} onSelect={setSelectedApp} />
+      <Sidebar
+        apps={apps}
+        selected={selectedApp}
+        onSelect={setSelectedApp}
+        collapsed={sidebarCollapsed}
+        onToggleCollapse={() => setSidebarCollapsed((prev) => !prev)}
+      />
       <main className="flex-1 overflow-hidden">
         {selectedApp ? (
           <AppView key={selectedApp} appName={selectedApp} />

--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -78,183 +78,225 @@ export function AppView({ appName }: { appName: string }) {
       animate={{ opacity: 1 }}
       transition={{ duration: 0.4 }}
     >
-      {/* 左ペイン: Overview / Source Info */}
-      <div className="flex-1 flex flex-col min-w-0 border-r border-gray-200">
-        {/* Tabs */}
-        <div className="flex items-center gap-1 px-4 bg-white border-b border-gray-100 shrink-0">
-          <TabButton
-            active={leftTab === "overview"}
-            onClick={() => setLeftTab("overview")}
-            label="Overview"
-          />
-          <TabButton
-            active={leftTab === "source-info"}
-            onClick={() => setLeftTab("source-info")}
-            label="Source Info"
-          />
-        </div>
-        {/* Content */}
-        <div className="flex-1 overflow-y-auto custom-scrollbar p-6 bg-white">
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={leftTab}
-              initial={{ opacity: 0, scale: 0.98 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.98 }}
-              transition={{ duration: 0.25 }}
-            >
-              <MarkdownPane content={leftTab === "overview" ? overview : sourceInfo} />
-            </motion.div>
-          </AnimatePresence>
-        </div>
-      </div>
-
-      {/* 右ペイン: Features */}
-      <div className="flex-1 flex flex-col min-w-0">
-        {/* Tabs */}
-        <div className="flex items-center gap-1 px-4 bg-white border-b border-gray-100 shrink-0">
-          <TabButton
-            active={!selectedFeature}
-            onClick={() => {
-              setSelectedFeature(null);
-              setFeatureContent("");
-            }}
-            label="Features"
-          />
-          {selectedFeature && (
-            <motion.span
-              className="flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium text-indigo-600 border-b-2 border-indigo-500"
-              initial={{ opacity: 0, x: -8 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.25 }}
-            >
-              <svg
-                aria-hidden="true"
-                className="size-3"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 5l7 7-7 7"
-                />
-              </svg>
-              {features.find((f) => f.id === selectedFeature)?.title ?? selectedFeature}
-            </motion.span>
-          )}
-        </div>
-        {/* Content */}
-        <div className="flex-1 overflow-y-auto custom-scrollbar p-6 bg-white">
-          <AnimatePresence mode="wait">
-            {selectedFeature ? (
+      {/* 左側: Overview/SourceInfo + Features一覧 */}
+      <motion.div
+        className="flex min-w-0 border-r border-gray-200"
+        animate={{ flex: selectedFeature ? "0 0 50%" : "1 1 100%" }}
+        transition={{ duration: 0.3, ease: "easeOut" }}
+        onClickCapture={() => {
+          if (selectedFeature) {
+            setSelectedFeature(null);
+            setFeatureContent("");
+          }
+        }}
+      >
+        {/* Overview / Source Info ペイン */}
+        <div className="flex-1 flex flex-col min-w-0 border-r border-gray-200">
+          {/* Tabs */}
+          <div className="flex items-center gap-1 px-4 bg-white border-b border-gray-100 shrink-0">
+            <TabButton
+              active={leftTab === "overview"}
+              onClick={() => {
+                setLeftTab("overview");
+                setSelectedFeature(null);
+                setFeatureContent("");
+              }}
+              label="Overview"
+            />
+            <TabButton
+              active={leftTab === "source-info"}
+              onClick={() => {
+                setLeftTab("source-info");
+                setSelectedFeature(null);
+                setFeatureContent("");
+              }}
+              label="Source Info"
+            />
+          </div>
+          {/* Content */}
+          <div className="flex-1 overflow-y-auto custom-scrollbar p-6 bg-white">
+            <AnimatePresence mode="wait">
               <motion.div
-                key={selectedFeature}
+                key={leftTab}
                 initial={{ opacity: 0, scale: 0.98 }}
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.98 }}
                 transition={{ duration: 0.25 }}
               >
+                <MarkdownPane content={leftTab === "overview" ? overview : sourceInfo} />
+              </motion.div>
+            </AnimatePresence>
+          </div>
+        </div>
+
+        {/* Features一覧ペイン */}
+        <div className="flex-1 flex flex-col min-w-0">
+          {/* Tabs */}
+          <div className="flex items-center gap-1 px-4 bg-white border-b border-gray-100 shrink-0">
+            <TabButton
+              active
+              onClick={() => {
+                setSelectedFeature(null);
+                setFeatureContent("");
+              }}
+              label="Features"
+            />
+          </div>
+          {/* Content */}
+          <div className="flex-1 overflow-y-auto custom-scrollbar p-6 bg-white">
+            <motion.div
+              className="space-y-2"
+              variants={cardContainerVariants}
+              initial="hidden"
+              animate="visible"
+            >
+              {features.map((f) => (
                 <motion.button
                   type="button"
-                  onClick={() => {
-                    setSelectedFeature(null);
-                    setFeatureContent("");
+                  key={f.id}
+                  variants={cardVariants}
+                  whileHover={{
+                    y: -2,
+                    boxShadow: "0 10px 25px -5px rgba(99, 102, 241, 0.08)",
+                    borderColor: "#c7d2fe",
                   }}
-                  className="group inline-flex items-center gap-1.5 mb-4 px-3 py-1.5 text-xs font-medium text-gray-500 bg-gray-100 rounded-full"
-                  whileHover={{ backgroundColor: "#eef2ff", color: "#4f46e5" }}
-                  transition={{ duration: 0.2 }}
+                  whileTap={{ scale: 0.995 }}
+                  className={`
+                    group w-full flex items-start gap-4 p-4 rounded-xl border bg-white text-left
+                    ${selectedFeature === f.id ? "border-indigo-300 bg-indigo-50/50 shadow-md shadow-indigo-500/10" : "border-gray-100"}
+                  `}
+                  onClick={() => setSelectedFeature(f.id)}
                 >
+                  {/* Number Badge */}
+                  <motion.span
+                    className={`
+                      inline-flex size-9 shrink-0 items-center justify-center rounded-xl text-xs font-bold
+                      ${selectedFeature === f.id ? "bg-gradient-to-br from-indigo-100 to-purple-100 text-indigo-700" : "bg-gradient-to-br from-indigo-50 to-purple-50 text-indigo-600"}
+                    `}
+                    whileHover={{
+                      background: "linear-gradient(to bottom right, #e0e7ff, #ede9fe)",
+                      boxShadow: "0 4px 12px rgba(99, 102, 241, 0.15)",
+                    }}
+                    transition={{ duration: 0.2 }}
+                  >
+                    {f.id.split("_")[0]}
+                  </motion.span>
+                  {/* Content */}
+                  <div className="min-w-0 flex-1">
+                    <h3
+                      className={`text-sm font-semibold group-hover:text-indigo-700 ${selectedFeature === f.id ? "text-indigo-700" : "text-gray-800"}`}
+                    >
+                      {f.title}
+                    </h3>
+                    {f.summary && (
+                      <p className="mt-1 text-xs text-gray-500 leading-relaxed line-clamp-2">
+                        {f.summary}
+                      </p>
+                    )}
+                  </div>
+                  {/* Arrow */}
                   <motion.svg
                     aria-hidden="true"
-                    className="size-3"
+                    className={`size-4 shrink-0 mt-0.5 ${selectedFeature === f.id ? "text-indigo-400" : "text-gray-300"}`}
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
-                    whileHover={{ x: -2 }}
+                    whileHover={{ x: 2, color: "#818cf8" }}
                     transition={{ duration: 0.2 }}
                   >
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"
                       strokeWidth={2}
-                      d="M15 19l-7-7 7-7"
+                      d="M9 5l7 7-7 7"
                     />
                   </motion.svg>
-                  一覧に戻る
                 </motion.button>
-                <MarkdownPane content={featureContent} />
-              </motion.div>
-            ) : (
-              <motion.div
-                key="feature-list"
-                className="space-y-2"
-                variants={cardContainerVariants}
-                initial="hidden"
-                animate="visible"
-              >
-                {features.map((f) => (
-                  <motion.button
-                    type="button"
-                    key={f.id}
-                    variants={cardVariants}
-                    whileHover={{
-                      y: -2,
-                      boxShadow: "0 10px 25px -5px rgba(99, 102, 241, 0.08)",
-                      borderColor: "#c7d2fe",
-                    }}
-                    whileTap={{ scale: 0.995 }}
-                    className="group w-full flex items-start gap-4 p-4 rounded-xl border border-gray-100 bg-white text-left"
-                    onClick={() => setSelectedFeature(f.id)}
-                  >
-                    {/* Number Badge */}
-                    <motion.span
-                      className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-50 to-purple-50 text-indigo-600 text-xs font-bold"
-                      whileHover={{
-                        background: "linear-gradient(to bottom right, #e0e7ff, #ede9fe)",
-                        boxShadow: "0 4px 12px rgba(99, 102, 241, 0.15)",
-                      }}
-                      transition={{ duration: 0.2 }}
-                    >
-                      {f.id.split("_")[0]}
-                    </motion.span>
-                    {/* Content */}
-                    <div className="min-w-0 flex-1">
-                      <h3 className="text-sm font-semibold text-gray-800 group-hover:text-indigo-700">
-                        {f.title}
-                      </h3>
-                      {f.summary && (
-                        <p className="mt-1 text-xs text-gray-500 leading-relaxed line-clamp-2">
-                          {f.summary}
-                        </p>
-                      )}
-                    </div>
-                    {/* Arrow */}
-                    <motion.svg
-                      aria-hidden="true"
-                      className="size-4 shrink-0 mt-0.5 text-gray-300"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      whileHover={{ x: 2, color: "#818cf8" }}
-                      transition={{ duration: 0.2 }}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M9 5l7 7-7 7"
-                      />
-                    </motion.svg>
-                  </motion.button>
-                ))}
-              </motion.div>
-            )}
-          </AnimatePresence>
+              ))}
+            </motion.div>
+          </div>
         </div>
-      </div>
+      </motion.div>
+
+      {/* 右側: Feature詳細（選択時にスライドイン） */}
+      <AnimatePresence>
+        {selectedFeature && (
+          <motion.div
+            key="feature-detail"
+            className="flex-1 flex flex-col min-w-0 border-l border-gray-200"
+            initial={{ width: 0, opacity: 0 }}
+            animate={{ width: "50%", opacity: 1 }}
+            exit={{ width: 0, opacity: 0 }}
+            transition={{ duration: 0.3, ease: "easeOut" }}
+          >
+            {/* Tabs */}
+            <div className="flex items-center gap-1 px-4 bg-white border-b border-gray-100 shrink-0">
+              <motion.span
+                className="flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium text-indigo-600 border-b-2 border-indigo-500"
+                initial={{ opacity: 0, x: -8 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.25 }}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="size-3"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+                {features.find((f) => f.id === selectedFeature)?.title ?? selectedFeature}
+              </motion.span>
+              <motion.button
+                type="button"
+                className="ml-auto p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+                onClick={() => {
+                  setSelectedFeature(null);
+                  setFeatureContent("");
+                }}
+                whileHover={{ scale: 1.1 }}
+                whileTap={{ scale: 0.95 }}
+                title="閉じる"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="size-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </motion.button>
+            </div>
+            {/* Content */}
+            <div className="flex-1 overflow-y-auto custom-scrollbar p-6 bg-white">
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={selectedFeature}
+                  initial={{ opacity: 0, x: 20 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: 20 }}
+                  transition={{ duration: 0.25, ease: "easeOut" }}
+                >
+                  <MarkdownPane content={featureContent} />
+                </motion.div>
+              </AnimatePresence>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </motion.div>
   );
 }

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -1,9 +1,12 @@
 import { motion } from "motion/react";
+import { useState } from "react";
 
 interface SidebarProps {
   apps: string[];
   selected: string | null;
   onSelect: (name: string) => void;
+  collapsed: boolean;
+  onToggleCollapse: () => void;
 }
 
 const containerVariants = {
@@ -16,99 +19,144 @@ const itemVariants = {
   visible: { opacity: 1, x: 0, transition: { duration: 0.3, ease: "easeOut" } },
 };
 
-export function Sidebar({ apps, selected, onSelect }: SidebarProps) {
-  return (
-    <aside className="w-64 shrink-0 flex flex-col bg-gradient-to-b from-gray-900 via-gray-900 to-gray-950 border-r border-gray-800">
-      {/* Header */}
-      <motion.div
-        className="px-5 py-6"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.4 }}
-      >
-        <div className="flex items-center gap-3">
-          <span className="inline-flex size-9 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
-            R
-          </span>
-          <div>
-            <h1 className="text-sm font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent">
-              Requirements
-            </h1>
-            <p className="text-[10px] text-gray-500 font-medium">Viewer</p>
-          </div>
-        </div>
-      </motion.div>
+const SIDEBAR_WIDTH = 256;
+const STRIP_WIDTH = 48;
 
-      {/* Navigation */}
-      <nav className="flex-1 overflow-y-auto dark-scrollbar px-3 pb-4">
-        <p className="px-3 mb-2 text-[10px] font-semibold uppercase tracking-[0.15em] text-gray-600">
-          Apps
-        </p>
-        <motion.div
-          className="space-y-0.5"
-          variants={containerVariants}
-          initial="hidden"
-          animate="visible"
-        >
-          {apps.map((app) => (
-            <motion.button
-              type="button"
-              key={app}
-              variants={itemVariants}
-              whileHover={{ x: 2 }}
-              className={`
-                group w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-[13px]
-                ${
-                  selected === app
-                    ? "bg-indigo-500/15 text-indigo-400 font-semibold shadow-lg shadow-indigo-500/5"
-                    : "text-gray-400 hover:bg-white/[0.04] hover:text-gray-200"
-                }
-              `}
-              onClick={() => onSelect(app)}
+export function Sidebar({ apps, selected, onSelect, collapsed, onToggleCollapse }: SidebarProps) {
+  const [hovered, setHovered] = useState(false);
+  const expanded = !collapsed || hovered;
+
+  return (
+    <motion.aside
+      className="shrink-0 h-full overflow-hidden bg-gradient-to-b from-gray-900 via-gray-900 to-gray-950 border-r border-gray-800"
+      animate={{ width: expanded ? SIDEBAR_WIDTH : STRIP_WIDTH }}
+      transition={{ duration: 0.25, ease: "easeOut" }}
+      onMouseEnter={() => collapsed && setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div className="h-full flex flex-col" style={{ width: SIDEBAR_WIDTH }}>
+        {/* Header */}
+        <div className="px-5 py-6 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
+              R
+            </span>
+            <motion.div animate={{ opacity: expanded ? 1 : 0 }} transition={{ duration: 0.2 }}>
+              <h1 className="text-sm font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent whitespace-nowrap">
+                Requirements
+              </h1>
+              <p className="text-[10px] text-gray-500 font-medium">Viewer</p>
+            </motion.div>
+          </div>
+          <motion.button
+            type="button"
+            className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-white/[0.06] transition-colors shrink-0"
+            onClick={onToggleCollapse}
+            title={collapsed ? "サイドバーを開く" : "サイドバーを閉じる"}
+            animate={{ opacity: expanded ? 1 : 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            <svg
+              aria-hidden="true"
+              className="size-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
             >
-              <motion.span
+              {collapsed ? (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5l7 7-7 7"
+                />
+              ) : (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 19l-7-7 7-7"
+                />
+              )}
+            </svg>
+          </motion.button>
+        </div>
+
+        {/* Navigation */}
+        <nav className="flex-1 overflow-y-auto dark-scrollbar px-3 pb-4">
+          <motion.p
+            className="px-3 mb-2 text-[10px] font-semibold uppercase tracking-[0.15em] text-gray-600 whitespace-nowrap"
+            animate={{ opacity: expanded ? 1 : 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            Apps
+          </motion.p>
+          <motion.div
+            className="space-y-0.5"
+            variants={containerVariants}
+            initial="hidden"
+            animate="visible"
+          >
+            {apps.map((app) => (
+              <motion.button
+                type="button"
+                key={app}
+                variants={itemVariants}
+                whileHover={{ x: 2 }}
                 className={`
-                  size-1.5 rounded-full
+                  group w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-[13px] whitespace-nowrap
                   ${
                     selected === app
-                      ? "bg-indigo-400 shadow-[0_0_6px_rgba(129,140,248,0.6)]"
-                      : "bg-gray-700 group-hover:bg-gray-500"
+                      ? "bg-indigo-500/15 text-indigo-400 font-semibold shadow-lg shadow-indigo-500/5"
+                      : "text-gray-400 hover:bg-white/[0.04] hover:text-gray-200"
                   }
                 `}
-                animate={selected === app ? { scale: [1, 1.4, 1] } : {}}
-                transition={{ duration: 0.3 }}
-              />
-              {app}
-            </motion.button>
-          ))}
-          {apps.length === 0 && (
-            <div className="px-3 py-8 text-center">
-              <div className="size-10 mx-auto mb-3 rounded-full bg-gray-800 flex items-center justify-center">
-                <svg
-                  aria-hidden="true"
-                  className="size-5 text-gray-600"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={1.5}
-                    d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
-                  />
-                </svg>
+                onClick={() => onSelect(app)}
+              >
+                <motion.span
+                  className={`
+                    size-1.5 shrink-0 rounded-full
+                    ${
+                      selected === app
+                        ? "bg-indigo-400 shadow-[0_0_6px_rgba(129,140,248,0.6)]"
+                        : "bg-gray-700 group-hover:bg-gray-500"
+                    }
+                  `}
+                  animate={selected === app ? { scale: [1, 1.4, 1] } : {}}
+                  transition={{ duration: 0.3 }}
+                />
+                {app}
+              </motion.button>
+            ))}
+            {apps.length === 0 && (
+              <div className="px-3 py-8 text-center">
+                <div className="size-10 mx-auto mb-3 rounded-full bg-gray-800 flex items-center justify-center">
+                  <svg
+                    aria-hidden="true"
+                    className="size-5 text-gray-600"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.5}
+                      d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+                    />
+                  </svg>
+                </div>
+                <p className="text-gray-600 text-xs">アプリがありません</p>
               </div>
-              <p className="text-gray-600 text-xs">アプリがありません</p>
-            </div>
-          )}
-        </motion.div>
-      </nav>
+            )}
+          </motion.div>
+        </nav>
 
-      {/* Footer */}
-      <div className="px-5 py-4 border-t border-gray-800/50">
-        <p className="text-[10px] text-gray-700">requirements_creator</p>
+        {/* Footer */}
+        <div className="px-5 py-4 border-t border-gray-800/50">
+          <p className="text-[10px] text-gray-700 whitespace-nowrap">requirements_creator</p>
+        </div>
       </div>
-    </aside>
+    </motion.aside>
   );
 }


### PR DESCRIPTION
## Summary

Viewerのサイドバーを折りたたみ可能にし、Featuresペインに左右スライドアニメーションを追加

Closes #10

## Changes

- **Sidebar折りたたみ**: トグルボタンで閉じる/開く。閉じた状態ではアイコンストリップ（w-12）を表示
- **マウスオーバー展開**: サイドバーが閉じた状態でホバーするとオーバーレイでフル幅展開
- **Featuresスライド**: 機能選択時にリストが左にスライドアウト、詳細が右からスライドイン。戻る時は逆方向にスライド

## Test plan

- [ ] サイドバーの折りたたみボタン（`<<`アイコン）をクリックしてサイドバーが閉じることを確認
- [ ] 閉じた状態でストリップの`>>`アイコンクリックで再展開を確認
- [ ] 閉じた状態でマウスオーバーによるオーバーレイ展開を確認
- [ ] Featuresペインで機能カードをクリックし、左→右スライドアニメーションを確認
- [ ] 「一覧に戻る」ボタンで右→左スライドアニメーションを確認