### PR TITLE
feat: 要件生成時のマルチエージェント対応（Codex/Gemini CLI連携）

### DIFF
--- a/.claude/hooks/agent-router.py
+++ b/.claude/hooks/agent-router.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook: Route to appropriate agent based on user intent.
+
+Analyzes user prompts and suggests the most appropriate agent
+(Codex for design/review, Gemini for research/trends).
+Optimized for the requirements_creator project.
+"""
+
+import json
+import sys
+
+# Triggers for Codex (design, review, deep reasoning)
+CODEX_TRIGGERS = {
+    "ja": [
+        "設計", "どう設計", "アーキテクチャ",
+        "レビュー", "確認して", "チェック",
+        "どちらがいい", "比較して", "トレードオフ",
+        "コンセプト", "アプリ案",
+        "実現可能", "フィージビリティ",
+        "考えて", "分析して",
+    ],
+    "en": [
+        "design", "architecture", "concept",
+        "review", "check", "evaluate",
+        "compare", "trade-off", "tradeoff",
+        "feasible", "feasibility",
+        "think", "analyze",
+    ],
+}
+
+# Triggers for Gemini (research, trends, external information)
+GEMINI_TRIGGERS = {
+    "ja": [
+        "調べて", "リサーチ", "調査",
+        "トレンド", "市場", "動向",
+        "最新", "ドキュメント",
+        "競合", "既存サービス",
+        "技術スタック",
+    ],
+    "en": [
+        "research", "investigate", "look up",
+        "trend", "market", "landscape",
+        "latest", "documentation",
+        "competitor", "existing",
+        "tech stack",
+    ],
+}
+
+
+def detect_agent(prompt: str) -> tuple[str | None, str]:
+    """Detect which agent should handle this prompt."""
+    prompt_lower = prompt.lower()
+
+    for triggers in CODEX_TRIGGERS.values():
+        for trigger in triggers:
+            if trigger in prompt_lower:
+                return "codex", trigger
+
+    for triggers in GEMINI_TRIGGERS.values():
+        for trigger in triggers:
+            if trigger in prompt_lower:
+                return "gemini", trigger
+
+    return None, ""
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+        prompt = data.get("prompt", "")
+
+        if len(prompt) < 10:
+            sys.exit(0)
+
+        agent, trigger = detect_agent(prompt)
+
+        if agent == "codex":
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": (
+                        f"[Agent Routing] Detected '{trigger}' - this task may benefit from "
+                        "Codex CLI's deep reasoning. Consider: "
+                        '`codex exec --model o4-mini --sandbox read-only --full-auto '
+                        '"{task}"` for design decisions or requirements review.'
+                    ),
+                }
+            }
+            print(json.dumps(output))
+
+        elif agent == "gemini":
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": (
+                        f"[Agent Routing] Detected '{trigger}' - this task may benefit from "
+                        "Gemini CLI's research capabilities. Consider: "
+                        '`gemini -p "Research: {topic}" 2>/dev/null` '
+                        "for trend analysis or market research."
+                    ),
+                }
+            }
+            print(json.dumps(output))
+
+        sys.exit(0)
+
+    except Exception as e:
+        print(f"Hook error: {e}", file=sys.stderr)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/log-cli-tools.py
+++ b/.claude/hooks/log-cli-tools.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+PostToolUse hook: Log Codex/Gemini CLI input/output to JSONL file.
+
+Triggers after Bash tool calls containing 'codex' or 'gemini' commands.
+Logs are stored in .claude/logs/cli-tools.jsonl
+"""
+
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+LOG_DIR = Path(__file__).parent.parent / "logs"
+LOG_FILE = LOG_DIR / "cli-tools.jsonl"
+
+
+def extract_codex_prompt(command: str) -> str | None:
+    """Extract prompt from codex exec command."""
+    patterns = [
+        r'codex\s+exec\s+.*?--full-auto\s+"([^"]+)"',
+        r"codex\s+exec\s+.*?--full-auto\s+'([^']+)'",
+        r'codex\s+exec\s+.*?"([^"]+)"\s*2>/dev/null',
+        r"codex\s+exec\s+.*?'([^']+)'\s*2>/dev/null",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, command, re.DOTALL)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def extract_gemini_prompt(command: str) -> str | None:
+    """Extract prompt from gemini command."""
+    patterns = [
+        r'gemini\s+-p\s+"([^"]+)"',
+        r"gemini\s+-p\s+'([^']+)'",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, command, re.DOTALL)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def extract_model(command: str) -> str | None:
+    """Extract model name from command."""
+    match = re.search(r"--model\s+(\S+)", command)
+    return match.group(1) if match else None
+
+
+def truncate_text(text: str, max_length: int = 2000) -> str:
+    """Truncate text if too long."""
+    if len(text) <= max_length:
+        return text
+    return text[:max_length] + f"... [truncated, {len(text)} total chars]"
+
+
+def log_entry(entry: dict) -> None:
+    """Append entry to JSONL log file."""
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return
+
+    tool_name = hook_input.get("tool_name", "")
+    if tool_name != "Bash":
+        return
+
+    tool_input = hook_input.get("tool_input", {})
+    tool_response = hook_input.get("tool_response", {})
+
+    command = tool_input.get("command", "")
+    output = tool_response.get("stdout", "") or tool_response.get("content", "")
+
+    is_codex = "codex" in command.lower()
+    is_gemini = "gemini" in command.lower() and "codex" not in command.lower()
+
+    if not (is_codex or is_gemini):
+        return
+
+    if is_codex:
+        tool = "codex"
+        prompt = extract_codex_prompt(command)
+        model = extract_model(command) or "o4-mini"
+    else:
+        tool = "gemini"
+        prompt = extract_gemini_prompt(command)
+        model = "gemini-2.5-pro"
+
+    if not prompt:
+        return
+
+    exit_code = tool_response.get("exit_code", 0)
+    success = exit_code == 0 and bool(output)
+
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "tool": tool,
+        "model": model,
+        "prompt": truncate_text(prompt),
+        "response": truncate_text(output) if output else "",
+        "success": success,
+        "exit_code": exit_code,
+    }
+
+    log_entry(entry)
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "additionalContext": (
+                        f"[LOG] {tool.capitalize()} call logged to .claude/logs/cli-tools.jsonl"
+                    ),
+                }
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/rules/codex-delegation.md
+++ b/.claude/rules/codex-delegation.md
@@ -1,0 +1,56 @@
+# Codex Delegation Rule
+
+**Codex CLI は要件生成における設計・レビューのパートナー。**
+
+## このプロジェクトでの役割
+
+| 役割 | フェーズ | 用途 |
+|------|---------|------|
+| **designer** | Phase 2 | keyword + research結果からアプリコンセプト案を提案 |
+| **reviewer** | Phase 4 | 生成された要件の品質・完全性チェック |
+
+## いつ使うか
+
+### generate パイプライン内（自動）
+
+`app.config.yaml` の `generate.agents.codex` が `enabled: true` かつ対応する role が設定されている場合、`generate.sh` が自動的に呼び出す。
+
+### 対話的に使う場合
+
+以下のような場面で Codex に相談:
+
+1. **アプリ設計の判断** — 「このコンセプトは実現可能か？」「どのアーキテクチャが適切か？」
+2. **要件のレビュー** — 「この要件は漏れがないか？」「機能の優先度は適切か？」
+3. **トレードオフ分析** — 「技術スタックAとBのどちらが適切か？」
+
+## 呼び出しパターン
+
+### 直接呼び出し（短い質問）
+
+```bash
+codex exec --model o4-mini --sandbox read-only --full-auto "Brief question" 2>/dev/null
+```
+
+### サブエージェント経由（詳細な分析）
+
+```
+Task tool:
+- subagent_type: "general-purpose"
+- prompt: |
+    Consult Codex about: {topic}
+    codex exec --model o4-mini --sandbox read-only --full-auto "{question}" 2>/dev/null
+    Return CONCISE summary.
+```
+
+## いつ使わないか
+
+- 単純なファイル編集
+- keyword.json の読み込みや整形
+- バリデーションスクリプトの実行
+- Git 操作
+
+## 言語プロトコル
+
+1. Codex には **英語** で質問
+2. 回答は **英語** で受け取り
+3. ユーザーには **日本語** で報告

--- a/.claude/rules/gemini-delegation.md
+++ b/.claude/rules/gemini-delegation.md
@@ -1,0 +1,55 @@
+# Gemini Delegation Rule
+
+**Gemini CLI は外部情報のリサーチ・分析スペシャリスト。**
+
+## このプロジェクトでの役割
+
+| 役割 | フェーズ | 用途 |
+|------|---------|------|
+| **researcher** | Phase 1 | keyword.json からトレンド・技術の外部調査 |
+
+## いつ使うか
+
+### generate パイプライン内（自動）
+
+`app.config.yaml` の `generate.agents.gemini` が `enabled: true` かつ `researcher` role が設定されている場合、`generate.sh` が自動的に呼び出す。
+
+### 対話的に使う場合
+
+以下のような場面で Gemini に調査依頼:
+
+1. **トレンド調査** — 「このキーワードに関する最新の市場動向は？」
+2. **技術リサーチ** — 「このフレームワークの最新ベストプラクティスは？」
+3. **競合分析** — 「この分野の既存サービスは？」
+
+## 呼び出しパターン
+
+### 直接呼び出し（短い質問）
+
+```bash
+gemini -p "Brief research question" 2>/dev/null
+```
+
+### サブエージェント経由（詳細な調査）
+
+```
+Task tool:
+- subagent_type: "general-purpose"
+- prompt: |
+    Research: {topic}
+    gemini -p "{question}" 2>/dev/null
+    Return CONCISE summary (5-7 bullet points).
+```
+
+## いつ使わないか
+
+- **コードベース分析** — Claude が 1M コンテキストで直接読む
+- 設計判断 — Codex の領域
+- ファイル編集 — Claude Code の領域
+- バリデーション — スクリプトの領域
+
+## 言語プロトコル
+
+1. Gemini には **英語** で質問
+2. 回答は **英語** で受け取り
+3. ユーザーには **日本語** で報告

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(pnpm:*)",
+      "Bash(codex:*)",
+      "Bash(gemini:*)",
       "WebFetch(domain:docs.anthropic.com)",
       "Bash(cat:*)",
       "Bash(find:*)",
@@ -35,6 +37,17 @@
     "enableAllProjectMcpServers": true
   },
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/agent-router.py"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|MultiEdit|Write",
@@ -42,6 +55,15 @@
           {
             "type": "command",
             "command": "pnpm format"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/log-cli-tools.py"
           }
         ]
       }

--- a/.claude/skills/generate-requirements/SKILL.md
+++ b/.claude/skills/generate-requirements/SKILL.md
@@ -162,6 +162,40 @@ tsx scripts/validate-requirements.ts {app_name}
 - 生成した機能数
 - バリデーション結果
 
+## マルチエージェント連携（generate.sh 経由の場合）
+
+`pnpm generate` で実行する場合、`app.config.yaml` の `generate.agents` 設定に基づき、外部エージェント（Codex CLI / Gemini CLI）が各フェーズで自動的に呼び出される。
+
+### フロー
+
+```
+[Phase 1: Research]  gemini (researcher) — トレンド・市場調査
+    ↓ research_context として渡される
+[Phase 2: Design]    codex (designer) — アプリコンセプト設計提案
+    ↓ design_context として渡される
+[Phase 3: Generate]  Claude Code — 本スキルによるメイン生成（本ステップ）
+    ↓
+[Phase 4: Review]    codex/gemini (reviewer) — 品質レビュー
+```
+
+- Phase 1-2 の結果はプロンプト内に「参考情報」として含まれる
+- 参考情報はあくまで参考であり、そのまま採用する必要はない
+- `--skip-agents` オプションで外部エージェントをスキップ可能
+
+### 対話的実行時の外部エージェント利用
+
+対話的に `/generate-requirements` を使う場合、必要に応じて手動でエージェントを呼び出せる:
+
+```bash
+# Codex に設計相談
+codex exec --model o4-mini --sandbox read-only --full-auto "{質問}" 2>/dev/null
+
+# Gemini にトレンド調査
+gemini -p "{調査内容}" 2>/dev/null
+```
+
+詳細は `.claude/rules/codex-delegation.md` / `.claude/rules/gemini-delegation.md` を参照。
+
 ## 注意事項
 
 - overview.md の機能一覧に載せた機能は **全て** features/ に個別ファイルを作ること。漏れは不可

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,103 @@
+# Codex CLI — Requirements Design & Review Agent
+
+**You are called by the requirements_creator pipeline for app concept design and quality review.**
+
+## Project Overview
+
+This project collects news/trend data, extracts keywords, and generates app requirement documents.
+Your role is to provide **deep reasoning** for app concept design and requirements quality review.
+
+```
+Data Collection → Keyword Extraction → [YOU: Design/Review] → Requirements Generation
+```
+
+## Your Roles
+
+### 1. Designer (Phase 2)
+
+Given extracted keywords and optional research results, brainstorm innovative app concepts:
+
+- Propose creative app ideas (1-2 levels of association from keywords)
+- Define target users and their pain points
+- Suggest 5-8 core features with priorities
+- Recommend technology stack
+- Consider monetization strategies
+
+**Output format:**
+
+```markdown
+## App Concept: {name}
+
+### Concept
+{1-2 sentence description}
+
+### Target Users
+{Who and what pain points}
+
+### Core Features
+| # | Feature | Description | Priority |
+|---|---------|-------------|----------|
+
+### Tech Stack
+{Recommendations with rationale}
+
+### Monetization
+{Revenue model}
+```
+
+### 2. Reviewer (Phase 4)
+
+Review generated requirements for quality and completeness:
+
+- Check overview.md for clear concept, realistic scope
+- Verify features cover user needs comprehensively
+- Evaluate technical feasibility of proposed stack
+- Check consistency between overview and feature specs
+- Identify missing non-functional requirements
+
+**Output format:**
+
+```markdown
+## Review Summary
+
+### Score: {A/B/C}
+
+### Strengths
+- {point 1}
+
+### Issues
+| # | Severity | File | Issue | Suggestion |
+|---|----------|------|-------|------------|
+
+### Recommendations
+- {actionable recommendation}
+```
+
+## Shared Context
+
+Read project context from:
+
+```
+.claude/rules/          # Coding principles
+gen/tags.json           # Available tags for categorization
+gen/requirements/       # Existing app requirements (for reference)
+```
+
+## How You're Called
+
+```bash
+codex exec --model o4-mini --sandbox read-only --full-auto "{task}" 2>/dev/null
+```
+
+## Language Protocol
+
+- **Input**: English
+- **Output**: English (the pipeline translates to Japanese)
+- **Code/Technical terms**: English
+
+## Key Principles
+
+1. **Be creative** — Don't suggest obvious apps; aim for 1-2 levels of conceptual leap
+2. **Be specific** — Concrete feature descriptions, not vague ideas
+3. **Be practical** — Consider real-world feasibility and market fit
+4. **Be decisive** — Give clear recommendations, not just options

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,12 @@
+# Codex CLI Project Configuration
+# Used by the requirements_creator pipeline for app design and review
+
+model = "o4-mini"
+approval_policy = "on-request"
+
+[features]
+skills = true
+
+[[skills.config]]
+enabled = true
+path = ".codex/skills/context-loader"

--- a/.codex/skills/context-loader/SKILL.md
+++ b/.codex/skills/context-loader/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: context-loader
+description: Load project context at the start of every task. Ensures Codex CLI understands the requirements_creator project structure, tags, and existing requirements.
+---
+
+# Context Loader for requirements_creator
+
+## Purpose
+
+Load project context so Codex CLI can provide informed design and review advice.
+
+## When to Activate
+
+**ALWAYS** — Run at the beginning of every task.
+
+## Workflow
+
+### Step 1: Understand Project Structure
+
+This project generates app requirement documents from trend keywords:
+
+```
+gen/
+├── tags.json                    # Tag definitions for categorization
+├── data_source/                 # Raw trend data (news, keywords)
+│   └── {timestamp}/
+│       ├── news.json
+│       └── keyword.json
+└── requirements/                # Generated app requirements
+    └── {app_name}/
+        ├── _source_info.json    # Source metadata, tags, keywords
+        ├── overview.md          # App overview (concept, features, stack)
+        ├── diagrams/            # Mermaid diagrams
+        └── features/            # Detailed feature specs
+```
+
+### Step 2: Load Tags
+
+Read `gen/tags.json` for available categorization tags.
+
+### Step 3: Reference Existing Requirements
+
+If the task involves reviewing or designing, check existing requirements in `gen/requirements/` for style and quality reference.
+
+### Step 4: Execute Task
+
+With loaded context, execute the requested task.
+
+## Output
+
+Briefly confirm:
+- Project structure understood
+- Tags loaded
+- Ready to execute task

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -1,0 +1,78 @@
+# Gemini CLI — Trend Research & Analysis Agent
+
+**You are called by the requirements_creator pipeline for external trend research and market analysis.**
+
+## Project Overview
+
+This project collects news/trend data, extracts keywords, and generates app requirement documents.
+Your role is to provide **external research** to enrich the keyword-to-app-concept pipeline.
+
+```
+Data Collection → Keyword Extraction → [YOU: Research] → App Concept Design → Requirements
+```
+
+## Your Role: Researcher (Phase 1)
+
+Given extracted keywords from trend data, research external information:
+
+1. **Current market trends** related to the keywords
+2. **Existing apps/services** in the identified spaces
+3. **Technology trends** and emerging frameworks
+4. **User pain points** that current solutions don't address
+5. **Potential market opportunities** and gaps
+
+## Output Format
+
+```markdown
+## Research: {keyword theme}
+
+### Market Trends
+- {trend 1 with context}
+- {trend 2 with context}
+
+### Existing Solutions
+| App/Service | Description | Gap/Weakness |
+|-------------|-------------|--------------|
+
+### Technology Landscape
+- {relevant tech trend}
+
+### Opportunities
+- {market gap or unmet need}
+
+### Sources
+- {URL or reference}
+```
+
+## How You're Called
+
+```bash
+gemini -p "{research question}" 2>/dev/null
+```
+
+## Strengths (Use These)
+
+- **Google Search grounding** — Access latest market information
+- **Broad knowledge** — Cross-domain trend analysis
+- **Web research** — Find existing solutions and competitors
+
+## NOT Your Job
+
+| Task | Who Does It |
+|------|-------------|
+| App concept design | Codex |
+| Requirements writing | Claude Code |
+| Code implementation | Claude Code |
+| Codebase analysis | Claude Code |
+
+## Language Protocol
+
+- **Input**: English
+- **Output**: English (the pipeline translates to Japanese)
+
+## Key Principles
+
+1. **Be current** — Focus on 2025-2026 trends and data
+2. **Cite sources** — Include URLs and references when possible
+3. **Be actionable** — Focus on insights that inform app design
+4. **Identify gaps** — Highlight unmet needs and opportunities

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,15 @@
+{
+  "model": {
+    "name": "gemini-2.5-pro"
+  },
+  "context": {
+    "fileName": ["GEMINI.md"],
+    "fileFiltering": {
+      "respectGitIgnore": true,
+      "respectGeminiIgnore": true
+    }
+  },
+  "experimental": {
+    "skills": true
+  }
+}

--- a/.gemini/skills/context-loader/SKILL.md
+++ b/.gemini/skills/context-loader/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: context-loader
+description: Load project context for Gemini CLI. Ensures Gemini understands the requirements_creator project and can provide relevant research.
+---
+
+# Context Loader for requirements_creator (Gemini)
+
+## Purpose
+
+Load project context so Gemini CLI can provide targeted research for app requirements generation.
+
+## When to Activate
+
+**ALWAYS** — Run at the beginning of research tasks.
+
+## Workflow
+
+### Step 1: Understand Project
+
+This project generates app requirement documents from trend keywords:
+- News/trend data is collected and keywords are extracted
+- Keywords are used to brainstorm innovative app concepts
+- Detailed requirements are generated for each app
+
+### Step 2: Understand Research Goal
+
+Your research should help inform:
+- What market trends relate to the extracted keywords
+- What existing solutions exist and their gaps
+- What technology stacks are trending
+- What user pain points remain unaddressed
+
+### Step 3: Execute Research
+
+Use Google Search grounding to find:
+- Current market data and trends
+- Competitor analysis
+- Technology landscape
+- User feedback and pain points
+
+## Output Guidelines
+
+- Structure with clear headings
+- Include source URLs when available
+- Focus on actionable insights for app design
+- Note constraints and risks

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -55,5 +55,25 @@ collect:
 # --- extract フェーズ設定（将来の拡張用） ---
 # extract:
 
-# --- generate フェーズ設定（将来の拡張用） ---
-# generate:
+# --- generate フェーズ設定 ---
+generate:
+  # マルチエージェント設定
+  # 各エージェントに役割（role）を割り当て、要件生成の各フェーズで活用する
+  # 定義済みロール:
+  #   researcher - Phase 1: keyword.jsonからトレンド・技術の外部調査（主にGemini向け）
+  #   designer   - Phase 2: keywords + research結果からアプリコンセプト案を提案（主にCodex向け）
+  #   reviewer   - Phase 4: 生成された要件の品質・完全性チェック
+  #   enhancer   - Phase 5: レビュー結果に基づく要件の修正・補強
+  agents:
+    codex:
+      enabled: true
+      model: o4-mini
+      sandbox: read-only
+      roles:
+        - designer
+        - reviewer
+    gemini:
+      enabled: false
+      model: gemini-2.5-pro
+      roles:
+        - researcher

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -7,23 +7,34 @@ cd "$PROJECT_ROOT"
 
 SKILL_FILE=".claude/skills/generate-requirements/SKILL.md"
 TEMPLATES_FILE=".claude/skills/generate-requirements/templates.md"
+CONFIG_FILE="app.config.yaml"
 
 # --- 出力先ベースディレクトリの読み込み ---
-OUTPUT_BASE=$(grep '^output_base_dir:' app.config.yaml 2>/dev/null | sed 's/^output_base_dir:[[:space:]]*//' | tr -d ' "'"'" || true)
+OUTPUT_BASE=$(grep '^output_base_dir:' "$CONFIG_FILE" 2>/dev/null | sed 's/^output_base_dir:[[:space:]]*//' | tr -d ' "'"'" || true)
 if [[ -z "$OUTPUT_BASE" ]]; then OUTPUT_BASE="gen"; fi
 DATA_SOURCE_DIR="${OUTPUT_BASE}/data_source"
+REQUIREMENTS_DIR="${OUTPUT_BASE}/requirements"
+
+# --- 一時ファイル管理 ---
+TMPDIR_AGENTS=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_AGENTS"' EXIT
+RESEARCH_CONTEXT="${TMPDIR_AGENTS}/research_context.md"
+DESIGN_CONTEXT="${TMPDIR_AGENTS}/design_context.md"
+REVIEW_RESULT="${TMPDIR_AGENTS}/review_result.md"
 
 # --- 引数処理 ---
 TARGET_DIR=""
 DATASET_SOURCE=""
 DATASET_NAME=""
+SKIP_AGENTS=false
 while [[ $# -gt 0 ]]; do
   case $1 in
     --target) TARGET_DIR="$2"; shift 2 ;;
     --dataset-source) DATASET_SOURCE="$2"; shift 2 ;;
     --dataset-name) DATASET_NAME="$2"; shift 2 ;;
+    --skip-agents) SKIP_AGENTS=true; shift ;;
     -h|--help)
-      echo "Usage: $0 [--target <data_source_subdir>] [--dataset-source <file> --dataset-name <name>]"
+      echo "Usage: $0 [--target <data_source_subdir>] [--dataset-source <file> --dataset-name <name>] [--skip-agents]"
       echo ""
       echo "keyword.jsonまたはデータセットソースを元にアプリ要件を生成します。"
       echo ""
@@ -31,6 +42,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --target          data_source配下のサブディレクトリ名（省略時は最新）"
       echo "  --dataset-source  データセットソースファイルパス"
       echo "  --dataset-name    データセット名"
+      echo "  --skip-agents     外部エージェント（codex/gemini）をスキップ"
       exit 0
       ;;
     --) shift ;;
@@ -38,9 +50,331 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# --- スキル内容とテンプレートを結合してシステムプロンプトファイルを作成 ---
+# =============================================================================
+# エージェント設定読み込み
+# =============================================================================
+
+# yq が使えない環境でも動作するよう、grep/sed ベースでYAMLからエージェント設定を読み取る
+# 構造: generate.agents.<name>.{enabled,model,sandbox,roles}
+
+get_agent_enabled() {
+  local agent="$1"
+  local val
+  val=$(awk "/^  *${agent}:/{found=1} found && /enabled:/{print \$2; exit}" <(sed -n '/^generate:/,/^[^ ]/p' "$CONFIG_FILE") 2>/dev/null || true)
+  [[ "$val" == "true" ]]
+}
+
+get_agent_model() {
+  local agent="$1"
+  awk "/^  *${agent}:/{found=1} found && /model:/{print \$2; exit}" <(sed -n '/^generate:/,/^[^ ]/p' "$CONFIG_FILE") 2>/dev/null || true
+}
+
+get_agent_sandbox() {
+  local agent="$1"
+  awk "/^  *${agent}:/{found=1} found && /sandbox:/{print \$2; exit}" <(sed -n '/^generate:/,/^[^ ]/p' "$CONFIG_FILE") 2>/dev/null || true
+}
+
+has_agent_role() {
+  local agent="$1"
+  local role="$2"
+  # roles配下の "- <role>" を検索
+  local in_agent=false
+  local in_roles=false
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]]*${agent}: ]]; then
+      in_agent=true
+      in_roles=false
+      continue
+    fi
+    if $in_agent && [[ "$line" =~ ^[[:space:]]*roles: ]]; then
+      in_roles=true
+      continue
+    fi
+    if $in_agent && $in_roles; then
+      if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*(.+) ]]; then
+        local r="${BASH_REMATCH[1]}"
+        r=$(echo "$r" | tr -d ' ')
+        if [[ "$r" == "$role" ]]; then
+          return 0
+        fi
+      else
+        # roles ブロック終了
+        in_roles=false
+        in_agent=false
+      fi
+    fi
+    # 別のエージェント定義に入ったらリセット
+    if $in_agent && [[ "$line" =~ ^[[:space:]]{4}[a-z] && ! "$line" =~ ^[[:space:]]*- ]]; then
+      in_agent=false
+      in_roles=false
+    fi
+  done < <(sed -n '/^generate:/,/^[^ ]/p' "$CONFIG_FILE" 2>/dev/null)
+  return 1
+}
+
+# 指定ロールを実行可能なエージェントが存在するか
+can_run_role() {
+  local role="$1"
+  if $SKIP_AGENTS; then return 1; fi
+  for agent in codex gemini; do
+    if get_agent_enabled "$agent" && has_agent_role "$agent" "$role"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# 指定ロールを持つ最初のエージェント名を返す
+get_role_agent() {
+  local role="$1"
+  for agent in codex gemini; do
+    if get_agent_enabled "$agent" && has_agent_role "$agent" "$role"; then
+      echo "$agent"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# =============================================================================
+# エージェント実行関数
+# =============================================================================
+
+run_research_phase() {
+  local keyword_file="$1"
+  local agent
+  agent=$(get_role_agent "researcher") || return 0
+
+  echo "--- Phase 1: Research ($agent) ---"
+  local model
+  model=$(get_agent_model "$agent")
+
+  local keywords
+  keywords=$(cat "$keyword_file")
+
+  if [[ "$agent" == "gemini" ]]; then
+    gemini -p "
+You are a trend research analyst. Analyze these extracted keywords for current technology trends and market opportunities.
+
+Keywords data:
+${keywords}
+
+Research and provide:
+1. Current market trends related to these keywords (2025-2026)
+2. Existing apps/services in these spaces and their gaps
+3. Emerging technology trends that could be leveraged
+4. User pain points that current solutions don't address
+5. Potential market opportunities
+
+Output: Structured analysis in markdown format.
+" 2>/dev/null > "$RESEARCH_CONTEXT" || true
+
+  elif [[ "$agent" == "codex" ]]; then
+    local sandbox
+    sandbox=$(get_agent_sandbox "$agent")
+    sandbox="${sandbox:-read-only}"
+    codex exec --model "${model:-o4-mini}" --sandbox "$sandbox" --full-auto "
+You are a trend research analyst. Analyze these extracted keywords for current technology trends and market opportunities.
+
+Keywords data:
+${keywords}
+
+Research and provide:
+1. Current market trends related to these keywords
+2. Existing apps/services in these spaces and their gaps
+3. Technology trends that could be leveraged
+4. User pain points that current solutions don't address
+5. Potential market opportunities
+
+Output: Structured analysis in markdown format.
+" 2>/dev/null > "$RESEARCH_CONTEXT" || true
+  fi
+
+  if [[ -s "$RESEARCH_CONTEXT" ]]; then
+    echo "  リサーチ結果: $(wc -l < "$RESEARCH_CONTEXT") 行"
+  else
+    echo "  リサーチ結果: なし（スキップ）"
+    rm -f "$RESEARCH_CONTEXT"
+  fi
+}
+
+run_design_phase() {
+  local keyword_file="$1"
+  local agent
+  agent=$(get_role_agent "designer") || return 0
+
+  echo "--- Phase 2: Design ($agent) ---"
+  local model
+  model=$(get_agent_model "$agent")
+
+  local keywords
+  keywords=$(cat "$keyword_file")
+
+  local research_input=""
+  if [[ -f "$RESEARCH_CONTEXT" ]]; then
+    research_input="
+
+Additional research context:
+$(cat "$RESEARCH_CONTEXT")"
+  fi
+
+  if [[ "$agent" == "codex" ]]; then
+    local sandbox
+    sandbox=$(get_agent_sandbox "$agent")
+    sandbox="${sandbox:-read-only}"
+    codex exec --model "${model:-o4-mini}" --sandbox "$sandbox" --full-auto "
+You are an innovative app designer. Given these keywords from trend analysis, brainstorm a creative and viable app concept.
+
+Keywords data:
+${keywords}
+${research_input}
+
+IMPORTANT: Don't suggest obvious apps. Use association thinking - jump 1-2 conceptual levels from the keywords to find innovative ideas.
+
+Provide:
+1. App name (English, kebab-case)
+2. Core concept (1-2 sentences)
+3. Target users and their pain points
+4. 5-8 core features with descriptions and priorities (High/Medium/Low)
+5. Suggested technology stack with rationale
+6. Monetization strategy
+
+Output: Structured markdown format.
+" 2>/dev/null > "$DESIGN_CONTEXT" || true
+
+  elif [[ "$agent" == "gemini" ]]; then
+    gemini -p "
+You are an innovative app designer. Given these keywords from trend analysis, brainstorm a creative and viable app concept.
+
+Keywords data:
+${keywords}
+${research_input}
+
+IMPORTANT: Don't suggest obvious apps. Use association thinking - jump 1-2 conceptual levels from the keywords to find innovative ideas.
+
+Provide:
+1. App name (English, kebab-case)
+2. Core concept (1-2 sentences)
+3. Target users and their pain points
+4. 5-8 core features with descriptions and priorities
+5. Suggested technology stack with rationale
+6. Monetization strategy
+
+Output: Structured markdown format.
+" 2>/dev/null > "$DESIGN_CONTEXT" || true
+  fi
+
+  if [[ -s "$DESIGN_CONTEXT" ]]; then
+    echo "  設計提案: $(wc -l < "$DESIGN_CONTEXT") 行"
+  else
+    echo "  設計提案: なし（スキップ）"
+    rm -f "$DESIGN_CONTEXT"
+  fi
+}
+
+run_review_phase() {
+  local app_name="$1"
+  local agent
+  agent=$(get_role_agent "reviewer") || return 0
+
+  local app_dir="${REQUIREMENTS_DIR}/${app_name}"
+  if [[ ! -d "$app_dir" ]]; then
+    echo "  レビュー対象ディレクトリが見つかりません: ${app_dir}"
+    return 0
+  fi
+
+  echo "--- Phase 4: Review ($agent) ---"
+  local model
+  model=$(get_agent_model "$agent")
+
+  # overview.mdとfeatureファイルを読み取り
+  local overview=""
+  if [[ -f "${app_dir}/overview.md" ]]; then
+    overview=$(cat "${app_dir}/overview.md")
+  fi
+
+  local features=""
+  for f in "${app_dir}"/features/*.md; do
+    if [[ -f "$f" ]]; then
+      features="${features}
+
+--- $(basename "$f") ---
+$(cat "$f")"
+    fi
+  done
+
+  if [[ "$agent" == "codex" ]]; then
+    local sandbox
+    sandbox=$(get_agent_sandbox "$agent")
+    sandbox="${sandbox:-read-only}"
+    codex exec --model "${model:-o4-mini}" --sandbox "$sandbox" --full-auto "
+Review these app requirements for quality and completeness.
+
+## overview.md
+${overview}
+
+## Feature Specs
+${features}
+
+Evaluate:
+1. Is the concept clear and the scope realistic?
+2. Do the features comprehensively cover user needs?
+3. Is the technical stack feasible and well-chosen?
+4. Are there consistency issues between overview and features?
+5. Are non-functional requirements adequately addressed?
+
+Output format:
+## Review Summary
+### Score: A/B/C
+### Strengths
+### Issues (table: #, Severity, File, Issue, Suggestion)
+### Recommendations
+" 2>/dev/null > "$REVIEW_RESULT" || true
+
+  elif [[ "$agent" == "gemini" ]]; then
+    gemini -p "
+Review these app requirements for quality and completeness.
+
+## overview.md
+${overview}
+
+## Feature Specs
+${features}
+
+Evaluate:
+1. Is the concept clear and the scope realistic?
+2. Do the features comprehensively cover user needs?
+3. Is the technical stack feasible and well-chosen?
+4. Are there consistency issues between overview and features?
+5. Are non-functional requirements adequately addressed?
+
+Output format:
+## Review Summary
+### Score: A/B/C
+### Strengths
+### Issues (table: #, Severity, File, Issue, Suggestion)
+### Recommendations
+" 2>/dev/null > "$REVIEW_RESULT" || true
+  fi
+
+  if [[ -s "$REVIEW_RESULT" ]]; then
+    echo "  レビュー結果: $(wc -l < "$REVIEW_RESULT") 行"
+    echo ""
+    echo "--- レビューサマリー ---"
+    head -30 "$REVIEW_RESULT"
+    echo "..."
+  else
+    echo "  レビュー結果: なし（スキップ）"
+    rm -f "$REVIEW_RESULT"
+  fi
+}
+
+# =============================================================================
+# スキル内容とテンプレートを結合してシステムプロンプトファイルを作成
+# =============================================================================
 PROMPT_FILE=$(mktemp)
-trap 'rm -f "$PROMPT_FILE"' EXIT
+# TMPDIR_AGENTS のtrapに追加
+trap 'rm -rf "$TMPDIR_AGENTS" "$PROMPT_FILE"' EXIT
 
 # フロントマターを除去してスキル本文を抽出
 awk 'BEGIN{n=0} /^---/{n++; next} n>=2{print}' "$SKILL_FILE" > "$PROMPT_FILE"
@@ -51,7 +385,9 @@ echo "---" >> "$PROMPT_FILE"
 echo "" >> "$PROMPT_FILE"
 cat "$TEMPLATES_FILE" >> "$PROMPT_FILE"
 
-# --- データセットモード ---
+# =============================================================================
+# データセットモード
+# =============================================================================
 if [[ -n "$DATASET_SOURCE" ]]; then
   echo "=== 要件生成（データセットモード） ==="
   echo "ソース: ${DATASET_SOURCE}"
@@ -81,7 +417,9 @@ tsx scripts/validate-requirements.ts <生成したapp_name>"
   exit 0
 fi
 
-# --- 通常モード（keyword.jsonベース） ---
+# =============================================================================
+# 通常モード（keyword.jsonベース）
+# =============================================================================
 if [[ -z "$TARGET_DIR" ]]; then
   TARGET_DIR=$(ls -1d "${DATA_SOURCE_DIR}"/*/ 2>/dev/null | xargs -n1 basename | sort | tail -1)
   if [[ -z "$TARGET_DIR" ]]; then
@@ -100,10 +438,69 @@ echo "=== 要件生成 ==="
 echo "対象: ${KEYWORD_FILE}"
 echo ""
 
-# --- Claude Code CLI で実行 ---
+# --- エージェント設定の表示 ---
+if ! $SKIP_AGENTS; then
+  echo "--- エージェント設定 ---"
+  for agent in codex gemini; do
+    if get_agent_enabled "$agent"; then
+      local_model=$(get_agent_model "$agent")
+      echo "  ${agent}: enabled (model: ${local_model:-default})"
+    else
+      echo "  ${agent}: disabled"
+    fi
+  done
+  echo ""
+fi
+
+# --- 生成前のアプリ一覧を記録（新規アプリ検出用） ---
+APPS_BEFORE=$(ls -1 "${REQUIREMENTS_DIR}" 2>/dev/null || true)
+
+# =============================================================================
+# Phase 1: Research（researcher ロール）
+# =============================================================================
+if can_run_role "researcher"; then
+  run_research_phase "$KEYWORD_FILE"
+  echo ""
+fi
+
+# =============================================================================
+# Phase 2: Design（designer ロール）
+# =============================================================================
+if can_run_role "designer"; then
+  run_design_phase "$KEYWORD_FILE"
+  echo ""
+fi
+
+# =============================================================================
+# Phase 3: Generate（Claude Code メイン生成）
+# =============================================================================
+echo "--- Phase 3: Generate (Claude Code) ---"
+
+# 外部エージェントのコンテキストをプロンプトに統合
+EXTRA_CONTEXT=""
+if [[ -f "$RESEARCH_CONTEXT" ]]; then
+  EXTRA_CONTEXT="${EXTRA_CONTEXT}
+
+## 外部リサーチ結果（参考情報）
+以下は外部エージェントによるトレンド・市場調査の結果です。アプリ案の構想に活用してください。
+
+$(cat "$RESEARCH_CONTEXT")"
+fi
+
+if [[ -f "$DESIGN_CONTEXT" ]]; then
+  EXTRA_CONTEXT="${EXTRA_CONTEXT}
+
+## 外部エージェントによる設計提案（参考情報）
+以下は外部エージェントによるアプリコンセプト提案です。参考にしつつ、独自の視点で要件を生成してください。
+そのまま採用する必要はありません。より良いアイデアがあれば自由に変更してください。
+
+$(cat "$DESIGN_CONTEXT")"
+fi
+
 PROMPT="以下のkeyword.jsonを読み込み、上記の要件生成スキルの手順に従ってアプリの要件を生成してください。
 対象ディレクトリ: ${TARGET_DIR}
 keyword.jsonパス: ${KEYWORD_FILE}
+${EXTRA_CONTEXT}
 
 生成完了後、以下のバリデーションスクリプトを実行して構造を検証してください:
 tsx scripts/validate-requirements.ts <生成したapp_name>"
@@ -111,3 +508,26 @@ tsx scripts/validate-requirements.ts <生成したapp_name>"
 claude -p "$PROMPT" \
   --append-system-prompt-file "$PROMPT_FILE" \
   --allowedTools "Read" "Write" "Glob" "Bash(mkdir:*)" "Bash(find:*)" "Bash(tsx:*)"
+
+echo ""
+
+# =============================================================================
+# Phase 4: Review（reviewer ロール）
+# =============================================================================
+if can_run_role "reviewer"; then
+  # 新規生成されたアプリを検出
+  APPS_AFTER=$(ls -1 "${REQUIREMENTS_DIR}" 2>/dev/null || true)
+  NEW_APPS=$(comm -13 <(echo "$APPS_BEFORE" | sort) <(echo "$APPS_AFTER" | sort) 2>/dev/null || true)
+
+  if [[ -n "$NEW_APPS" ]]; then
+    for app_name in $NEW_APPS; do
+      run_review_phase "$app_name"
+    done
+  else
+    echo "--- Phase 4: Review ---"
+    echo "  新規アプリが検出されませんでした。レビューをスキップします。"
+  fi
+  echo ""
+fi
+
+echo "=== 要件生成完了 ==="

--- a/scripts/lib/agents.ts
+++ b/scripts/lib/agents.ts
@@ -1,0 +1,44 @@
+import type { AgentConfig } from "./config.js";
+import { loadAppConfig } from "./config.js";
+
+/** 定義済みロール */
+export type AgentRole = "researcher" | "designer" | "reviewer" | "enhancer";
+
+const VALID_ROLES: readonly AgentRole[] = ["researcher", "designer", "reviewer", "enhancer"];
+
+/**
+ * app.config.yaml から generate.agents を読み込む。
+ * 未設定の場合は空オブジェクトを返す。
+ */
+export function loadAgentConfigs(): Record<string, AgentConfig> {
+  const config = loadAppConfig();
+  return config.generate?.agents ?? {};
+}
+
+/**
+ * 指定ロールを持つ有効なエージェント一覧を返す。
+ */
+export function getAgentsWithRole(
+  role: AgentRole,
+  agents?: Record<string, AgentConfig>,
+): Array<{ name: string; config: AgentConfig }> {
+  const configs = agents ?? loadAgentConfigs();
+  return Object.entries(configs)
+    .filter(([, cfg]) => cfg.enabled && cfg.roles.includes(role))
+    .map(([name, config]) => ({ name, config }));
+}
+
+/**
+ * 指定エージェントが有効かどうかを返す。
+ */
+export function isAgentEnabled(name: string, agents?: Record<string, AgentConfig>): boolean {
+  const configs = agents ?? loadAgentConfigs();
+  return configs[name]?.enabled ?? false;
+}
+
+/**
+ * ロール値が有効かどうかを検証する。
+ */
+export function isValidRole(role: string): role is AgentRole {
+  return (VALID_ROLES as readonly string[]).includes(role);
+}

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -11,10 +11,20 @@ export interface SourceConfig {
   output_file: string;
 }
 
+export interface AgentConfig {
+  enabled: boolean;
+  model: string;
+  sandbox?: string;
+  roles: string[];
+}
+
 export interface AppConfig {
   output_base_dir?: string;
   collect: {
     sources: Record<string, SourceConfig>;
+  };
+  generate?: {
+    agents?: Record<string, AgentConfig>;
   };
 }
 

--- a/scripts/validate-requirements.ts
+++ b/scripts/validate-requirements.ts
@@ -109,13 +109,25 @@ function validate(appName: string): ValidationError[] {
     errors.push({ file: "diagrams/", message: "diagramsディレクトリが存在しません" });
   }
 
-  // 5. _source_info.json スキーマバリデーション
+  // 5. _source_info.json バリデーション（JSON構文 + スキーマ）
   const sourceInfoPath = join(appDir, "_source_info.json");
   if (existsSync(sourceInfoPath)) {
-    try {
-      const raw = readFileSync(sourceInfoPath, "utf-8");
-      const data = JSON.parse(raw) as SourceInfoJson;
+    const raw = readFileSync(sourceInfoPath, "utf-8");
 
+    // 5a. JSON構文チェック（未エスケープのクォート等を検出）
+    let data: SourceInfoJson | null = null;
+    try {
+      data = JSON.parse(raw) as SourceInfoJson;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      errors.push({
+        file: "_source_info.json",
+        message: `JSON構文エラー: ${msg}（未エスケープのダブルクォートや末尾カンマ等がないか確認してください）`,
+      });
+    }
+
+    // 5b. スキーマバリデーション（JSON構文が正常な場合のみ）
+    if (data) {
       if (!data.source?.directory) {
         errors.push({ file: "_source_info.json", message: "source.directoryが未設定です" });
       }
@@ -161,11 +173,6 @@ function validate(appName: string): ValidationError[] {
           }
         }
       }
-    } catch (e) {
-      errors.push({
-        file: "_source_info.json",
-        message: `JSONパースエラー: ${e instanceof Error ? e.message : String(e)}`,
-      });
     }
   }
 


### PR DESCRIPTION
## Summary

要件生成（`pnpm generate`）時に Claude Code だけでなく、Codex CLI・Gemini CLI も活用可能にする。
`app.config.yaml` の `generate.agents` セクションでエージェントの有効/無効・モデル・役割（role）を設定し、各フェーズで自動的に呼び出す。

参考リポジトリ `claude-code-orchestra` の有用な設計パターン（委譲ルール、フック、CLI設定等）を適用。

Closes #2

## Changes

### 設定
- `app.config.yaml` に `generate.agents` セクション追加（codex: designer+reviewer, gemini: researcher）
- `scripts/lib/config.ts` に `AgentConfig` 型追加
- `scripts/lib/agents.ts` 新規作成（エージェント設定読み込みユーティリティ）

### マルチエージェントフロー（`scripts/generate.sh`）
- Phase 1: Research（gemini/researcher） — トレンド・市場調査
- Phase 2: Design（codex/designer） — アプリコンセプト設計提案
- Phase 3: Generate（Claude Code） — メイン要件生成（research+design結果をプロンプトに統合）
- Phase 4: Review（codex/reviewer） — 生成された要件の品質レビュー
- `--skip-agents` オプションで外部エージェントをスキップ可能
- 後方互換性: エージェント未設定/disabled時は従来通りClaude Code単独動作

### Codex CLI設定（`.codex/`）
- `AGENTS.md` — 要件生成に特化した役割定義
- `config.toml` — o4-mini, context-loaderスキル
- `skills/context-loader/SKILL.md` — プロジェクトコンテキスト読み込み

### Gemini CLI設定（`.gemini/`）
- `GEMINI.md` — リサーチ特化の役割定義
- `settings.json` — gemini-2.5-pro, スキル有効化
- `skills/context-loader/SKILL.md` — プロジェクトコンテキスト読み込み

### Claude Code設定
- `.claude/rules/codex-delegation.md` — Codex使用タイミング・パターン
- `.claude/rules/gemini-delegation.md` — Gemini使用タイミング・パターン
- `.claude/hooks/agent-router.py` — ユーザー入力からエージェント自動提案
- `.claude/hooks/log-cli-tools.py` — codex/gemini実行ログを`.claude/logs/cli-tools.jsonl`に自動記録
- `.claude/settings.json` — Bash(codex/gemini)権限、フック設定追加

### スキル
- `SKILL.md` にマルチエージェントフロー参照を追記

## Test plan

- [ ] `app.config.yaml` のagent設定が正しく読み込まれるか確認
- [ ] codex disabled / gemini disabled 状態で `pnpm generate --skip-agents` が従来通り動作するか確認
- [ ] codex enabled 状態で `pnpm generate` を実行し、Design→Generate→Review フローが動作するか確認
- [ ] gemini enabled 状態で Research フェーズが実行されるか確認
- [ ] `.claude/logs/cli-tools.jsonl` にログが記録されるか確認
- [ ] バリデーション（`pnpm generate:validate`）が通過するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)