### PR TITLE
feat: viewerにmemoのCommit & Pushボタンを追加

### DIFF
--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -1,10 +1,14 @@
+import { exec } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { parse } from "yaml";
+
+const execAsync = promisify(exec);
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const projectRoot = resolve(__dirname, "..");
@@ -100,6 +104,65 @@ app.post("/api/apps/:name/memo", async (c) => {
   const body = await c.req.json<{ content: string }>();
   writeFileSync(filePath, body.content, "utf-8");
   return c.json({ success: true });
+});
+
+app.post("/api/git/commit-push", async (c) => {
+  if (!isDev) return c.json({ error: "Only available in dev mode" }, 403);
+
+  const genDir = resolve(REQUIREMENTS_DIR, "..");
+  const logs: string[] = [];
+
+  try {
+    await execAsync("git rev-parse --git-dir", { cwd: genDir });
+  } catch {
+    return c.json({
+      success: false,
+      output: "Error: gen ディレクトリに git リポジトリが見つかりません",
+    });
+  }
+
+  try {
+    const add = await execAsync("git add .", { cwd: genDir });
+    logs.push("$ git add .");
+    if (add.stdout.trim()) logs.push(add.stdout.trim());
+    if (add.stderr.trim()) logs.push(add.stderr.trim());
+  } catch (err: unknown) {
+    const e = err as { message: string };
+    logs.push("$ git add .", e.message);
+    return c.json({ success: false, output: logs.join("\n") });
+  }
+
+  try {
+    const commit = await execAsync('git commit -m "update"', { cwd: genDir });
+    logs.push('$ git commit -m "update"');
+    if (commit.stdout.trim()) logs.push(commit.stdout.trim());
+    if (commit.stderr.trim()) logs.push(commit.stderr.trim());
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; message: string };
+    logs.push('$ git commit -m "update"');
+    const output = `${e.stdout || ""}${e.stderr || ""}`.trim();
+    if (output.includes("nothing to commit")) {
+      logs.push(output);
+      return c.json({ success: true, output: logs.join("\n") });
+    }
+    logs.push(output || e.message);
+    return c.json({ success: false, output: logs.join("\n") });
+  }
+
+  try {
+    const push = await execAsync("git push", { cwd: genDir });
+    logs.push("$ git push");
+    if (push.stdout.trim()) logs.push(push.stdout.trim());
+    if (push.stderr.trim()) logs.push(push.stderr.trim());
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; message: string };
+    logs.push("$ git push");
+    const output = `${e.stdout || ""}${e.stderr || ""}`.trim();
+    logs.push(output || e.message);
+    return c.json({ success: false, output: logs.join("\n") });
+  }
+
+  return c.json({ success: true, output: logs.join("\n") });
 });
 
 // --- Server ---

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { fetchApps } from "./api";
 import { AppView } from "./components/AppView";
 import { Sidebar } from "./components/Sidebar";
+import { ToastProvider } from "./components/Toast";
 import { useIsMobile } from "./hooks/useIsMobile";
 
 export function App() {
@@ -37,62 +38,64 @@ export function App() {
   };
 
   return (
-    <div className="flex h-screen overflow-hidden bg-gray-950">
-      {/* Mobile header */}
-      {isMobile && (
-        <div className="fixed top-0 left-0 right-0 z-30 h-12 flex items-center gap-3 px-4 bg-gray-950/95 backdrop-blur-sm border-b border-gray-800">
-          <button
-            type="button"
-            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-200 hover:bg-white/[0.06]"
-            onClick={() => setMobileSidebarOpen(true)}
-          >
-            <svg
-              className="size-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
+    <ToastProvider>
+      <div className="flex h-screen overflow-hidden bg-gray-950">
+        {/* Mobile header */}
+        {isMobile && (
+          <div className="fixed top-0 left-0 right-0 z-30 h-12 flex items-center gap-3 px-4 bg-gray-950/95 backdrop-blur-sm border-b border-gray-800">
+            <button
+              type="button"
+              className="p-1.5 rounded-lg text-gray-400 hover:text-gray-200 hover:bg-white/[0.06]"
+              onClick={() => setMobileSidebarOpen(true)}
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 6h16M4 12h16M4 18h16"
-              />
-            </svg>
-          </button>
-          <span className="text-sm font-semibold text-gray-200 truncate">
-            {selectedApp ?? "Requirements Viewer"}
-          </span>
-        </div>
-      )}
-
-      <Sidebar
-        apps={apps}
-        selected={selectedApp}
-        onSelect={handleSelectApp}
-        collapsed={sidebarCollapsed}
-        onToggleCollapse={() => setSidebarCollapsed((prev) => !prev)}
-        isMobile={isMobile}
-        mobileOpen={mobileSidebarOpen}
-        onMobileClose={() => setMobileSidebarOpen(false)}
-      />
-
-      <main
-        className={`flex-1 overflow-hidden ${
-          isMobile
-            ? "pt-12 bg-gray-900"
-            : "mb-3 mr-3 rounded-2xl bg-gray-900 shadow-2xl shadow-black/50 ring-1 ring-gray-800"
-        }`}
-      >
-        {selectedApp ? (
-          <AppView key={selectedApp} appName={selectedApp} isMobile={isMobile} />
-        ) : (
-          <div className="flex h-full items-center justify-center text-gray-500 text-sm">
-            アプリを選択してください
+              <svg
+                className="size-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
+              </svg>
+            </button>
+            <span className="text-sm font-semibold text-gray-200 truncate">
+              {selectedApp ?? "Requirements Viewer"}
+            </span>
           </div>
         )}
-      </main>
-    </div>
+
+        <Sidebar
+          apps={apps}
+          selected={selectedApp}
+          onSelect={handleSelectApp}
+          collapsed={sidebarCollapsed}
+          onToggleCollapse={() => setSidebarCollapsed((prev) => !prev)}
+          isMobile={isMobile}
+          mobileOpen={mobileSidebarOpen}
+          onMobileClose={() => setMobileSidebarOpen(false)}
+        />
+
+        <main
+          className={`flex-1 overflow-hidden ${
+            isMobile
+              ? "pt-12 bg-gray-900"
+              : "mb-3 mr-3 rounded-2xl bg-gray-900 shadow-2xl shadow-black/50 ring-1 ring-gray-800"
+          }`}
+        >
+          {selectedApp ? (
+            <AppView key={selectedApp} appName={selectedApp} isMobile={isMobile} />
+          ) : (
+            <div className="flex h-full items-center justify-center text-gray-500 text-sm">
+              アプリを選択してください
+            </div>
+          )}
+        </main>
+      </div>
+    </ToastProvider>
   );
 }

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -57,3 +57,13 @@ export async function saveMemo(appName: string, content: string): Promise<{ succ
   });
   return res.json();
 }
+
+export interface GitResult {
+  success: boolean;
+  output: string;
+}
+
+export async function commitAndPush(): Promise<GitResult> {
+  const res = await fetch(`${BASE}/git/commit-push`, { method: "POST" });
+  return res.json();
+}

--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence, motion } from "motion/react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
+  commitAndPush,
   type Feature,
   fetchFeatureDetail,
   fetchFeatures,
@@ -10,6 +11,7 @@ import {
 } from "../api";
 import { MarkdownPane } from "./MarkdownPane";
 import { MemoTab } from "./MemoTab";
+import { useToast } from "./Toast";
 
 type LeftTab = "overview" | "source-info" | "memo";
 type MobileTab = "overview" | "source-info" | "features" | "memo";
@@ -34,6 +36,8 @@ export function AppView({ appName, isMobile }: { appName: string; isMobile: bool
   const [mobileTab, setMobileTab] = useState<MobileTab>("overview");
   const [loading, setLoading] = useState(true);
   const [isDev, setIsDev] = useState(false);
+  const [pushing, setPushing] = useState(false);
+  const { showToast } = useToast();
 
   useEffect(() => {
     fetchMode().then((r) => setIsDev(r.isDev));
@@ -60,6 +64,28 @@ export function AppView({ appName, isMobile }: { appName: string; isMobile: bool
       fetchFeatureDetail(appName, selectedFeature).then((r) => setFeatureContent(r.content));
     }
   }, [appName, selectedFeature]);
+
+  const handleCommitPush = useCallback(async () => {
+    if (pushing) return;
+    setPushing(true);
+    try {
+      const result = await commitAndPush();
+      showToast({
+        title: result.success ? "Commit & Push 完了" : "Commit & Push 失敗",
+        output: result.output,
+        success: result.success,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      showToast({
+        title: "Commit & Push エラー",
+        output: message,
+        success: false,
+      });
+    } finally {
+      setPushing(false);
+    }
+  }, [pushing, showToast]);
 
   if (loading) {
     return (
@@ -159,6 +185,12 @@ export function AppView({ appName, isMobile }: { appName: string; isMobile: bool
             onClick={() => setMobileTab("memo")}
             label="Memo"
           />
+          {isDev && mobileTab === "memo" && (
+            <>
+              <div className="flex-1" />
+              <CommitPushButton pushing={pushing} onClick={handleCommitPush} />
+            </>
+          )}
         </div>
         {/* Content */}
         {mobileTab === "memo" ? (
@@ -281,6 +313,12 @@ export function AppView({ appName, isMobile }: { appName: string; isMobile: bool
               }}
               label="Memo"
             />
+            {isDev && leftTab === "memo" && (
+              <>
+                <div className="flex-1" />
+                <CommitPushButton pushing={pushing} onClick={handleCommitPush} />
+              </>
+            )}
           </div>
           {/* Content */}
           {leftTab === "memo" ? (
@@ -477,6 +515,23 @@ export function AppView({ appName, isMobile }: { appName: string; isMobile: bool
         )}
       </AnimatePresence>
     </motion.div>
+  );
+}
+
+function CommitPushButton({ pushing, onClick }: { pushing: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className={`px-3 py-1 my-1 text-xs font-medium rounded-lg transition-colors ${
+        pushing
+          ? "bg-gray-700 text-gray-400 cursor-not-allowed"
+          : "bg-emerald-700 text-white hover:bg-emerald-600"
+      }`}
+      onClick={onClick}
+      disabled={pushing}
+    >
+      {pushing ? "Push中..." : "Commit & Push"}
+    </button>
   );
 }
 

--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -185,7 +185,7 @@ export function AppView({ appName, isMobile }: { appName: string; isMobile: bool
             onClick={() => setMobileTab("memo")}
             label="Memo"
           />
-          {isDev && mobileTab === "memo" && (
+          {isDev && (
             <>
               <div className="flex-1" />
               <CommitPushButton pushing={pushing} onClick={handleCommitPush} />
@@ -313,7 +313,7 @@ export function AppView({ appName, isMobile }: { appName: string; isMobile: bool
               }}
               label="Memo"
             />
-            {isDev && leftTab === "memo" && (
+            {isDev && (
               <>
                 <div className="flex-1" />
                 <CommitPushButton pushing={pushing} onClick={handleCommitPush} />

--- a/viewer/src/components/MemoTab.tsx
+++ b/viewer/src/components/MemoTab.tsx
@@ -1,8 +1,7 @@
 import { motion } from "motion/react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { commitAndPush, fetchMemo, saveMemo } from "../api";
+import { fetchMemo, saveMemo } from "../api";
 import { MarkdownPane } from "./MarkdownPane";
-import { useToast } from "./Toast";
 
 type MemoView = "edit" | "preview";
 
@@ -19,10 +18,8 @@ export function MemoTab({
   const [savedContent, setSavedContent] = useState("");
   const [view, setView] = useState<MemoView>("edit");
   const [saving, setSaving] = useState(false);
-  const [pushing, setPushing] = useState(false);
   const [loading, setLoading] = useState(true);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const { showToast } = useToast();
 
   useEffect(() => {
     setLoading(true);
@@ -43,28 +40,6 @@ export function MemoTab({
     setSavedContent(content);
     setSaving(false);
   }, [appName, content, hasChanges, saving]);
-
-  const handleCommitPush = useCallback(async () => {
-    if (pushing) return;
-    setPushing(true);
-    try {
-      const result = await commitAndPush();
-      showToast({
-        title: result.success ? "Commit & Push 完了" : "Commit & Push 失敗",
-        output: result.output,
-        success: result.success,
-      });
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Unknown error";
-      showToast({
-        title: "Commit & Push エラー",
-        output: message,
-        success: false,
-      });
-    } finally {
-      setPushing(false);
-    }
-  }, [pushing, showToast]);
 
   if (loading) {
     return (
@@ -120,32 +95,18 @@ export function MemoTab({
           )}
           <div className="flex-1" />
           {isDev && (
-            <>
-              <button
-                type="button"
-                className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
-                  hasChanges
-                    ? "bg-indigo-600 text-white hover:bg-indigo-500"
-                    : "bg-gray-800 text-gray-600 cursor-not-allowed"
-                }`}
-                onClick={handleSave}
-                disabled={!hasChanges || saving}
-              >
-                {saving ? "保存中..." : "保存"}
-              </button>
-              <button
-                type="button"
-                className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
-                  pushing
-                    ? "bg-gray-700 text-gray-400 cursor-not-allowed"
-                    : "bg-emerald-700 text-white hover:bg-emerald-600"
-                }`}
-                onClick={handleCommitPush}
-                disabled={pushing}
-              >
-                {pushing ? "Push中..." : "Commit & Push"}
-              </button>
-            </>
+            <button
+              type="button"
+              className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
+                hasChanges
+                  ? "bg-indigo-600 text-white hover:bg-indigo-500"
+                  : "bg-gray-800 text-gray-600 cursor-not-allowed"
+              }`}
+              onClick={handleSave}
+              disabled={!hasChanges || saving}
+            >
+              {saving ? "保存中..." : "保存"}
+            </button>
           )}
         </div>
         {/* Content */}
@@ -188,18 +149,6 @@ export function MemoTab({
               disabled={!hasChanges || saving}
             >
               {saving ? "保存中..." : "保存"}
-            </button>
-            <button
-              type="button"
-              className={`px-3 py-1.5 my-1 text-xs font-medium rounded-lg transition-colors ${
-                pushing
-                  ? "bg-gray-700 text-gray-400 cursor-not-allowed"
-                  : "bg-emerald-700 text-white hover:bg-emerald-600"
-              }`}
-              onClick={handleCommitPush}
-              disabled={pushing}
-            >
-              {pushing ? "Push中..." : "Commit & Push"}
             </button>
           </div>
           <textarea

--- a/viewer/src/components/MemoTab.tsx
+++ b/viewer/src/components/MemoTab.tsx
@@ -1,7 +1,8 @@
 import { motion } from "motion/react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { fetchMemo, saveMemo } from "../api";
+import { commitAndPush, fetchMemo, saveMemo } from "../api";
 import { MarkdownPane } from "./MarkdownPane";
+import { useToast } from "./Toast";
 
 type MemoView = "edit" | "preview";
 
@@ -18,8 +19,10 @@ export function MemoTab({
   const [savedContent, setSavedContent] = useState("");
   const [view, setView] = useState<MemoView>("edit");
   const [saving, setSaving] = useState(false);
+  const [pushing, setPushing] = useState(false);
   const [loading, setLoading] = useState(true);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { showToast } = useToast();
 
   useEffect(() => {
     setLoading(true);
@@ -40,6 +43,28 @@ export function MemoTab({
     setSavedContent(content);
     setSaving(false);
   }, [appName, content, hasChanges, saving]);
+
+  const handleCommitPush = useCallback(async () => {
+    if (pushing) return;
+    setPushing(true);
+    try {
+      const result = await commitAndPush();
+      showToast({
+        title: result.success ? "Commit & Push 完了" : "Commit & Push 失敗",
+        output: result.output,
+        success: result.success,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      showToast({
+        title: "Commit & Push エラー",
+        output: message,
+        success: false,
+      });
+    } finally {
+      setPushing(false);
+    }
+  }, [pushing, showToast]);
 
   if (loading) {
     return (
@@ -95,18 +120,32 @@ export function MemoTab({
           )}
           <div className="flex-1" />
           {isDev && (
-            <button
-              type="button"
-              className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
-                hasChanges
-                  ? "bg-indigo-600 text-white hover:bg-indigo-500"
-                  : "bg-gray-800 text-gray-600 cursor-not-allowed"
-              }`}
-              onClick={handleSave}
-              disabled={!hasChanges || saving}
-            >
-              {saving ? "保存中..." : "保存"}
-            </button>
+            <>
+              <button
+                type="button"
+                className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
+                  hasChanges
+                    ? "bg-indigo-600 text-white hover:bg-indigo-500"
+                    : "bg-gray-800 text-gray-600 cursor-not-allowed"
+                }`}
+                onClick={handleSave}
+                disabled={!hasChanges || saving}
+              >
+                {saving ? "保存中..." : "保存"}
+              </button>
+              <button
+                type="button"
+                className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
+                  pushing
+                    ? "bg-gray-700 text-gray-400 cursor-not-allowed"
+                    : "bg-emerald-700 text-white hover:bg-emerald-600"
+                }`}
+                onClick={handleCommitPush}
+                disabled={pushing}
+              >
+                {pushing ? "Push中..." : "Commit & Push"}
+              </button>
+            </>
           )}
         </div>
         {/* Content */}
@@ -149,6 +188,18 @@ export function MemoTab({
               disabled={!hasChanges || saving}
             >
               {saving ? "保存中..." : "保存"}
+            </button>
+            <button
+              type="button"
+              className={`px-3 py-1.5 my-1 text-xs font-medium rounded-lg transition-colors ${
+                pushing
+                  ? "bg-gray-700 text-gray-400 cursor-not-allowed"
+                  : "bg-emerald-700 text-white hover:bg-emerald-600"
+              }`}
+              onClick={handleCommitPush}
+              disabled={pushing}
+            >
+              {pushing ? "Push中..." : "Commit & Push"}
             </button>
           </div>
           <textarea

--- a/viewer/src/components/Toast.tsx
+++ b/viewer/src/components/Toast.tsx
@@ -1,0 +1,121 @@
+import { AnimatePresence, motion } from "motion/react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+
+interface ToastData {
+  title: string;
+  output: string;
+  success: boolean;
+}
+
+interface ToastContextValue {
+  showToast: (data: ToastData) => void;
+}
+
+const ToastContext = createContext<ToastContextValue>({ showToast: () => {} });
+
+export function useToast() {
+  return useContext(ToastContext);
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toast, setToast] = useState<ToastData | null>(null);
+
+  const showToast = useCallback((data: ToastData) => {
+    setToast(data);
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setToast(null);
+  }, []);
+
+  useEffect(() => {
+    if (!toast) return;
+    const ms = toast.success ? 8000 : 15000;
+    const timer = setTimeout(dismiss, ms);
+    return () => clearTimeout(timer);
+  }, [toast, dismiss]);
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <AnimatePresence>
+        {toast && <ToastComponent toast={toast} onDismiss={dismiss} />}
+      </AnimatePresence>
+    </ToastContext.Provider>
+  );
+}
+
+function ToastComponent({ toast, onDismiss }: { toast: ToastData; onDismiss: () => void }) {
+  return (
+    <motion.div
+      className="fixed bottom-4 right-4 z-50 w-[420px] max-w-[calc(100vw-2rem)] rounded-xl border shadow-2xl shadow-black/50 overflow-hidden"
+      style={{
+        borderColor: toast.success ? "#374151" : "#7f1d1d",
+        backgroundColor: toast.success ? "#111827" : "#1c1017",
+      }}
+      initial={{ opacity: 0, y: 40, scale: 0.95 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, y: 20, scale: 0.95 }}
+      transition={{ duration: 0.25, ease: "easeOut" }}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 px-4 py-2.5 border-b border-gray-800">
+        <span
+          className={`text-xs font-semibold ${toast.success ? "text-green-400" : "text-red-400"}`}
+        >
+          {toast.title}
+        </span>
+        <div className="flex-1" />
+        <button
+          type="button"
+          className="p-1 rounded-md text-gray-500 hover:text-gray-300 hover:bg-gray-700/50 transition-colors"
+          onClick={onDismiss}
+        >
+          <svg
+            className="size-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+      {/* Output */}
+      <div className="max-h-60 overflow-y-auto dark-scrollbar p-4">
+        <pre className="text-xs font-mono leading-relaxed whitespace-pre-wrap break-all">
+          {highlightOutput(toast.output)}
+        </pre>
+      </div>
+    </motion.div>
+  );
+}
+
+function highlightOutput(output: string): React.ReactNode {
+  return output.split("\n").map((line, i) => {
+    let className = "text-gray-300";
+    if (line.startsWith("$ ")) {
+      className = "text-indigo-400 font-semibold";
+    } else if (/error|fatal|rejected|failed/i.test(line)) {
+      className = "text-red-400";
+    } else if (/warning|nothing to commit/i.test(line)) {
+      className = "text-yellow-400";
+    } else if (/create mode|delete mode|->|=>/i.test(line)) {
+      className = "text-cyan-400";
+    } else if (/\d+ files? changed|insertions?|deletions?/i.test(line)) {
+      className = "text-green-400";
+    }
+    return (
+      // biome-ignore lint/suspicious/noArrayIndexKey: static log output, never reordered
+      <div key={i} className={className}>
+        {line || "\u00A0"}
+      </div>
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- ViewerのMemoタブに「Commit & Push」ボタンを追加
- ボタン押下で `gen/` ディレクトリ（別リポジトリ）内の全ファイルを一括 `git add → commit → push`
- 実行ログを画面右下にトースト表示（シンタックスハイライト付き）

Closes #27

## Changes

- `viewer/server.ts`: `POST /api/git/commit-push` エンドポイント追加（genディレクトリでgitコマンド実行）
- `viewer/src/api.ts`: `commitAndPush()` API関数追加
- `viewer/src/components/Toast.tsx`: トーストコンポーネント新規作成（Context + Provider パターン、自動消去、コマンドログのシンタックスハイライト）
- `viewer/src/components/MemoTab.tsx`: Commit & Pushボタン追加（デスクトップ・モバイル両対応、isDev時のみ表示）
- `viewer/src/App.tsx`: `ToastProvider` でラップ

## Test plan

- [ ] devモードでViewerを起動し、MemoタブにCommit & Pushボタンが表示されることを確認
- [ ] genディレクトリがgitリポジトリの場合、ボタン押下でadd/commit/pushが実行されることを確認
- [ ] 実行ログがトーストに表示され、コマンド行・成功・エラーが色分けされることを確認
- [ ] 変更がない場合（nothing to commit）にも成功トーストが表示されることを確認
- [ ] genディレクトリがgitリポジトリでない場合、エラートーストが表示されることを確認
- [ ] モバイルレイアウトでもボタンが正しく表示・動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)