### PR TITLE
feat: 検索窓の仕様変更 - タグ複数選択AND検索と複合検索

### DIFF
--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -306,26 +306,44 @@ app.get("/api/apps-with-tags", (c) => {
 });
 
 app.get("/api/search", async (c) => {
-  const query = c.req.query("q")?.trim();
-  const type = c.req.query("type") || "grep";
-  if (!query) return c.json({ results: [] });
+  const query = c.req.query("q")?.trim() || "";
+  const tagsParam = c.req.query("tags")?.trim() || "";
+  const selectedTags = tagsParam ? tagsParam.split(",").filter(Boolean) : [];
+
+  if (!query && selectedTags.length === 0) return c.json({ results: [] });
   if (!existsSync(REQUIREMENTS_DIR)) return c.json({ results: [] });
 
-  if (type === "tag") {
+  // タグのみ検索
+  if (!query && selectedTags.length > 0) {
     const dirs = readdirSync(REQUIREMENTS_DIR, { withFileTypes: true }).filter((d) =>
       d.isDirectory(),
     );
     const results = dirs
       .map((d) => {
         const tags = extractTags(join(REQUIREMENTS_DIR, d.name));
-        const matched = tags.filter((t) => t.includes(query));
-        return matched.length > 0 ? { app: d.name, tags, matchedTags: matched } : null;
+        const matched = selectedTags.filter((st) => tags.includes(st));
+        return matched.length === selectedTags.length
+          ? { app: d.name, tags, matchedTags: matched }
+          : null;
       })
       .filter(Boolean);
-    return c.json({ results });
+    return c.json({ results, resultType: "tag" });
   }
 
-  // grep search
+  // grep検索（タグフィルタ付きの可能性あり）
+  const tagFilterApps =
+    selectedTags.length > 0
+      ? new Set(
+          readdirSync(REQUIREMENTS_DIR, { withFileTypes: true })
+            .filter((d) => d.isDirectory())
+            .filter((d) => {
+              const tags = extractTags(join(REQUIREMENTS_DIR, d.name));
+              return selectedTags.every((st) => tags.includes(st));
+            })
+            .map((d) => d.name),
+        )
+      : null;
+
   try {
     const { stdout } = await execAsync(
       `grep -rn --include='*.md' --include='*.json' ${JSON.stringify(query)} ${JSON.stringify(REQUIREMENTS_DIR)}`,
@@ -341,6 +359,7 @@ app.get("/api/search", async (c) => {
       const relPath = fullPath.replace(`${REQUIREMENTS_DIR}/`, "");
       const parts = relPath.split("/");
       const app = parts[0];
+      if (tagFilterApps && !tagFilterApps.has(app)) continue;
       const file = parts.slice(1).join("/");
       if (!grouped[app]) grouped[app] = [];
       let entry = grouped[app].find((e) => e.file === file);
@@ -351,9 +370,9 @@ app.get("/api/search", async (c) => {
       entry.matches.push({ line: Number(lineNum), text: text.trim() });
     }
     const results = Object.entries(grouped).map(([app, files]) => ({ app, files }));
-    return c.json({ results });
+    return c.json({ results, resultType: "grep" });
   } catch {
-    return c.json({ results: [] });
+    return c.json({ results: [], resultType: "grep" });
   }
 });
 

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -7,8 +7,7 @@ import {
   fetchOverview,
   type GrepSearchResult,
   generateFromDataset,
-  searchByTag,
-  searchGrep,
+  search,
   type TagSearchResult,
 } from "./api";
 import { type AppTab, AppView } from "./components/AppView";
@@ -64,7 +63,8 @@ export function App() {
   // Search state
   const [searchActive, setSearchActive] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [searchType, setSearchType] = useState<"grep" | "tag">("grep");
+  const [searchTags, setSearchTags] = useState<string[]>([]);
+  const [searchResultType, setSearchResultType] = useState<"grep" | "tag">("grep");
   const [grepResults, setGrepResults] = useState<GrepSearchResult[]>([]);
   const [tagResults, setTagResults] = useState<TagSearchResult[]>([]);
   const [searching, setSearching] = useState(false);
@@ -295,21 +295,21 @@ export function App() {
   );
 
   const handleSearch = useCallback(
-    async (query: string, type: "grep" | "tag") => {
+    async (query: string, tags: string[]) => {
       setSearchQuery(query);
-      setSearchType(type);
+      setSearchTags(tags);
       setSearchActive(true);
       setViewMode("apps");
       setSearching(true);
       if (isMobile) setMobileSidebarOpen(false);
       try {
-        if (type === "grep") {
-          const results = await searchGrep(query);
-          setGrepResults(results);
+        const data = await search(query, tags);
+        setSearchResultType(data.resultType);
+        if (data.resultType === "grep") {
+          setGrepResults(data.results as GrepSearchResult[]);
           setTagResults([]);
         } else {
-          const results = await searchByTag(query);
-          setTagResults(results);
+          setTagResults(data.results as TagSearchResult[]);
           setGrepResults([]);
         }
       } finally {
@@ -322,6 +322,7 @@ export function App() {
   const handleClearSearch = useCallback(() => {
     setSearchActive(false);
     setSearchQuery("");
+    setSearchTags([]);
     setGrepResults([]);
     setTagResults([]);
   }, []);
@@ -400,7 +401,8 @@ export function App() {
             ) : (
               <SearchView
                 query={searchQuery}
-                searchType={searchType}
+                selectedTags={searchTags}
+                searchResultType={searchResultType}
                 grepResults={grepResults}
                 tagResults={tagResults}
                 onSelectApp={handleSelectApp}

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -186,16 +186,15 @@ export async function fetchAppsWithTags(): Promise<AppWithTags[]> {
   return res.json();
 }
 
-export async function searchGrep(query: string): Promise<GrepSearchResult[]> {
-  const res = await fetch(`${BASE}/search?type=grep&q=${encodeURIComponent(query)}`);
-  const data = await res.json();
-  return data.results;
-}
-
-export async function searchByTag(tag: string): Promise<TagSearchResult[]> {
-  const res = await fetch(`${BASE}/search?type=tag&q=${encodeURIComponent(tag)}`);
-  const data = await res.json();
-  return data.results;
+export async function search(
+  query: string,
+  tags: string[],
+): Promise<{ results: GrepSearchResult[] | TagSearchResult[]; resultType: "grep" | "tag" }> {
+  const params = new URLSearchParams();
+  if (query) params.set("q", query);
+  if (tags.length > 0) params.set("tags", tags.join(","));
+  const res = await fetch(`${BASE}/search?${params.toString()}`);
+  return res.json();
 }
 
 // --- Git API ---

--- a/viewer/src/components/SearchView.tsx
+++ b/viewer/src/components/SearchView.tsx
@@ -4,7 +4,8 @@ import type { GrepSearchResult, TagSearchResult } from "../api";
 
 interface SearchViewProps {
   query: string;
-  searchType: "grep" | "tag";
+  selectedTags: string[];
+  searchResultType: "grep" | "tag";
   grepResults: GrepSearchResult[];
   tagResults: TagSearchResult[];
   onSelectApp: (app: string) => void;
@@ -13,7 +14,8 @@ interface SearchViewProps {
 
 export function SearchView({
   query,
-  searchType,
+  selectedTags,
+  searchResultType,
   grepResults,
   tagResults,
   onSelectApp,
@@ -25,10 +27,11 @@ export function SearchView({
     matches: { line: number; text: string }[];
   } | null>(null);
 
-  if (searchType === "tag") {
+  if (searchResultType === "tag") {
     return (
       <TagResultsView
         query={query}
+        selectedTags={selectedTags}
         results={tagResults}
         onSelectApp={onSelectApp}
         isMobile={isMobile}
@@ -39,6 +42,7 @@ export function SearchView({
   return (
     <GrepResultsView
       query={query}
+      selectedTags={selectedTags}
       results={grepResults}
       selectedItem={selectedItem}
       onSelectItem={setSelectedItem}
@@ -48,19 +52,43 @@ export function SearchView({
   );
 }
 
+function SearchHeader({
+  query,
+  selectedTags,
+  resultCount,
+  suffix,
+}: {
+  query: string;
+  selectedTags: string[];
+  resultCount: number;
+  suffix: string;
+}) {
+  const parts: string[] = [];
+  if (query) parts.push(`全文: "${query}"`);
+  if (selectedTags.length > 0) parts.push(`タグ: ${selectedTags.join(", ")}`);
+  return (
+    <p className="text-xs text-gray-500 mb-4">
+      {parts.join(" + ")} - {resultCount}
+      {suffix}
+    </p>
+  );
+}
+
 function TagResultsView({
   query,
+  selectedTags,
   results,
   onSelectApp,
   isMobile,
 }: {
   query: string;
+  selectedTags: string[];
   results: TagSearchResult[];
   onSelectApp: (app: string) => void;
   isMobile: boolean;
 }) {
   if (results.length === 0) {
-    return <EmptyState query={query} type="tag" />;
+    return <EmptyState query={selectedTags.join(", ") || query} type="tag" />;
   }
 
   return (
@@ -70,9 +98,12 @@ function TagResultsView({
       animate={{ opacity: 1 }}
       transition={{ duration: 0.3 }}
     >
-      <p className="text-xs text-gray-500 mb-4">
-        タグ検索: &quot;{query}&quot; - {results.length}件のアプリ
-      </p>
+      <SearchHeader
+        query={query}
+        selectedTags={selectedTags}
+        resultCount={results.length}
+        suffix="件のアプリ"
+      />
       <div className="space-y-3">
         {results.map((r) => (
           <motion.button
@@ -106,6 +137,7 @@ function TagResultsView({
 
 function GrepResultsView({
   query,
+  selectedTags,
   results,
   selectedItem,
   onSelectItem,
@@ -113,6 +145,7 @@ function GrepResultsView({
   isMobile,
 }: {
   query: string;
+  selectedTags: string[];
   results: GrepSearchResult[];
   selectedItem: { app: string; file: string; matches: { line: number; text: string }[] } | null;
   onSelectItem: (
@@ -133,9 +166,12 @@ function GrepResultsView({
   if (isMobile) {
     return (
       <div className="h-full overflow-y-auto dark-scrollbar p-4 pb-8">
-        <p className="text-xs text-gray-500 mb-4">
-          全文検索: &quot;{query}&quot; - {totalMatches}件のマッチ
-        </p>
+        <SearchHeader
+          query={query}
+          selectedTags={selectedTags}
+          resultCount={totalMatches}
+          suffix="件のマッチ"
+        />
         {selectedItem ? (
           <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }}>
             <button
@@ -177,9 +213,12 @@ function GrepResultsView({
   return (
     <div className="flex h-full">
       <div className="flex-1 min-w-0 overflow-y-auto dark-scrollbar p-6 border-r border-gray-700/50">
-        <p className="text-xs text-gray-500 mb-4">
-          全文検索: &quot;{query}&quot; - {totalMatches}件のマッチ
-        </p>
+        <SearchHeader
+          query={query}
+          selectedTags={selectedTags}
+          resultCount={totalMatches}
+          suffix="件のマッチ"
+        />
         <ResultList
           results={results}
           query={query}

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -1,6 +1,17 @@
 import { AnimatePresence, motion } from "motion/react";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import type { AppInfo } from "../api";
+
+const ALL_TAGS = [
+  "AI",
+  "Web3",
+  "ヘルスケア",
+  "教育",
+  "金融",
+  "モビリティ",
+  "サステナビリティ",
+  "エンタメ",
+];
 
 interface SidebarProps {
   apps: AppInfo[];
@@ -13,7 +24,7 @@ interface SidebarProps {
   onMobileClose: () => void;
   viewMode: "apps" | "datasets";
   onSelectDatasets: () => void;
-  onSearch: (query: string, type: "grep" | "tag") => void;
+  onSearch: (query: string, tags: string[]) => void;
   onClearSearch: () => void;
   isSearchActive: boolean;
 }
@@ -36,21 +47,42 @@ function SearchInput({
   onClear,
   isActive,
 }: {
-  onSearch: (query: string, type: "grep" | "tag") => void;
+  onSearch: (query: string, tags: string[]) => void;
   onClear: () => void;
   isActive: boolean;
 }) {
   const [query, setQuery] = useState("");
-  const [searchType, setSearchType] = useState<"grep" | "tag">("grep");
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [tagDialogOpen, setTagDialogOpen] = useState(false);
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (query.trim()) onSearch(query.trim(), searchType);
-  };
+  const canSearch = query.trim() || selectedTags.length > 0;
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      if (canSearch) onSearch(query.trim(), selectedTags);
+    },
+    [query, selectedTags, canSearch, onSearch],
+  );
 
   const handleClear = () => {
     setQuery("");
+    setSelectedTags([]);
+    setTagDialogOpen(false);
     onClear();
+  };
+
+  const toggleTag = (tag: string) => {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  };
+
+  const handleTagSearch = () => {
+    setTagDialogOpen(false);
+    if (query.trim() || selectedTags.length > 0) {
+      onSearch(query.trim(), selectedTags);
+    }
   };
 
   return (
@@ -75,10 +107,10 @@ function SearchInput({
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="検索..."
+            placeholder="全文検索..."
             className="w-full pl-8 pr-8 py-1.5 text-xs bg-gray-800/80 border border-gray-700/50 rounded-lg text-gray-200 placeholder-gray-500 focus:outline-none focus:border-indigo-500/50 focus:ring-1 focus:ring-indigo-500/20"
           />
-          {(query || isActive) && (
+          {(query || selectedTags.length > 0 || isActive) && (
             <button
               type="button"
               className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300"
@@ -101,30 +133,91 @@ function SearchInput({
             </button>
           )}
         </div>
-        <div className="flex gap-1">
-          <button
-            type="button"
-            className={`flex-1 px-2 py-1 text-[10px] font-medium rounded-md transition-colors ${
-              searchType === "grep"
-                ? "bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/30"
-                : "bg-gray-800/50 text-gray-500 hover:text-gray-300"
-            }`}
-            onClick={() => setSearchType("grep")}
-          >
-            全文検索
-          </button>
-          <button
-            type="button"
-            className={`flex-1 px-2 py-1 text-[10px] font-medium rounded-md transition-colors ${
-              searchType === "tag"
-                ? "bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/30"
-                : "bg-gray-800/50 text-gray-500 hover:text-gray-300"
-            }`}
-            onClick={() => setSearchType("tag")}
-          >
-            タグ検索
-          </button>
-        </div>
+
+        {/* タグ指定ボタン */}
+        <button
+          type="button"
+          className={`w-full px-2 py-1 text-[10px] font-medium rounded-md transition-colors ${
+            selectedTags.length > 0 || tagDialogOpen
+              ? "bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/30"
+              : "bg-gray-800/50 text-gray-500 hover:text-gray-300"
+          }`}
+          onClick={() => setTagDialogOpen((prev) => !prev)}
+        >
+          タグ指定{selectedTags.length > 0 ? ` (${selectedTags.length})` : ""}
+        </button>
+
+        {/* 選択中タグのバッジ */}
+        {selectedTags.length > 0 && !tagDialogOpen && (
+          <div className="flex flex-wrap gap-1">
+            {selectedTags.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-500/20 text-indigo-300 hover:bg-indigo-500/30 transition-colors"
+                onClick={() => toggleTag(tag)}
+              >
+                {tag}
+                <svg
+                  className="size-2.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* タグ選択ダイアログ */}
+        <AnimatePresence>
+          {tagDialogOpen && (
+            <motion.div
+              className="rounded-lg border border-gray-700/50 bg-gray-800/90 p-2 space-y-1.5"
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              exit={{ opacity: 0, height: 0 }}
+              transition={{ duration: 0.15 }}
+            >
+              <p className="text-[10px] text-gray-500 font-medium">タグを選択（AND検索）</p>
+              <div className="flex flex-wrap gap-1">
+                {ALL_TAGS.map((tag) => {
+                  const isSelected = selectedTags.includes(tag);
+                  return (
+                    <button
+                      key={tag}
+                      type="button"
+                      className={`px-2 py-0.5 rounded-md text-[10px] font-medium transition-colors ${
+                        isSelected
+                          ? "bg-indigo-500/30 text-indigo-300 ring-1 ring-indigo-500/40"
+                          : "bg-gray-700/50 text-gray-400 hover:bg-gray-700/80 hover:text-gray-300"
+                      }`}
+                      onClick={() => toggleTag(tag)}
+                    >
+                      {tag}
+                    </button>
+                  );
+                })}
+              </div>
+              <button
+                type="button"
+                className="w-full px-2 py-1 text-[10px] font-medium rounded-md bg-indigo-500/20 text-indigo-300 hover:bg-indigo-500/30 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                disabled={!canSearch}
+                onClick={handleTagSearch}
+              >
+                検索
+              </button>
+            </motion.div>
+          )}
+        </AnimatePresence>
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary

検索窓のUIと検索ロジックを仕様変更し、タグの複数選択AND検索と全文検索との複合検索を実装。

Closes #44

## Changes

- **サーバー側API** (`server.ts`): `/api/search` を `tags` パラメータ対応に拡張。タグのみ → AND検索、全文+タグ → grep結果をタグでフィルタ
- **クライアントAPI** (`api.ts`): `searchGrep()` / `searchByTag()` を統一された `search(query, tags)` に置換
- **SearchInput** (`Sidebar.tsx`): テキスト入力は全文検索専用に。「タグ指定」ボタンでダイアログを開き、定義済み8タグからチェックボックスで複数選択可能。選択中タグはバッジ表示
- **App.tsx**: handleSearch のシグネチャを `(query, tags)` に変更し、3パターン（全文のみ / タグのみ / 複合）に対応
- **SearchView** (`SearchView.tsx`): 検索ヘッダーを検索条件に応じた動的表示に更新

## Test plan

- [ ] 全文検索: テキスト入力 → Enter で従来通りgrep検索が動作すること
- [ ] タグのみ検索: タグ指定ボタン → タグ複数選択 → 検索ボタンで、選択した全タグを持つアプリのみ表示されること（AND検索）
- [ ] 複合検索: テキスト入力 + タグ選択で、タグ条件に合致するアプリ内の全文検索結果のみ表示されること
- [ ] タグバッジのクリックでタグを個別解除できること
- [ ] クリアボタンで全検索条件がリセットされること
- [ ] モバイル表示で正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)