### PR TITLE
feat: ブラウザバック/フォワード対応

### DIFF
--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -20,6 +20,27 @@ import { useIsMobile } from "./hooks/useIsMobile";
 
 type ViewMode = "apps" | "datasets";
 
+function buildUrl(state: {
+  viewMode: ViewMode;
+  app?: string | null;
+  feature?: string | null;
+  dataset?: string | null;
+}) {
+  const url = new URL(window.location.href);
+  url.searchParams.delete("app");
+  url.searchParams.delete("view");
+  url.searchParams.delete("dataset");
+  url.searchParams.delete("feature");
+  if (state.viewMode === "datasets") {
+    url.searchParams.set("view", "datasets");
+    if (state.dataset) url.searchParams.set("dataset", state.dataset);
+  } else {
+    if (state.app) url.searchParams.set("app", state.app);
+    if (state.feature) url.searchParams.set("feature", state.feature);
+  }
+  return url.toString();
+}
+
 export function App() {
   const [apps, setApps] = useState<AppInfo[]>([]);
   const [selectedApp, setSelectedApp] = useState<string | null>(null);
@@ -45,68 +66,106 @@ export function App() {
   const [tagResults, setTagResults] = useState<TagSearchResult[]>([]);
   const [searching, setSearching] = useState(false);
 
+  // Feature state (lifted from AppView for URL sync)
+  const [selectedFeature, setSelectedFeature] = useState<string | null>(null);
+
   useEffect(() => {
     fetchApps().then(setApps);
     fetchMode().then((r) => setIsDev(r.isDev));
   }, []);
 
+  // 初回ロード: URLからstate復元
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
+    const isDatasetView = params.get("view") === "datasets";
     // URL から datasets ビュー + 選択データセットを復元
-    if (params.get("view") === "datasets") {
+    if (isDatasetView) {
       setViewMode("datasets");
       const dsParam = params.get("dataset");
       if (dsParam) setSelectedDataset(dsParam);
     }
+
     if (apps.length > 0 && !selectedApp) {
       const appParam = params.get("app");
       const names = apps.map((a) => a.name);
-      setSelectedApp(appParam && names.includes(appParam) ? appParam : apps[0].name);
+      const validApp = appParam && names.includes(appParam);
+      const app = validApp ? appParam : apps[0].name;
+      setSelectedApp(app);
+
+      // feature パラメータの復元（apps ビューの場合のみ）
+      if (!isDatasetView && validApp) {
+        const featureParam = params.get("feature");
+        if (featureParam) setSelectedFeature(featureParam);
+      }
+
+      // URL正規化
+      window.history.replaceState(
+        {},
+        "",
+        buildUrl({
+          viewMode: isDatasetView ? "datasets" : "apps",
+          app: isDatasetView ? undefined : app,
+          feature: !isDatasetView && validApp ? params.get("feature") : undefined,
+          dataset: isDatasetView ? params.get("dataset") : undefined,
+        }),
+      );
     }
   }, [apps, selectedApp]);
 
+  // ブラウザバック/フォワード対応
   useEffect(() => {
-    if (selectedApp && viewMode === "apps") {
-      const url = new URL(window.location.href);
-      url.searchParams.set("app", selectedApp);
-      url.searchParams.delete("view");
-      url.searchParams.delete("dataset");
-      window.history.replaceState({}, "", url.toString());
-    }
-    if (viewMode === "datasets") {
-      const url = new URL(window.location.href);
-      url.searchParams.set("view", "datasets");
-      url.searchParams.delete("app");
-      if (selectedDataset) {
-        url.searchParams.set("dataset", selectedDataset);
+    const handlePopState = () => {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get("view") === "datasets") {
+        setViewMode("datasets");
+        setSelectedDataset(params.get("dataset"));
+        setSelectedFeature(null);
       } else {
-        url.searchParams.delete("dataset");
+        setViewMode("apps");
+        const appParam = params.get("app");
+        if (appParam && apps.some((a) => a.name === appParam)) {
+          setSelectedApp(appParam);
+          setSelectedFeature(params.get("feature"));
+        }
       }
-      window.history.replaceState({}, "", url.toString());
-    }
-  }, [selectedApp, viewMode, selectedDataset]);
+      setSearchActive(false);
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, [apps]);
 
   const handleSelectApp = (app: string) => {
     setSelectedApp(app);
+    setSelectedFeature(null);
     setViewMode("apps");
     setSearchActive(false);
     if (isMobile) setMobileSidebarOpen(false);
+    window.history.pushState({}, "", buildUrl({ viewMode: "apps", app }));
   };
 
   const handleSelectDatasets = () => {
     setViewMode("datasets");
+    setSelectedFeature(null);
     setSearchActive(false);
     if (isMobile) setMobileSidebarOpen(false);
+    window.history.pushState({}, "", buildUrl({ viewMode: "datasets", dataset: selectedDataset }));
   };
 
   const handleNavigateToDataset = (datasetName: string) => {
     setSelectedDataset(datasetName);
+    setSelectedFeature(null);
     setViewMode("datasets");
     setSearchActive(false);
+    window.history.pushState({}, "", buildUrl({ viewMode: "datasets", dataset: datasetName }));
   };
 
   const handleNavigateToApp = (appName: string) => {
     handleSelectApp(appName);
+  };
+
+  const handleSelectFeature = (feature: string | null) => {
+    setSelectedFeature(feature);
+    window.history.pushState({}, "", buildUrl({ viewMode: "apps", app: selectedApp, feature }));
   };
 
   // --- Dataset generation with polling ---
@@ -298,6 +357,8 @@ export function App() {
               isMobile={isMobile}
               onNavigateToDataset={handleNavigateToDataset}
               onNavigateToApp={handleNavigateToApp}
+              selectedFeature={selectedFeature}
+              onSelectFeature={handleSelectFeature}
             />
           ) : (
             <div className="flex h-full items-center justify-center text-gray-500 text-sm">

--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -33,16 +33,19 @@ export function AppView({
   isMobile,
   onNavigateToDataset,
   onNavigateToApp,
+  selectedFeature,
+  onSelectFeature,
 }: {
   appName: string;
   isMobile: boolean;
   onNavigateToDataset?: (datasetName: string) => void;
   onNavigateToApp?: (appName: string) => void;
+  selectedFeature: string | null;
+  onSelectFeature: (feature: string | null) => void;
 }) {
   const [overview, setOverview] = useState("");
   const [sourceInfo, setSourceInfo] = useState<SourceInfo | null>(null);
   const [features, setFeatures] = useState<Feature[]>([]);
-  const [selectedFeature, setSelectedFeature] = useState<string | null>(null);
   const [featureContent, setFeatureContent] = useState("");
   const [leftTab, setLeftTab] = useState<LeftTab>("overview");
   const [mobileTab, setMobileTab] = useState<MobileTab>("overview");
@@ -56,7 +59,6 @@ export function AppView({
   }, []);
 
   useEffect(() => {
-    setSelectedFeature(null);
     setFeatureContent("");
     setLeftTab("overview");
     setMobileTab("overview");
@@ -136,7 +138,7 @@ export function AppView({
               type="button"
               className="p-1.5 rounded-lg text-gray-400 hover:text-gray-200 hover:bg-gray-700/50 transition-colors"
               onClick={() => {
-                setSelectedFeature(null);
+                onSelectFeature(null);
                 setFeatureContent("");
               }}
             >
@@ -232,7 +234,7 @@ export function AppView({
                       type="button"
                       key={f.id}
                       className="w-full flex items-start gap-3 p-4 rounded-xl border border-gray-700/50 bg-gray-800/60 text-left active:bg-gray-800 transition-colors"
-                      onClick={() => setSelectedFeature(f.id)}
+                      onClick={() => onSelectFeature(f.id)}
                     >
                       <span className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg text-xs font-bold bg-gradient-to-br from-indigo-900/40 to-purple-900/40 text-indigo-400">
                         {f.id.split("_")[0]}
@@ -320,7 +322,7 @@ export function AppView({
         transition={{ duration: 0.3, ease: "easeOut" }}
         onClick={() => {
           if (selectedFeature) {
-            setSelectedFeature(null);
+            onSelectFeature(null);
             setFeatureContent("");
           }
         }}
@@ -333,7 +335,7 @@ export function AppView({
               active={leftTab === "overview"}
               onClick={() => {
                 setLeftTab("overview");
-                setSelectedFeature(null);
+                onSelectFeature(null);
                 setFeatureContent("");
               }}
               label="Overview"
@@ -342,7 +344,7 @@ export function AppView({
               active={leftTab === "source-info"}
               onClick={() => {
                 setLeftTab("source-info");
-                setSelectedFeature(null);
+                onSelectFeature(null);
                 setFeatureContent("");
               }}
               label="Source Info"
@@ -351,7 +353,7 @@ export function AppView({
               active={leftTab === "memo"}
               onClick={() => {
                 setLeftTab("memo");
-                setSelectedFeature(null);
+                onSelectFeature(null);
                 setFeatureContent("");
               }}
               label="Memo"
@@ -414,7 +416,7 @@ export function AppView({
             <TabButton
               active
               onClick={() => {
-                setSelectedFeature(null);
+                onSelectFeature(null);
                 setFeatureContent("");
               }}
               label="Features"
@@ -446,7 +448,7 @@ export function AppView({
                   onClick={(e) => {
                     e.stopPropagation();
                     if (selectedFeature === f.id) return;
-                    setSelectedFeature(f.id);
+                    onSelectFeature(f.id);
                   }}
                 >
                   {/* Number Badge */}
@@ -550,7 +552,7 @@ export function AppView({
                 type="button"
                 className="ml-auto p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/50 transition-colors"
                 onClick={() => {
-                  setSelectedFeature(null);
+                  onSelectFeature(null);
                   setFeatureContent("");
                 }}
                 whileHover={{ scale: 1.1 }}


### PR DESCRIPTION
## Summary

Viewerのブラウザバック/フォワードに対応。SPAのままクエリパラメータで状態管理し、履歴ナビゲーションを可能にした。

Closes #32

## Changes

- `replaceState` → `pushState` に変更し、ナビゲーション操作ごとに履歴エントリを作成
- `popstate` イベントリスナーを追加し、ブラウザバック/フォワード時にURLからstateを復元
- `selectedFeature` を AppView のローカルstateから App に昇格させ、URLクエリパラメータ (`?feature=<id>`) と同期
- `buildUrl` ヘルパー関数を追加し、URL構築ロジックを一元化
- 初回ロード時に `?app=<name>&feature=<id>` からfeature選択状態も復元

## Test plan

- [ ] アプリを切り替えた後、ブラウザバックで前のアプリに戻れること
- [ ] feature選択後にブラウザバックでfeature一覧に戻れること
- [ ] apps ↔ datasets ビュー切替後にブラウザバック/フォワードで戻れること
- [ ] `?app=<name>&feature=<id>` のURLを直接開いてfeatureが表示されること
- [ ] ブラウザリロードで現在の表示が維持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)