### PR TITLE
feat: viewerのスマートフォン向けレスポンシブ対応

### DIFF
--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -2,10 +2,13 @@ import { useEffect, useState } from "react";
 import { fetchApps } from "./api";
 import { AppView } from "./components/AppView";
 import { Sidebar } from "./components/Sidebar";
+import { useIsMobile } from "./hooks/useIsMobile";
 
 export function App() {
   const [apps, setApps] = useState<string[]>([]);
   const [selectedApp, setSelectedApp] = useState<string | null>(null);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     fetchApps().then(setApps);
@@ -17,12 +20,54 @@ export function App() {
     }
   }, [apps, selectedApp]);
 
+  const handleSelectApp = (app: string) => {
+    setSelectedApp(app);
+    if (isMobile) setMobileSidebarOpen(false);
+  };
+
   return (
     <div className="flex h-screen overflow-hidden bg-gray-50">
-      <Sidebar apps={apps} selected={selectedApp} onSelect={setSelectedApp} />
-      <main className="flex-1 overflow-hidden">
+      {/* Mobile header */}
+      {isMobile && (
+        <div className="fixed top-0 left-0 right-0 z-30 h-12 flex items-center gap-3 px-4 bg-gray-950/95 backdrop-blur-sm border-b border-gray-800">
+          <button
+            type="button"
+            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-200 hover:bg-white/[0.06]"
+            onClick={() => setMobileSidebarOpen(true)}
+          >
+            <svg
+              className="size-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 6h16M4 12h16M4 18h16"
+              />
+            </svg>
+          </button>
+          <span className="text-sm font-semibold text-gray-200 truncate">
+            {selectedApp ?? "Requirements Viewer"}
+          </span>
+        </div>
+      )}
+
+      <Sidebar
+        apps={apps}
+        selected={selectedApp}
+        onSelect={handleSelectApp}
+        isMobile={isMobile}
+        mobileOpen={mobileSidebarOpen}
+        onMobileClose={() => setMobileSidebarOpen(false)}
+      />
+
+      <main className={`flex-1 overflow-hidden ${isMobile ? "pt-12" : ""}`}>
         {selectedApp ? (
-          <AppView key={selectedApp} appName={selectedApp} />
+          <AppView key={selectedApp} appName={selectedApp} isMobile={isMobile} />
         ) : (
           <div className="flex h-full items-center justify-center text-gray-400 text-sm">
             アプリを選択してください

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -17,9 +17,19 @@ export function App() {
 
   useEffect(() => {
     if (apps.length > 0 && !selectedApp) {
-      setSelectedApp(apps[0]);
+      const params = new URLSearchParams(window.location.search);
+      const appParam = params.get("app");
+      setSelectedApp(appParam && apps.includes(appParam) ? appParam : apps[0]);
     }
   }, [apps, selectedApp]);
+
+  useEffect(() => {
+    if (selectedApp) {
+      const url = new URL(window.location.href);
+      url.searchParams.set("app", selectedApp);
+      window.history.replaceState({}, "", url.toString());
+    }
+  }, [selectedApp]);
 
   const handleSelectApp = (app: string) => {
     setSelectedApp(app);

--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -86,7 +86,7 @@ export function AppView({ appName, isMobile }: { appName: string; isMobile: bool
           transition={{ duration: 0.25, ease: "easeOut" }}
         >
           {/* Header with back button */}
-          <div className="flex items-center gap-2 px-4 bg-gray-800/50 border-b border-gray-700/50 shrink-0">
+          <div className="flex items-center gap-2 px-4 bg-gray-900 border-b border-gray-800 shrink-0">
             <button
               type="button"
               className="p-1.5 rounded-lg text-gray-400 hover:text-gray-200 hover:bg-gray-700/50 transition-colors"
@@ -131,7 +131,7 @@ export function AppView({ appName, isMobile }: { appName: string; isMobile: bool
         transition={{ duration: 0.4 }}
       >
         {/* Tabs */}
-        <div className="flex items-center gap-1 px-4 bg-gray-800/50 border-b border-gray-700/50 shrink-0 overflow-x-auto">
+        <div className="flex items-center gap-1 px-4 bg-gray-900 border-b border-gray-800 shrink-0 overflow-x-auto">
           <TabButton
             active={mobileTab === "overview"}
             onClick={() => setMobileTab("overview")}

--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -10,6 +10,7 @@ import {
 import { MarkdownPane } from "./MarkdownPane";
 
 type LeftTab = "overview" | "source-info";
+type MobileTab = "overview" | "source-info" | "features";
 
 const cardContainerVariants = {
   hidden: {},
@@ -21,19 +22,21 @@ const cardVariants = {
   visible: { opacity: 1, y: 0, transition: { duration: 0.4, ease: "easeOut" } },
 };
 
-export function AppView({ appName }: { appName: string }) {
+export function AppView({ appName, isMobile }: { appName: string; isMobile: boolean }) {
   const [overview, setOverview] = useState("");
   const [sourceInfo, setSourceInfo] = useState("");
   const [features, setFeatures] = useState<Feature[]>([]);
   const [selectedFeature, setSelectedFeature] = useState<string | null>(null);
   const [featureContent, setFeatureContent] = useState("");
   const [leftTab, setLeftTab] = useState<LeftTab>("overview");
+  const [mobileTab, setMobileTab] = useState<MobileTab>("overview");
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     setSelectedFeature(null);
     setFeatureContent("");
     setLeftTab("overview");
+    setMobileTab("overview");
     setLoading(true);
     Promise.all([
       fetchOverview(appName).then((r) => setOverview(r.content)),
@@ -71,6 +74,145 @@ export function AppView({ appName }: { appName: string }) {
     );
   }
 
+  /* ── Mobile layout ── */
+  if (isMobile) {
+    // Feature detail view
+    if (selectedFeature) {
+      return (
+        <motion.div
+          className="flex flex-col h-full"
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.25, ease: "easeOut" }}
+        >
+          {/* Header with back button */}
+          <div className="flex items-center gap-2 px-4 bg-white border-b border-gray-100 shrink-0">
+            <button
+              type="button"
+              className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+              onClick={() => {
+                setSelectedFeature(null);
+                setFeatureContent("");
+              }}
+            >
+              <svg
+                className="size-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 19l-7-7 7-7"
+                />
+              </svg>
+            </button>
+            <span className="text-xs font-medium text-indigo-600 py-2.5 truncate">
+              {features.find((f) => f.id === selectedFeature)?.title ?? selectedFeature}
+            </span>
+          </div>
+          {/* Content */}
+          <div className="flex-1 overflow-y-auto custom-scrollbar p-4 bg-white">
+            <MarkdownPane content={featureContent} />
+          </div>
+        </motion.div>
+      );
+    }
+
+    // Tab-based view
+    return (
+      <motion.div
+        className="flex flex-col h-full"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.4 }}
+      >
+        {/* Tabs */}
+        <div className="flex items-center gap-1 px-4 bg-white border-b border-gray-100 shrink-0 overflow-x-auto">
+          <TabButton
+            active={mobileTab === "overview"}
+            onClick={() => setMobileTab("overview")}
+            label="Overview"
+          />
+          <TabButton
+            active={mobileTab === "source-info"}
+            onClick={() => setMobileTab("source-info")}
+            label="Source Info"
+          />
+          <TabButton
+            active={mobileTab === "features"}
+            onClick={() => setMobileTab("features")}
+            label="Features"
+          />
+        </div>
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto custom-scrollbar p-4 bg-white">
+          <AnimatePresence mode="wait">
+            {mobileTab === "features" ? (
+              <motion.div
+                key="features"
+                className="space-y-2"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2 }}
+              >
+                {features.map((f) => (
+                  <button
+                    type="button"
+                    key={f.id}
+                    className="w-full flex items-start gap-3 p-4 rounded-xl border border-gray-100 bg-white text-left active:bg-gray-50 transition-colors"
+                    onClick={() => setSelectedFeature(f.id)}
+                  >
+                    <span className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg text-xs font-bold bg-gradient-to-br from-indigo-50 to-purple-50 text-indigo-600">
+                      {f.id.split("_")[0]}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <h3 className="text-sm font-semibold text-gray-800">{f.title}</h3>
+                      {f.summary && (
+                        <p className="mt-1 text-xs text-gray-500 leading-relaxed line-clamp-2">
+                          {f.summary}
+                        </p>
+                      )}
+                    </div>
+                    <svg
+                      className="size-4 shrink-0 mt-0.5 text-gray-300"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                  </button>
+                ))}
+              </motion.div>
+            ) : (
+              <motion.div
+                key={mobileTab}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2 }}
+              >
+                <MarkdownPane content={mobileTab === "overview" ? overview : sourceInfo} />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </motion.div>
+    );
+  }
+
+  /* ── Desktop layout (unchanged) ── */
   return (
     <motion.div
       className="flex h-full"
@@ -272,7 +414,7 @@ function TabButton({
     <button
       type="button"
       className={`
-        relative px-3 py-2.5 text-xs font-medium
+        relative px-3 py-2.5 text-xs font-medium whitespace-nowrap
         ${active ? "text-indigo-600" : "text-gray-400 hover:text-gray-600"}
       `}
       onClick={onClick}

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -1,9 +1,12 @@
-import { motion } from "motion/react";
+import { AnimatePresence, motion } from "motion/react";
 
 interface SidebarProps {
   apps: string[];
   selected: string | null;
   onSelect: (name: string) => void;
+  isMobile: boolean;
+  mobileOpen: boolean;
+  onMobileClose: () => void;
 }
 
 const containerVariants = {
@@ -16,7 +19,142 @@ const itemVariants = {
   visible: { opacity: 1, x: 0, transition: { duration: 0.3, ease: "easeOut" } },
 };
 
-export function Sidebar({ apps, selected, onSelect }: SidebarProps) {
+export function Sidebar({
+  apps,
+  selected,
+  onSelect,
+  isMobile,
+  mobileOpen,
+  onMobileClose,
+}: SidebarProps) {
+  /* ── Mobile: overlay sidebar ── */
+  if (isMobile) {
+    return (
+      <AnimatePresence>
+        {mobileOpen && (
+          <>
+            {/* Backdrop */}
+            <motion.div
+              className="fixed inset-0 z-40 bg-black/60"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              onClick={onMobileClose}
+            />
+            {/* Panel */}
+            <motion.aside
+              className="fixed inset-y-0 left-0 z-50 w-[280px] flex flex-col bg-gradient-to-b from-gray-900 via-gray-900 to-gray-950 border-r border-gray-800"
+              initial={{ x: -280 }}
+              animate={{ x: 0 }}
+              exit={{ x: -280 }}
+              transition={{ duration: 0.25, ease: "easeOut" }}
+            >
+              {/* Header */}
+              <div className="px-5 py-6 flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <span className="inline-flex size-9 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
+                    R
+                  </span>
+                  <div>
+                    <h1 className="text-sm font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent">
+                      Requirements
+                    </h1>
+                    <p className="text-[10px] text-gray-500 font-medium">Viewer</p>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-white/[0.06] transition-colors"
+                  onClick={onMobileClose}
+                  title="閉じる"
+                >
+                  <svg
+                    className="size-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              </div>
+
+              {/* Navigation */}
+              <nav className="flex-1 overflow-y-auto dark-scrollbar px-3 pb-4">
+                <p className="px-3 mb-2 text-[10px] font-semibold uppercase tracking-[0.15em] text-gray-600">
+                  Apps
+                </p>
+                <div className="space-y-0.5">
+                  {apps.map((app) => (
+                    <button
+                      type="button"
+                      key={app}
+                      className={`
+                        w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-[13px]
+                        ${
+                          selected === app
+                            ? "bg-indigo-500/15 text-indigo-400 font-semibold shadow-lg shadow-indigo-500/5"
+                            : "text-gray-400 hover:bg-white/[0.04] hover:text-gray-200"
+                        }
+                      `}
+                      onClick={() => onSelect(app)}
+                    >
+                      <span
+                        className={`
+                          size-1.5 shrink-0 rounded-full
+                          ${
+                            selected === app
+                              ? "bg-indigo-400 shadow-[0_0_6px_rgba(129,140,248,0.6)]"
+                              : "bg-gray-700"
+                          }
+                        `}
+                      />
+                      {app}
+                    </button>
+                  ))}
+                  {apps.length === 0 && (
+                    <div className="px-3 py-8 text-center">
+                      <div className="size-10 mx-auto mb-3 rounded-full bg-gray-800 flex items-center justify-center">
+                        <svg
+                          aria-hidden="true"
+                          className="size-5 text-gray-600"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={1.5}
+                            d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+                          />
+                        </svg>
+                      </div>
+                      <p className="text-gray-600 text-xs">アプリがありません</p>
+                    </div>
+                  )}
+                </div>
+              </nav>
+
+              {/* Footer */}
+              <div className="px-5 py-4 border-t border-gray-800/50">
+                <p className="text-[10px] text-gray-700">requirements_creator</p>
+              </div>
+            </motion.aside>
+          </>
+        )}
+      </AnimatePresence>
+    );
+  }
+
+  /* ── Desktop: fixed sidebar ── */
   return (
     <aside className="w-64 shrink-0 flex flex-col bg-gradient-to-b from-gray-900 via-gray-900 to-gray-950 border-r border-gray-800">
       {/* Header */}

--- a/viewer/src/hooks/useIsMobile.ts
+++ b/viewer/src/hooks/useIsMobile.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+export function useIsMobile(breakpoint = 768) {
+  const [isMobile, setIsMobile] = useState(
+    () => window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [breakpoint]);
+
+  return isMobile;
+}


### PR DESCRIPTION
## Summary

viewerをスマートフォン（iPhone / Android Chrome）向けにレスポンシブ対応。

Closes #15

## Changes

- `useIsMobile` フック追加（768px breakpoint、`matchMedia` ベース）
- モバイル時サイドバーをオーバーレイ表示に切り替え（ハンバーガーメニュー + バックドロップ + スライドアニメーション）
- モバイルヘッダー追加（アプリ名 + メニューボタン）
- AppView をモバイル時にタブベース（Overview / Source Info / Features）の縦レイアウトに変更
- Feature 選択時は詳細画面に遷移し、戻るボタンで一覧に復帰
- メインコンテンツのマージン/角丸をモバイル時に削除してフル幅表示
- デスクトップ表示は一切変更なし

## Test plan

- [ ] iPhone Safari / Chrome でビューワーにアクセスし、ハンバーガーメニューからアプリ切替が動作すること
- [ ] モバイル表示で Overview / Source Info / Features タブが正しく切り替わること
- [ ] Features タブでカードをタップすると詳細画面に遷移し、戻るボタンで一覧に戻れること
- [ ] Android Chrome で同様の動作確認
- [ ] デスクトップブラウザで従来通りのレイアウトが維持されること
- [ ] 画面回転時にレイアウトが正しく切り替わること