### PR TITLE
fix: viewerサイドバーの描画ラグとFeature再選択時の不要な読み込みを修正

### DIFF
--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -225,7 +225,7 @@ export function AppView({ appName, isMobile }: { appName: string; isMobile: bool
         className="flex min-w-0 border-r border-gray-700/50"
         animate={{ flex: selectedFeature ? "0 0 50%" : "1 1 100%" }}
         transition={{ duration: 0.3, ease: "easeOut" }}
-        onClickCapture={() => {
+        onClick={() => {
           if (selectedFeature) {
             setSelectedFeature(null);
             setFeatureContent("");
@@ -307,7 +307,11 @@ export function AppView({ appName, isMobile }: { appName: string; isMobile: bool
                     group w-full flex items-start gap-4 p-4 rounded-xl border bg-gray-800/60 text-left
                     ${selectedFeature === f.id ? "border-indigo-500/50 bg-indigo-950/30 shadow-md shadow-indigo-500/10" : "border-gray-700/50"}
                   `}
-                  onClick={() => setSelectedFeature(f.id)}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (selectedFeature === f.id) return;
+                    setSelectedFeature(f.id);
+                  }}
                 >
                   {/* Number Badge */}
                   <motion.span

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -14,12 +14,12 @@ interface SidebarProps {
 
 const containerVariants = {
   hidden: {},
-  visible: { transition: { staggerChildren: 0.06 } },
+  visible: { transition: { staggerChildren: 0.02 } },
 };
 
 const itemVariants = {
   hidden: { opacity: 0, x: -8 },
-  visible: { opacity: 1, x: 0, transition: { duration: 0.3, ease: "easeOut" } },
+  visible: { opacity: 1, x: 0, transition: { duration: 0.15, ease: "easeOut" } },
 };
 
 const SIDEBAR_WIDTH = 256;
@@ -232,6 +232,7 @@ export function Sidebar({
             Apps
           </motion.p>
           <motion.div
+            key={apps.length}
             className="space-y-0.5"
             variants={containerVariants}
             initial="hidden"


### PR DESCRIPTION
## Summary
- サイドバーのスタガーアニメーションを高速化（stagger: 0.06→0.02, duration: 0.3→0.15）し、アプリ一覧の描画ラグを解消
- `apps` フェッチ後にコンテナを再マウント（`key={apps.length}`）し、アイテムが `opacity:0` のまま止まりマウスオーバーまで表示されない問題を修正
- Feature選択の `onClickCapture` を `onClick` + `stopPropagation` に変更し、同一Featureを再クリックした際の不要なコンテンツリセット・再フェッチを防止

## Test plan
- [ ] サイドバーのアプリ一覧がページ読み込み直後に即座に表示されることを確認
- [ ] サイドバーのフェードインアニメーションが自然に動作すること
- [ ] Feature詳細パネルで同じFeatureを再クリックしてもコンテンツが消えないことを確認
- [ ] 別のFeatureを選択した際は正常にコンテンツが切り替わること
- [ ] 左側パネルの空き領域クリックでFeature詳細パネルが閉じること

🤖 Generated with [Claude Code](https://claude.com/claude-code)