### PR TITLE
fix: SPビューのスクロール領域に下部余白を追加

### DIFF
--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -160,7 +160,7 @@ export function AppView({
             </span>
           </div>
           {/* Content */}
-          <div className="flex-1 overflow-y-auto dark-scrollbar p-4 bg-gray-900">
+          <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-8 bg-gray-900">
             <MarkdownPane content={featureContent} />
           </div>
         </motion.div>
@@ -216,7 +216,7 @@ export function AppView({
             <MemoTab appName={appName} isMobile={isMobile} isDev={isDev} />
           </div>
         ) : (
-          <div className="flex-1 overflow-y-auto dark-scrollbar p-4 bg-gray-900">
+          <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-8 bg-gray-900">
             <AnimatePresence mode="wait">
               {mobileTab === "features" ? (
                 <motion.div

--- a/viewer/src/components/DatasetManager.tsx
+++ b/viewer/src/components/DatasetManager.tsx
@@ -150,7 +150,7 @@ export function DatasetManager({
           <div className="flex-1" />
           {isDev && <CreateButton onClick={() => setCreating(true)} />}
         </div>
-        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 bg-gray-900">
+        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-8 bg-gray-900">
           <CreateForm
             show={creating}
             name={newName}
@@ -544,7 +544,7 @@ function DatasetItemList({
   }
 
   return (
-    <div className="flex-1 overflow-y-auto dark-scrollbar p-4 bg-gray-900">
+    <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-8 bg-gray-900">
       <motion.div
         className="space-y-4"
         initial={{ opacity: 0 }}

--- a/viewer/src/components/MemoTab.tsx
+++ b/viewer/src/components/MemoTab.tsx
@@ -120,7 +120,7 @@ export function MemoTab({
               placeholder="Markdownで入力..."
             />
           ) : (
-            <div className="p-4">
+            <div className="p-4 pb-8">
               <MarkdownPane content={content || "*メモはまだありません*"} />
             </div>
           )}

--- a/viewer/src/components/SearchView.tsx
+++ b/viewer/src/components/SearchView.tsx
@@ -65,7 +65,7 @@ function TagResultsView({
 
   return (
     <motion.div
-      className={`h-full overflow-y-auto dark-scrollbar ${isMobile ? "p-4" : "p-6"}`}
+      className={`h-full overflow-y-auto dark-scrollbar ${isMobile ? "p-4 pb-8" : "p-6"}`}
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.3 }}
@@ -132,7 +132,7 @@ function GrepResultsView({
 
   if (isMobile) {
     return (
-      <div className="h-full overflow-y-auto dark-scrollbar p-4">
+      <div className="h-full overflow-y-auto dark-scrollbar p-4 pb-8">
         <p className="text-xs text-gray-500 mb-4">
           全文検索: &quot;{query}&quot; - {totalMatches}件のマッチ
         </p>


### PR DESCRIPTION
## Summary

モバイル（SP）ビューで下部までスクロールした際にコンテンツが画面端に密着する問題を修正。各スクロール領域に `pb-8` の下部余白を追加。

Closes #33

## Changes

- `AppView`: モバイルタブビュー（Overview/SourceInfo/Features）・Feature詳細ビューに `pb-8` 追加
- `SearchView`: Grep検索・Tag検索のモバイル表示に `pb-8` 追加
- `MemoTab`: Preview表示に `pb-8` 追加
- `DatasetManager`: データセット一覧・アイテム一覧に `pb-8` 追加

## Test plan

- [ ] SPビュー（モバイル幅）で各タブ（Overview / Source Info / Features / Memo）の下部までスクロールし、余白が確保されていることを確認
- [ ] Feature詳細画面の下部にも余白があることを確認
- [ ] 検索結果（Grep / Tag）のモバイル表示で下部余白を確認
- [ ] データセット管理画面のモバイル表示で下部余白を確認
- [ ] デスクトップ表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)