### PR TITLE
feat: viewerにお気に入り機能を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,16 +39,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 │       └── generate-requirements/
 ├── gen/                      # 生成データ出力先（.gitignore対象）
 │   ├── tags.json             # タグ定義（generateごとに自由に追加可能）
+│   ├── favorite.json         # お気に入りデータ（FavoriteItem配列）
 │   ├── data_source/          # 外部APIから取得した生データ（タイムスタンプ付きサブディレクトリ）
 │   │   └── yyyy_mm_dd_hh_mm_ss/
 │   │       ├── news.json
 │   │       └── keyword.json
+│   ├── datasets/             # データセット定義（JSON、Viewer経由で管理）
+│   │   └── {dataset_name}.json
 │   └── requirements/         # 生成されたアプリ要件（アプリ単位のサブディレクトリ）
 │       └── {app_name}/
 │           ├── _source_info.json
 │           ├── overview.md
-│           └── features/
-│               └── {nn}_{feature_name}.md
+│           ├── memo.md           # メモ（Viewerから編集可能、dev mode時のみ）
+│           ├── features/
+│           │   └── {nn}_{feature_name}.md
+│           └── diagrams/         # 図解（Mermaid等のMarkdown）
+│               └── {nn}_{diagram_name}.md
 ├── scripts/                  # CLIツール群
 │   ├── collect.ts            # データ収集
 │   ├── extract.sh / extract.ts  # キーワード抽出
@@ -60,7 +66,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 │       ├── config.ts         # app.config.yaml読み込み
 │       ├── data-source.ts    # data_source操作ユーティリティ
 │       ├── fetchers.ts       # API呼び出し（NewsAPI等）
-│       └── storage.ts        # ファイル出力
+│       ├── paths.ts          # パス定数
+│       ├── storage.ts        # ファイル出力
+│       └── tags.ts           # タグ管理（gen/tags.jsonから動的読み込み・バリデーション）
 ├── viewer/                   # Webビューワー（pnpmワークスペースパッケージ）
 │   ├── server.ts             # Hono APIサーバ + Vite dev middleware
 │   ├── vite.config.ts
@@ -70,9 +78,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 │       ├── index.css
 │       ├── main.tsx
 │       └── components/
-│           ├── AppView.tsx    # メインビュー（overview + features表示）
-│           ├── MarkdownPane.tsx  # Markdownレンダリング
-│           └── Sidebar.tsx    # アプリ選択サイドバー
+│           ├── AppView.tsx        # メインビュー（overview + features + diagrams + memo表示）
+│           ├── DatasetAddButton.tsx  # データセットへのアイテム追加ボタン
+│           ├── DatasetManager.tsx # データセット管理画面
+│           ├── FavoritePage.tsx   # お気に入り一覧ページ（解除・データセット追加機能付き）
+│           ├── MarkdownPane.tsx   # Markdownレンダリング
+│           ├── MemoTab.tsx        # メモ編集タブ
+│           ├── SearchView.tsx     # 検索結果表示
+│           ├── Sidebar.tsx        # アプリ選択サイドバー（タグフィルタ・検索機能付き）
+│           └── Toast.tsx          # トースト通知
 ├── todo/                     # 開発タスク管理（フェーズ別）
 ├── app.config.yaml           # アプリケーション設定（フェーズ別の設定を階層管理）
 ├── biome.jsonc               # Biome設定（フォーマッター・リンター）
@@ -169,6 +183,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **YouTube Data API**: 無効（デフォルト）。人気動画ランキング取得
 - TikTok、RSSフィード: 今後追加予定（設定テンプレートのみ）
 
+## タグシステム
+
+タグ定義は `gen/tags.json`（文字列配列）に外部化されており、generateのたびに自由に追加可能。
+
+- **定義ファイル**: `gen/tags.json` -- 全タグの文字列配列
+- **バリデーション**: `scripts/lib/tags.ts` が `gen/tags.json` を動的に読み込み、各アプリに最低3つのタグを要求
+- **Viewer連携**: Sidebarのタグ選択は `GET /api/tags` から動的に取得（ハードコーディングなし）
+- **表示**: アプリ一覧では最大3つのタグをバッジ表示
+
 ## カスタムエージェント
 
 - `update-memory` - CLAUDE.mdをプロジェクト最新情報に同期更新
@@ -187,14 +210,54 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ビューワーサーバ（Hono）が提供するAPIエンドポイント:
 
+### アプリ・コンテンツ
+
 | エンドポイント | 説明 |
 | -------------- | ------ |
-| `GET /api/apps` | アプリ一覧 |
+| `GET /api/apps` | アプリ一覧（タグ最大3つ付き、更新日時降順） |
 | `GET /api/apps/:name/overview` | overview.mdの内容 |
 | `GET /api/apps/:name/features` | 機能一覧（タイトル・概要付き） |
 | `GET /api/apps/:name/features/:featureId` | 機能詳細のMarkdown |
 | `GET /api/apps/:name/source-info` | _source_info.jsonの内容 |
+| `GET /api/apps/:name/diagrams` | 図解一覧（Markdown） |
+| `GET /api/apps/:name/memo` | メモ内容の取得 |
+| `POST /api/apps/:name/memo` | メモ内容の保存（dev modeのみ） |
 | `GET /api/tags` | 定義済みタグ一覧（`gen/tags.json`） |
+| `GET /api/mode` | 動作モード（isDev）の取得 |
+
+### お気に入り
+
+| エンドポイント | 説明 |
+| -------------- | ------ |
+| `GET /api/favorites` | お気に入り一覧取得（`gen/favorite.json`） |
+| `POST /api/favorites` | お気に入り追加（body: `{appName, type, featureId?, diagramId?, title?}`） |
+| `DELETE /api/favorites` | お気に入り削除（body: 同上） |
+
+### データセット
+
+| エンドポイント | 説明 |
+| -------------- | ------ |
+| `GET /api/datasets` | データセット一覧 |
+| `GET /api/datasets/:name` | データセット詳細 |
+| `POST /api/datasets` | データセット作成（dev modeのみ） |
+| `DELETE /api/datasets/:name` | データセット削除（dev modeのみ） |
+| `POST /api/datasets/:name/items` | データセットにアイテム追加（dev modeのみ） |
+| `DELETE /api/datasets/:name/items` | データセットからアイテム削除（dev modeのみ） |
+| `POST /api/datasets/:name/generate` | データセットからパイプライン実行（dev modeのみ） |
+| `GET /api/datasets/:name/generated-apps` | データセットから生成されたアプリ一覧 |
+
+### 検索
+
+| エンドポイント | 説明 |
+| -------------- | ------ |
+| `GET /api/apps-with-tags` | 全アプリのタグ情報（全タグ取得、名前順） |
+| `GET /api/search?q=&tags=` | 全文検索 + タグAND検索（複合検索対応） |
+
+### Git操作
+
+| エンドポイント | 説明 |
+| -------------- | ------ |
+| `POST /api/git/commit-push` | genディレクトリのgit add + commit + push（dev modeのみ） |
 
 ## pnpmワークスペース構成
 

--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -56,6 +56,43 @@ interface DatasetItem {
   title?: string;
 }
 
+interface FavoriteItem {
+  appName: string;
+  type: "overview" | "feature" | "diagram";
+  featureId?: string;
+  diagramId?: string;
+  title?: string;
+}
+
+function loadFavoritesPath(): string {
+  try {
+    const configPath = resolve(projectRoot, "app.config.yaml");
+    const raw = readFileSync(configPath, "utf-8");
+    const config = parse(raw) as { output_base_dir?: string };
+    const base = config.output_base_dir ?? "gen";
+    return resolve(projectRoot, base, "favorite.json");
+  } catch {
+    return resolve(projectRoot, "gen", "favorite.json");
+  }
+}
+
+const FAVORITES_PATH = loadFavoritesPath();
+
+function readFavorites(): FavoriteItem[] {
+  if (!existsSync(FAVORITES_PATH)) return [];
+  try {
+    return JSON.parse(readFileSync(FAVORITES_PATH, "utf-8")) as FavoriteItem[];
+  } catch {
+    return [];
+  }
+}
+
+function writeFavorites(items: FavoriteItem[]): void {
+  const dir = resolve(FAVORITES_PATH, "..");
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(FAVORITES_PATH, JSON.stringify(items, null, 2), "utf-8");
+}
+
 interface Dataset {
   name: string;
   createdAt: string;
@@ -404,6 +441,43 @@ app.get("/api/search", async (c) => {
   } catch {
     return c.json({ results: [], resultType: "grep" });
   }
+});
+
+// --- Favorites API ---
+app.get("/api/favorites", (c) => {
+  return c.json(readFavorites());
+});
+
+app.post("/api/favorites", async (c) => {
+  const item = await c.req.json<FavoriteItem>();
+  const favorites = readFavorites();
+  const exists = favorites.some(
+    (f) =>
+      f.appName === item.appName &&
+      f.type === item.type &&
+      f.featureId === item.featureId &&
+      f.diagramId === item.diagramId,
+  );
+  if (exists) return c.json({ error: "既にお気に入りに登録されています" }, 409);
+  favorites.push(item);
+  writeFavorites(favorites);
+  return c.json({ success: true });
+});
+
+app.delete("/api/favorites", async (c) => {
+  const item = await c.req.json<FavoriteItem>();
+  const favorites = readFavorites();
+  const filtered = favorites.filter(
+    (f) =>
+      !(
+        f.appName === item.appName &&
+        f.type === item.type &&
+        f.featureId === item.featureId &&
+        f.diagramId === item.diagramId
+      ),
+  );
+  writeFavorites(filtered);
+  return c.json({ success: true });
 });
 
 // --- Git API ---

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -13,12 +13,13 @@ import {
 } from "./api";
 import { type AppTab, AppView } from "./components/AppView";
 import { DatasetManager } from "./components/DatasetManager";
+import { FavoritePage } from "./components/FavoritePage";
 import { SearchView } from "./components/SearchView";
 import { Sidebar } from "./components/Sidebar";
 import { ToastProvider } from "./components/Toast";
 import { useIsMobile } from "./hooks/useIsMobile";
 
-type ViewMode = "apps" | "datasets";
+type ViewMode = "apps" | "datasets" | "favorites";
 
 function buildUrl(state: {
   viewMode: ViewMode;
@@ -36,6 +37,8 @@ function buildUrl(state: {
   if (state.viewMode === "datasets") {
     url.searchParams.set("view", "datasets");
     if (state.dataset) url.searchParams.set("dataset", state.dataset);
+  } else if (state.viewMode === "favorites") {
+    url.searchParams.set("view", "favorites");
   } else {
     if (state.app) url.searchParams.set("app", state.app);
     if (state.feature) url.searchParams.set("feature", state.feature);
@@ -95,9 +98,13 @@ export function App() {
   // 初回ロード: URLからstate復元
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const isDatasetView = params.get("view") === "datasets";
-    // URL から datasets ビュー + 選択データセットを復元
-    if (isDatasetView) {
+    const viewParam = params.get("view");
+    const isDatasetView = viewParam === "datasets";
+    const isFavoritesView = viewParam === "favorites";
+    // URL から datasets/favorites ビュー復元
+    if (isFavoritesView) {
+      setViewMode("favorites");
+    } else if (isDatasetView) {
       setViewMode("datasets");
       const dsParam = params.get("dataset");
       if (dsParam) setSelectedDataset(dsParam);
@@ -129,15 +136,16 @@ export function App() {
         tabParam && ["overview", "source-info", "diagrams", "features", "memo"].includes(tabParam)
           ? tabParam
           : undefined;
+      const currentViewMode = isFavoritesView ? "favorites" : isDatasetView ? "datasets" : "apps";
       window.history.replaceState(
         {},
         "",
         buildUrl({
-          viewMode: isDatasetView ? "datasets" : "apps",
-          app: isDatasetView ? undefined : app,
-          feature: !isDatasetView && validApp ? params.get("feature") : undefined,
+          viewMode: currentViewMode,
+          app: currentViewMode === "apps" ? app : undefined,
+          feature: currentViewMode === "apps" && validApp ? params.get("feature") : undefined,
           dataset: isDatasetView ? params.get("dataset") : undefined,
-          tab: !isDatasetView && validApp ? validTab : undefined,
+          tab: currentViewMode === "apps" && validApp ? validTab : undefined,
         }),
       );
     }
@@ -147,7 +155,12 @@ export function App() {
   useEffect(() => {
     const handlePopState = () => {
       const params = new URLSearchParams(window.location.search);
-      if (params.get("view") === "datasets") {
+      const viewParam = params.get("view");
+      if (viewParam === "favorites") {
+        setViewMode("favorites");
+        setSelectedFeature(null);
+        setSelectedTab("overview");
+      } else if (viewParam === "datasets") {
         setViewMode("datasets");
         setSelectedDataset(params.get("dataset"));
         setSelectedFeature(null);
@@ -192,6 +205,14 @@ export function App() {
     setSearchActive(false);
     if (isMobile) setMobileSidebarOpen(false);
     window.history.pushState({}, "", buildUrl({ viewMode: "datasets", dataset: selectedDataset }));
+  };
+
+  const handleSelectFavorites = () => {
+    setViewMode("favorites");
+    setSelectedFeature(null);
+    setSearchActive(false);
+    if (isMobile) setMobileSidebarOpen(false);
+    window.history.pushState({}, "", buildUrl({ viewMode: "favorites" }));
   };
 
   const handleNavigateToDataset = (datasetName: string) => {
@@ -363,7 +384,11 @@ export function App() {
               </svg>
             </button>
             <span className="text-sm font-semibold text-gray-200 truncate">
-              {viewMode === "datasets" ? "データセット" : (selectedApp ?? "Requirements Viewer")}
+              {viewMode === "favorites"
+                ? "お気に入り"
+                : viewMode === "datasets"
+                  ? "データセット"
+                  : (selectedApp ?? "Requirements Viewer")}
             </span>
           </div>
         )}
@@ -379,6 +404,7 @@ export function App() {
           onMobileClose={() => setMobileSidebarOpen(false)}
           viewMode={viewMode}
           onSelectDatasets={handleSelectDatasets}
+          onSelectFavorites={handleSelectFavorites}
           onSearch={handleSearch}
           onClearSearch={handleClearSearch}
           isSearchActive={searchActive}
@@ -392,7 +418,9 @@ export function App() {
               : "mb-3 mr-3 rounded-2xl bg-gray-900 shadow-2xl shadow-black/50 ring-1 ring-gray-800"
           }`}
         >
-          {viewMode === "datasets" ? (
+          {viewMode === "favorites" ? (
+            <FavoritePage isMobile={isMobile} isDev={isDev} onSelectApp={handleNavigateToApp} />
+          ) : viewMode === "datasets" ? (
             <DatasetManager
               isMobile={isMobile}
               isDev={isDev}

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -227,6 +227,32 @@ export function App() {
     handleSelectApp(appName);
   };
 
+  const handleNavigateToFeature = (appName: string, featureId: string) => {
+    setSelectedApp(appName);
+    setSelectedFeature(featureId);
+    setSelectedTab("features");
+    setViewMode("apps");
+    setSearchActive(false);
+    if (isMobile) setMobileSidebarOpen(false);
+    window.history.pushState(
+      {},
+      "",
+      buildUrl({ viewMode: "apps", app: appName, feature: featureId, tab: "features" }),
+    );
+  };
+
+  const handleNavigateToDiagram = (appName: string) => {
+    setSelectedApp(appName);
+    setSelectedFeature(null);
+    setSelectedTab("diagrams");
+    setPinnedTab(null);
+    localStorage.removeItem("viewer:pinnedTab");
+    setViewMode("apps");
+    setSearchActive(false);
+    if (isMobile) setMobileSidebarOpen(false);
+    window.history.pushState({}, "", buildUrl({ viewMode: "apps", app: appName, tab: "diagrams" }));
+  };
+
   const handleSelectFeature = (feature: string | null) => {
     setSelectedFeature(feature);
     window.history.pushState(
@@ -419,7 +445,13 @@ export function App() {
           }`}
         >
           {viewMode === "favorites" ? (
-            <FavoritePage isMobile={isMobile} isDev={isDev} onSelectApp={handleNavigateToApp} />
+            <FavoritePage
+              isMobile={isMobile}
+              isDev={isDev}
+              onSelectApp={handleNavigateToApp}
+              onSelectFeature={handleNavigateToFeature}
+              onSelectDiagram={handleNavigateToDiagram}
+            />
           ) : viewMode === "datasets" ? (
             <DatasetManager
               isMobile={isMobile}

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -214,6 +214,41 @@ export async function search(
   return res.json();
 }
 
+// --- Favorites API ---
+
+export interface FavoriteItem {
+  appName: string;
+  type: "overview" | "feature" | "diagram";
+  featureId?: string;
+  diagramId?: string;
+  title?: string;
+}
+
+export async function fetchFavorites(): Promise<FavoriteItem[]> {
+  const res = await fetch(`${BASE}/favorites`);
+  return res.json();
+}
+
+export async function addFavorite(
+  item: FavoriteItem,
+): Promise<{ success: boolean; error?: string }> {
+  const res = await fetch(`${BASE}/favorites`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(item),
+  });
+  return res.json();
+}
+
+export async function removeFavorite(item: FavoriteItem): Promise<{ success: boolean }> {
+  const res = await fetch(`${BASE}/favorites`, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(item),
+  });
+  return res.json();
+}
+
 // --- Git API ---
 
 export interface GitResult {

--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -1,15 +1,19 @@
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useState } from "react";
 import {
+  addFavorite,
   commitAndPush,
   type DiagramFile,
+  type FavoriteItem,
   type Feature,
   fetchDiagrams,
+  fetchFavorites,
   fetchFeatureDetail,
   fetchFeatures,
   fetchMode,
   fetchOverview,
   fetchSourceInfo,
+  removeFavorite,
   type SourceInfo,
 } from "../api";
 import { DatasetAddButton } from "./DatasetAddButton";
@@ -63,11 +67,53 @@ export function AppView({
   const [loading, setLoading] = useState(true);
   const [isDev, setIsDev] = useState(false);
   const [pushing, setPushing] = useState(false);
+  const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
   const { showToast } = useToast();
 
   useEffect(() => {
     fetchMode().then((r) => setIsDev(r.isDev));
   }, []);
+
+  useEffect(() => {
+    fetchFavorites().then(setFavorites);
+  }, []);
+
+  const isFavorited = useCallback(
+    (type: FavoriteItem["type"], featureId?: string, diagramId?: string) => {
+      return favorites.some(
+        (f) =>
+          f.appName === appName &&
+          f.type === type &&
+          f.featureId === featureId &&
+          f.diagramId === diagramId,
+      );
+    },
+    [appName, favorites],
+  );
+
+  const handleToggleFavorite = useCallback(
+    async (type: FavoriteItem["type"], title?: string, featureId?: string, diagramId?: string) => {
+      const item: FavoriteItem = { appName, type, featureId, diagramId, title };
+      if (isFavorited(type, featureId, diagramId)) {
+        await removeFavorite(item);
+        setFavorites((prev) =>
+          prev.filter(
+            (f) =>
+              !(
+                f.appName === appName &&
+                f.type === type &&
+                f.featureId === featureId &&
+                f.diagramId === diagramId
+              ),
+          ),
+        );
+      } else {
+        await addFavorite(item);
+        setFavorites((prev) => [...prev, item]);
+      }
+    },
+    [appName, isFavorited],
+  );
 
   useEffect(() => {
     setFeatureContent("");
@@ -224,6 +270,12 @@ export function AppView({
             pinned={pinnedTab === "memo"}
             onPin={() => onPinTab("memo")}
           />
+          {mobileTab === "overview" && (
+            <FavoriteToggleButton
+              active={isFavorited("overview")}
+              onClick={() => handleToggleFavorite("overview", appName)}
+            />
+          )}
           {isDev && (
             <>
               {mobileTab === "overview" && (
@@ -273,6 +325,10 @@ export function AppView({
                         )}
                       </div>
                       <div className="flex items-center gap-1 shrink-0 mt-0.5">
+                        <FavoriteToggleButton
+                          active={isFavorited("feature", f.id)}
+                          onClick={() => handleToggleFavorite("feature", f.title, f.id)}
+                        />
                         <DatasetAddButton
                           item={{
                             appName,
@@ -325,7 +381,15 @@ export function AppView({
                   {diagrams.length > 0 ? (
                     <div className="space-y-8">
                       {diagrams.map((d) => (
-                        <section key={d.id}>
+                        <section key={d.id} className="relative">
+                          <div className="absolute top-0 right-0 z-10">
+                            <FavoriteToggleButton
+                              active={isFavorited("diagram", undefined, d.id)}
+                              onClick={() =>
+                                handleToggleFavorite("diagram", d.title, undefined, d.id)
+                              }
+                            />
+                          </div>
                           <MarkdownPane content={d.content} />
                         </section>
                       ))}
@@ -420,6 +484,12 @@ export function AppView({
               pinned={pinnedTab === "memo"}
               onPin={() => onPinTab("memo")}
             />
+            {leftTab === "overview" && (
+              <FavoriteToggleButton
+                active={isFavorited("overview")}
+                onClick={() => handleToggleFavorite("overview", appName)}
+              />
+            )}
             {isDev && (
               <>
                 {leftTab === "overview" && (
@@ -466,7 +536,15 @@ export function AppView({
                     {diagrams.length > 0 ? (
                       <div className="space-y-8">
                         {diagrams.map((d) => (
-                          <section key={d.id}>
+                          <section key={d.id} className="relative">
+                            <div className="absolute top-0 right-0 z-10">
+                              <FavoriteToggleButton
+                                active={isFavorited("diagram", undefined, d.id)}
+                                onClick={() =>
+                                  handleToggleFavorite("diagram", d.title, undefined, d.id)
+                                }
+                              />
+                            </div>
                             <MarkdownPane content={d.content} />
                           </section>
                         ))}
@@ -560,8 +638,12 @@ export function AppView({
                       </p>
                     )}
                   </div>
-                  {/* Dataset add + Arrow */}
+                  {/* Favorite + Dataset add + Arrow */}
                   <div className="flex items-center gap-1 shrink-0 mt-0.5">
+                    <FavoriteToggleButton
+                      active={isFavorited("feature", f.id)}
+                      onClick={() => handleToggleFavorite("feature", f.title, f.id)}
+                    />
                     <DatasetAddButton
                       item={{
                         appName,
@@ -920,5 +1002,38 @@ function TabButton({
         transition={{ duration: 0.3, ease: "easeOut" }}
       />
     </div>
+  );
+}
+
+function FavoriteToggleButton({ active, onClick }: { active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className={`p-1 rounded-md transition-colors ${
+        active
+          ? "text-pink-400 hover:text-pink-300"
+          : "text-gray-600 hover:text-pink-400 hover:bg-pink-400/10"
+      }`}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      title={active ? "お気に入りから削除" : "お気に入りに追加"}
+    >
+      <svg
+        className="size-4"
+        viewBox="0 0 24 24"
+        fill={active ? "currentColor" : "none"}
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
+        />
+      </svg>
+    </button>
   );
 }

--- a/viewer/src/components/FavoritePage.tsx
+++ b/viewer/src/components/FavoritePage.tsx
@@ -7,6 +7,8 @@ interface FavoritePageProps {
   isMobile: boolean;
   isDev: boolean;
   onSelectApp: (appName: string) => void;
+  onSelectFeature: (appName: string, featureId: string) => void;
+  onSelectDiagram: (appName: string) => void;
   onRefresh?: () => void;
 }
 
@@ -56,7 +58,14 @@ function toDatasetItem(fav: FavoriteItem) {
   };
 }
 
-export function FavoritePage({ isMobile, isDev, onSelectApp, onRefresh }: FavoritePageProps) {
+export function FavoritePage({
+  isMobile,
+  isDev,
+  onSelectApp,
+  onSelectFeature,
+  onSelectDiagram,
+  onRefresh,
+}: FavoritePageProps) {
   const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -222,9 +231,21 @@ export function FavoritePage({ isMobile, isDev, onSelectApp, onRefresh }: Favori
                             >
                               {typeLabel(item.type)}
                             </span>
-                            <span className="flex-1 text-xs text-gray-300 truncate">
+                            <button
+                              type="button"
+                              className="flex-1 text-xs text-gray-300 truncate text-left hover:text-indigo-300 transition-colors"
+                              onClick={() => {
+                                if (item.type === "feature" && item.featureId) {
+                                  onSelectFeature(item.appName, item.featureId);
+                                } else if (item.type === "diagram") {
+                                  onSelectDiagram(item.appName);
+                                } else {
+                                  onSelectApp(item.appName);
+                                }
+                              }}
+                            >
                               {item.title ?? item.appName}
-                            </span>
+                            </button>
                             <div className="flex items-center gap-1 shrink-0">
                               {isDev && (
                                 <DatasetAddButton item={toDatasetItem(item)} isDev={isDev} />

--- a/viewer/src/components/FavoritePage.tsx
+++ b/viewer/src/components/FavoritePage.tsx
@@ -1,7 +1,15 @@
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useState } from "react";
-import { type FavoriteItem, fetchFavorites, removeFavorite } from "../api";
+import {
+  type FavoriteItem,
+  fetchDiagrams,
+  fetchFavorites,
+  fetchFeatureDetail,
+  fetchOverview,
+  removeFavorite,
+} from "../api";
 import { DatasetAddButton } from "./DatasetAddButton";
+import { MarkdownPane } from "./MarkdownPane";
 
 interface FavoritePageProps {
   isMobile: boolean;
@@ -58,6 +66,30 @@ function toDatasetItem(fav: FavoriteItem) {
   };
 }
 
+function itemKey(item: FavoriteItem): string {
+  return `${item.appName}-${item.type}-${item.featureId ?? ""}-${item.diagramId ?? ""}`;
+}
+
+async function fetchPreviewContent(item: FavoriteItem): Promise<string> {
+  switch (item.type) {
+    case "overview": {
+      const res = await fetchOverview(item.appName);
+      return res.content;
+    }
+    case "feature": {
+      if (!item.featureId) return "";
+      const res = await fetchFeatureDetail(item.appName, item.featureId);
+      return res.content;
+    }
+    case "diagram": {
+      if (!item.diagramId) return "";
+      const diagrams = await fetchDiagrams(item.appName);
+      const found = diagrams.find((d) => d.id === item.diagramId);
+      return found?.content ?? "";
+    }
+  }
+}
+
 export function FavoritePage({
   isMobile,
   isDev,
@@ -68,6 +100,9 @@ export function FavoritePage({
 }: FavoritePageProps) {
   const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [previewItem, setPreviewItem] = useState<FavoriteItem | null>(null);
+  const [previewContent, setPreviewContent] = useState("");
+  const [previewLoading, setPreviewLoading] = useState(false);
 
   const load = useCallback(() => {
     setLoading(true);
@@ -94,10 +129,39 @@ export function FavoritePage({
             ),
         ),
       );
+      if (previewItem && itemKey(previewItem) === itemKey(item)) {
+        setPreviewItem(null);
+        setPreviewContent("");
+      }
       onRefresh?.();
     },
-    [onRefresh],
+    [onRefresh, previewItem],
   );
+
+  const handlePreview = useCallback(
+    async (item: FavoriteItem) => {
+      if (previewItem && itemKey(previewItem) === itemKey(item)) {
+        setPreviewItem(null);
+        setPreviewContent("");
+        return;
+      }
+      setPreviewItem(item);
+      setPreviewContent("");
+      setPreviewLoading(true);
+      try {
+        const content = await fetchPreviewContent(item);
+        setPreviewContent(content);
+      } finally {
+        setPreviewLoading(false);
+      }
+    },
+    [previewItem],
+  );
+
+  const closePreview = useCallback(() => {
+    setPreviewItem(null);
+    setPreviewContent("");
+  }, []);
 
   const grouped = groupByApp(favorites);
 
@@ -120,6 +184,236 @@ export function FavoritePage({
       </div>
     );
   }
+
+  /* ── Mobile: preview replaces list ── */
+  if (isMobile && previewItem) {
+    return (
+      <motion.div
+        className="flex flex-col h-full"
+        initial={{ opacity: 0, x: 20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.25, ease: "easeOut" }}
+      >
+        <div className="flex items-center gap-2 px-4 bg-gray-900 border-b border-gray-800 shrink-0">
+          <button
+            type="button"
+            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-200 hover:bg-gray-700/50 transition-colors"
+            onClick={closePreview}
+          >
+            <svg
+              className="size-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <span
+            className={`inline-flex shrink-0 items-center justify-center rounded text-[9px] font-bold px-1.5 py-0.5 ${typeBadgeClass(previewItem.type)}`}
+          >
+            {typeLabel(previewItem.type)}
+          </span>
+          <span className="text-xs font-medium text-gray-300 py-2.5 truncate">
+            {previewItem.title ?? previewItem.appName}
+          </span>
+        </div>
+        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-8 bg-gray-900">
+          {previewLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <motion.div
+                className="size-6 rounded-full border-2 border-gray-700 border-t-gray-400"
+                animate={{ rotate: 360 }}
+                transition={{ duration: 1, repeat: Number.POSITIVE_INFINITY, ease: "linear" }}
+              />
+            </div>
+          ) : (
+            <MarkdownPane content={previewContent} />
+          )}
+        </div>
+      </motion.div>
+    );
+  }
+
+  const listContent = (
+    <>
+      {favorites.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16">
+          <div className="size-14 mx-auto mb-4 rounded-full bg-gray-800 flex items-center justify-center">
+            <svg
+              className="size-7 text-gray-600"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
+              />
+            </svg>
+          </div>
+          <p className="text-sm text-gray-500">お気に入りがありません</p>
+          <p className="text-xs text-gray-600 mt-1">
+            アプリのハートアイコンからお気に入りに追加できます
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          <AnimatePresence>
+            {grouped.map((group) => (
+              <motion.section
+                key={group.appName}
+                layout
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -12 }}
+                transition={{ duration: 0.3 }}
+              >
+                {/* App header */}
+                <button
+                  type="button"
+                  className="flex items-center gap-2 mb-3 group"
+                  onClick={() => onSelectApp(group.appName)}
+                >
+                  <span className="inline-flex shrink-0 items-center justify-center rounded text-[9px] font-bold px-1.5 py-0.5 bg-indigo-900/40 text-indigo-400">
+                    APP
+                  </span>
+                  <span className="text-sm font-semibold text-gray-200 group-hover:text-indigo-300 transition-colors truncate">
+                    {group.appName}
+                  </span>
+                  <svg
+                    className="size-3.5 text-gray-600 group-hover:text-indigo-400 transition-colors"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                </button>
+
+                {/* Items */}
+                <div className="space-y-1.5 ml-2">
+                  <AnimatePresence>
+                    {group.items.map((item) => {
+                      const key = itemKey(item);
+                      const isActive = previewItem != null && itemKey(previewItem) === key;
+                      return (
+                        <motion.div
+                          key={key}
+                          layout
+                          initial={{ opacity: 0, x: -8 }}
+                          animate={{ opacity: 1, x: 0 }}
+                          exit={{ opacity: 0, x: 8, height: 0 }}
+                          transition={{ duration: 0.2 }}
+                          className={`flex items-center gap-2 px-3 py-2 rounded-lg border group/item ${
+                            isActive
+                              ? "bg-indigo-500/10 border-indigo-500/30"
+                              : "bg-gray-800/60 border-gray-700/30"
+                          }`}
+                        >
+                          <span
+                            className={`inline-flex shrink-0 items-center justify-center rounded text-[9px] font-bold px-1.5 py-0.5 ${typeBadgeClass(item.type)}`}
+                          >
+                            {typeLabel(item.type)}
+                          </span>
+                          <button
+                            type="button"
+                            className="flex-1 text-xs text-gray-300 truncate text-left hover:text-indigo-300 transition-colors"
+                            onClick={() => {
+                              if (item.type === "feature" && item.featureId) {
+                                onSelectFeature(item.appName, item.featureId);
+                              } else if (item.type === "diagram") {
+                                onSelectDiagram(item.appName);
+                              } else {
+                                onSelectApp(item.appName);
+                              }
+                            }}
+                          >
+                            {item.title ?? item.appName}
+                          </button>
+                          <div className="flex items-center gap-1 shrink-0">
+                            {/* Preview button */}
+                            <button
+                              type="button"
+                              className={`p-1 rounded-md transition-colors ${
+                                isActive
+                                  ? "text-indigo-400 bg-indigo-400/10"
+                                  : "text-gray-600 hover:text-indigo-400 hover:bg-indigo-400/10 opacity-0 group-hover/item:opacity-100"
+                              }`}
+                              onClick={() => handlePreview(item)}
+                              title="プレビュー"
+                            >
+                              <svg
+                                className="size-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                aria-hidden="true"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
+                                />
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                                />
+                              </svg>
+                            </button>
+                            {isDev && <DatasetAddButton item={toDatasetItem(item)} isDev={isDev} />}
+                            <button
+                              type="button"
+                              className="p-1 rounded-md text-gray-600 hover:text-pink-400 hover:bg-pink-400/10 transition-colors opacity-0 group-hover/item:opacity-100"
+                              onClick={() => handleRemove(item)}
+                              title="お気に入りから削除"
+                            >
+                              <svg
+                                className="size-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                aria-hidden="true"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M6 18L18 6M6 6l12 12"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                        </motion.div>
+                      );
+                    })}
+                  </AnimatePresence>
+                </div>
+              </motion.section>
+            ))}
+          </AnimatePresence>
+        </div>
+      )}
+    </>
+  );
 
   return (
     <motion.div
@@ -144,59 +438,48 @@ export function FavoritePage({
         </div>
       </div>
 
-      {/* Content */}
-      <div
-        className={`flex-1 overflow-y-auto dark-scrollbar ${isMobile ? "p-4 pb-8" : "p-6"} bg-gray-900`}
-      >
-        {favorites.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16">
-            <div className="size-14 mx-auto mb-4 rounded-full bg-gray-800 flex items-center justify-center">
-              <svg
-                className="size-7 text-gray-600"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                aria-hidden="true"
+      {/* Body: list + preview pane */}
+      <div className="flex flex-1 min-h-0">
+        {/* List pane */}
+        <div
+          className={`overflow-y-auto dark-scrollbar ${isMobile ? "p-4 pb-8" : "p-6"} bg-gray-900 ${
+            previewItem && !isMobile ? "border-r border-gray-700/50" : ""
+          }`}
+          style={{ flex: previewItem && !isMobile ? "0 0 50%" : "1 1 100%" }}
+        >
+          {listContent}
+        </div>
+
+        {/* Preview pane (desktop only) */}
+        {!isMobile && (
+          <AnimatePresence>
+            {previewItem && (
+              <motion.div
+                key="preview"
+                className="flex flex-col min-w-0 bg-gray-900"
+                initial={{ width: 0, opacity: 0 }}
+                animate={{ width: "50%", opacity: 1 }}
+                exit={{ width: 0, opacity: 0 }}
+                transition={{ duration: 0.3, ease: "easeOut" }}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={1.5}
-                  d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
-                />
-              </svg>
-            </div>
-            <p className="text-sm text-gray-500">お気に入りがありません</p>
-            <p className="text-xs text-gray-600 mt-1">
-              アプリのハートアイコンからお気に入りに追加できます
-            </p>
-          </div>
-        ) : (
-          <div className="space-y-6">
-            <AnimatePresence>
-              {grouped.map((group) => (
-                <motion.section
-                  key={group.appName}
-                  layout
-                  initial={{ opacity: 0, y: 12 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -12 }}
-                  transition={{ duration: 0.3 }}
-                >
-                  {/* App header */}
+                {/* Preview header */}
+                <div className="flex items-center gap-2 px-4 bg-gray-800/50 border-b border-gray-700/50 shrink-0">
+                  <span
+                    className={`inline-flex shrink-0 items-center justify-center rounded text-[9px] font-bold px-1.5 py-0.5 ${typeBadgeClass(previewItem.type)}`}
+                  >
+                    {typeLabel(previewItem.type)}
+                  </span>
+                  <span className="flex-1 text-xs font-medium text-gray-300 py-2.5 truncate">
+                    {previewItem.title ?? previewItem.appName}
+                  </span>
                   <button
                     type="button"
-                    className="flex items-center gap-2 mb-3 group"
-                    onClick={() => onSelectApp(group.appName)}
+                    className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/50 transition-colors"
+                    onClick={closePreview}
+                    title="閉じる"
                   >
-                    <span className="inline-flex shrink-0 items-center justify-center rounded text-[9px] font-bold px-1.5 py-0.5 bg-indigo-900/40 text-indigo-400">
-                      APP
-                    </span>
-                    <span className="text-sm font-semibold text-gray-200 group-hover:text-indigo-300 transition-colors truncate">
-                      {group.appName}
-                    </span>
                     <svg
-                      className="size-3.5 text-gray-600 group-hover:text-indigo-400 transition-colors"
+                      className="size-4"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
@@ -206,81 +489,48 @@ export function FavoritePage({
                         strokeLinecap="round"
                         strokeLinejoin="round"
                         strokeWidth={2}
-                        d="M9 5l7 7-7 7"
+                        d="M6 18L18 6M6 6l12 12"
                       />
                     </svg>
                   </button>
-
-                  {/* Items */}
-                  <div className="space-y-1.5 ml-2">
-                    <AnimatePresence>
-                      {group.items.map((item) => {
-                        const key = `${item.appName}-${item.type}-${item.featureId ?? ""}-${item.diagramId ?? ""}`;
-                        return (
-                          <motion.div
-                            key={key}
-                            layout
-                            initial={{ opacity: 0, x: -8 }}
-                            animate={{ opacity: 1, x: 0 }}
-                            exit={{ opacity: 0, x: 8, height: 0 }}
-                            transition={{ duration: 0.2 }}
-                            className="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-800/60 border border-gray-700/30 group/item"
-                          >
-                            <span
-                              className={`inline-flex shrink-0 items-center justify-center rounded text-[9px] font-bold px-1.5 py-0.5 ${typeBadgeClass(item.type)}`}
-                            >
-                              {typeLabel(item.type)}
-                            </span>
-                            <button
-                              type="button"
-                              className="flex-1 text-xs text-gray-300 truncate text-left hover:text-indigo-300 transition-colors"
-                              onClick={() => {
-                                if (item.type === "feature" && item.featureId) {
-                                  onSelectFeature(item.appName, item.featureId);
-                                } else if (item.type === "diagram") {
-                                  onSelectDiagram(item.appName);
-                                } else {
-                                  onSelectApp(item.appName);
-                                }
-                              }}
-                            >
-                              {item.title ?? item.appName}
-                            </button>
-                            <div className="flex items-center gap-1 shrink-0">
-                              {isDev && (
-                                <DatasetAddButton item={toDatasetItem(item)} isDev={isDev} />
-                              )}
-                              <button
-                                type="button"
-                                className="p-1 rounded-md text-gray-600 hover:text-pink-400 hover:bg-pink-400/10 transition-colors opacity-0 group-hover/item:opacity-100"
-                                onClick={() => handleRemove(item)}
-                                title="お気に入りから削除"
-                              >
-                                <svg
-                                  className="size-4"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                  stroke="currentColor"
-                                  aria-hidden="true"
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={2}
-                                    d="M6 18L18 6M6 6l12 12"
-                                  />
-                                </svg>
-                              </button>
-                            </div>
-                          </motion.div>
-                        );
-                      })}
-                    </AnimatePresence>
-                  </div>
-                </motion.section>
-              ))}
-            </AnimatePresence>
-          </div>
+                </div>
+                {/* Preview content */}
+                <div className="flex-1 overflow-y-auto dark-scrollbar p-6 bg-gray-900">
+                  <AnimatePresence mode="wait">
+                    {previewLoading ? (
+                      <motion.div
+                        key="loading"
+                        className="flex items-center justify-center py-12"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                      >
+                        <motion.div
+                          className="size-6 rounded-full border-2 border-gray-700 border-t-gray-400"
+                          animate={{ rotate: 360 }}
+                          transition={{
+                            duration: 1,
+                            repeat: Number.POSITIVE_INFINITY,
+                            ease: "linear",
+                          }}
+                        />
+                      </motion.div>
+                    ) : (
+                      <motion.div
+                        key={itemKey(previewItem)}
+                        initial={{ opacity: 0, x: 20 }}
+                        animate={{ opacity: 1, x: 0 }}
+                        exit={{ opacity: 0, x: 20 }}
+                        transition={{ duration: 0.25, ease: "easeOut" }}
+                      >
+                        <MarkdownPane content={previewContent} />
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
         )}
       </div>
     </motion.div>

--- a/viewer/src/components/FavoritePage.tsx
+++ b/viewer/src/components/FavoritePage.tsx
@@ -353,7 +353,7 @@ export function FavoritePage({
                               className={`p-1 rounded-md transition-colors ${
                                 isActive
                                   ? "text-indigo-400 bg-indigo-400/10"
-                                  : "text-gray-600 hover:text-indigo-400 hover:bg-indigo-400/10 opacity-0 group-hover/item:opacity-100"
+                                  : "text-gray-600 hover:text-indigo-400 hover:bg-indigo-400/10"
                               }`}
                               onClick={() => handlePreview(item)}
                               title="プレビュー"
@@ -382,7 +382,7 @@ export function FavoritePage({
                             {isDev && <DatasetAddButton item={toDatasetItem(item)} isDev={isDev} />}
                             <button
                               type="button"
-                              className="p-1 rounded-md text-gray-600 hover:text-pink-400 hover:bg-pink-400/10 transition-colors opacity-0 group-hover/item:opacity-100"
+                              className="p-1 rounded-md text-gray-600 hover:text-pink-400 hover:bg-pink-400/10 transition-colors"
                               onClick={() => handleRemove(item)}
                               title="お気に入りから削除"
                             >

--- a/viewer/src/components/FavoritePage.tsx
+++ b/viewer/src/components/FavoritePage.tsx
@@ -1,0 +1,267 @@
+import { AnimatePresence, motion } from "motion/react";
+import { useCallback, useEffect, useState } from "react";
+import { type FavoriteItem, fetchFavorites, removeFavorite } from "../api";
+import { DatasetAddButton } from "./DatasetAddButton";
+
+interface FavoritePageProps {
+  isMobile: boolean;
+  isDev: boolean;
+  onSelectApp: (appName: string) => void;
+  onRefresh?: () => void;
+}
+
+interface GroupedFavorites {
+  appName: string;
+  items: FavoriteItem[];
+}
+
+function groupByApp(items: FavoriteItem[]): GroupedFavorites[] {
+  const map = new Map<string, FavoriteItem[]>();
+  for (const item of items) {
+    const list = map.get(item.appName) ?? [];
+    list.push(item);
+    map.set(item.appName, list);
+  }
+  return Array.from(map.entries()).map(([appName, items]) => ({ appName, items }));
+}
+
+function typeLabel(type: FavoriteItem["type"]): string {
+  switch (type) {
+    case "overview":
+      return "OVR";
+    case "feature":
+      return "FTR";
+    case "diagram":
+      return "DGM";
+  }
+}
+
+function typeBadgeClass(type: FavoriteItem["type"]): string {
+  switch (type) {
+    case "overview":
+      return "bg-blue-900/40 text-blue-400";
+    case "feature":
+      return "bg-purple-900/40 text-purple-400";
+    case "diagram":
+      return "bg-emerald-900/40 text-emerald-400";
+  }
+}
+
+function toDatasetItem(fav: FavoriteItem) {
+  return {
+    appName: fav.appName,
+    type: fav.type === "diagram" ? ("overview" as const) : (fav.type as "overview" | "feature"),
+    featureId: fav.featureId,
+    title: fav.title,
+  };
+}
+
+export function FavoritePage({ isMobile, isDev, onSelectApp, onRefresh }: FavoritePageProps) {
+  const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    fetchFavorites()
+      .then(setFavorites)
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleRemove = useCallback(
+    async (item: FavoriteItem) => {
+      await removeFavorite(item);
+      setFavorites((prev) =>
+        prev.filter(
+          (f) =>
+            !(
+              f.appName === item.appName &&
+              f.type === item.type &&
+              f.featureId === item.featureId &&
+              f.diagramId === item.diagramId
+            ),
+        ),
+      );
+      onRefresh?.();
+    },
+    [onRefresh],
+  );
+
+  const grouped = groupByApp(favorites);
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <motion.div
+          className="flex flex-col items-center gap-3"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.3 }}
+        >
+          <motion.div
+            className="size-8 rounded-full border-2 border-pink-800 border-t-pink-400"
+            animate={{ rotate: 360 }}
+            transition={{ duration: 1, repeat: Number.POSITIVE_INFINITY, ease: "linear" }}
+          />
+          <p className="text-xs text-gray-500">読み込み中...</p>
+        </motion.div>
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      className="flex flex-col h-full"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3 px-6 py-4 bg-gray-800/50 border-b border-gray-700/50 shrink-0">
+        <svg
+          className="size-5 text-pink-400"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M11.645 20.91l-.007-.003-.022-.012a15.247 15.247 0 01-.383-.218 25.18 25.18 0 01-4.244-3.17C4.688 15.36 2.25 12.174 2.25 8.25 2.25 5.322 4.714 3 7.688 3A5.5 5.5 0 0112 5.052 5.5 5.5 0 0116.313 3c2.973 0 5.437 2.322 5.437 5.25 0 3.925-2.438 7.111-4.739 9.256a25.175 25.175 0 01-4.244 3.17 15.247 15.247 0 01-.383.219l-.022.012-.007.004-.003.001a.752.752 0 01-.704 0l-.003-.001z" />
+        </svg>
+        <div>
+          <h2 className="text-sm font-bold text-gray-200">お気に入り</h2>
+          <p className="text-[10px] text-gray-500">{favorites.length} 件のお気に入り</p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div
+        className={`flex-1 overflow-y-auto dark-scrollbar ${isMobile ? "p-4 pb-8" : "p-6"} bg-gray-900`}
+      >
+        {favorites.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16">
+            <div className="size-14 mx-auto mb-4 rounded-full bg-gray-800 flex items-center justify-center">
+              <svg
+                className="size-7 text-gray-600"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
+                />
+              </svg>
+            </div>
+            <p className="text-sm text-gray-500">お気に入りがありません</p>
+            <p className="text-xs text-gray-600 mt-1">
+              アプリのハートアイコンからお気に入りに追加できます
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <AnimatePresence>
+              {grouped.map((group) => (
+                <motion.section
+                  key={group.appName}
+                  layout
+                  initial={{ opacity: 0, y: 12 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -12 }}
+                  transition={{ duration: 0.3 }}
+                >
+                  {/* App header */}
+                  <button
+                    type="button"
+                    className="flex items-center gap-2 mb-3 group"
+                    onClick={() => onSelectApp(group.appName)}
+                  >
+                    <span className="inline-flex shrink-0 items-center justify-center rounded text-[9px] font-bold px-1.5 py-0.5 bg-indigo-900/40 text-indigo-400">
+                      APP
+                    </span>
+                    <span className="text-sm font-semibold text-gray-200 group-hover:text-indigo-300 transition-colors truncate">
+                      {group.appName}
+                    </span>
+                    <svg
+                      className="size-3.5 text-gray-600 group-hover:text-indigo-400 transition-colors"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                  </button>
+
+                  {/* Items */}
+                  <div className="space-y-1.5 ml-2">
+                    <AnimatePresence>
+                      {group.items.map((item) => {
+                        const key = `${item.appName}-${item.type}-${item.featureId ?? ""}-${item.diagramId ?? ""}`;
+                        return (
+                          <motion.div
+                            key={key}
+                            layout
+                            initial={{ opacity: 0, x: -8 }}
+                            animate={{ opacity: 1, x: 0 }}
+                            exit={{ opacity: 0, x: 8, height: 0 }}
+                            transition={{ duration: 0.2 }}
+                            className="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-800/60 border border-gray-700/30 group/item"
+                          >
+                            <span
+                              className={`inline-flex shrink-0 items-center justify-center rounded text-[9px] font-bold px-1.5 py-0.5 ${typeBadgeClass(item.type)}`}
+                            >
+                              {typeLabel(item.type)}
+                            </span>
+                            <span className="flex-1 text-xs text-gray-300 truncate">
+                              {item.title ?? item.appName}
+                            </span>
+                            <div className="flex items-center gap-1 shrink-0">
+                              {isDev && (
+                                <DatasetAddButton item={toDatasetItem(item)} isDev={isDev} />
+                              )}
+                              <button
+                                type="button"
+                                className="p-1 rounded-md text-gray-600 hover:text-pink-400 hover:bg-pink-400/10 transition-colors opacity-0 group-hover/item:opacity-100"
+                                onClick={() => handleRemove(item)}
+                                title="お気に入りから削除"
+                              >
+                                <svg
+                                  className="size-4"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  aria-hidden="true"
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M6 18L18 6M6 6l12 12"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </motion.div>
+                        );
+                      })}
+                    </AnimatePresence>
+                  </div>
+                </motion.section>
+              ))}
+            </AnimatePresence>
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -11,8 +11,9 @@ interface SidebarProps {
   isMobile: boolean;
   mobileOpen: boolean;
   onMobileClose: () => void;
-  viewMode: "apps" | "datasets";
+  viewMode: "apps" | "datasets" | "favorites";
   onSelectDatasets: () => void;
+  onSelectFavorites: () => void;
   onSearch: (query: string, tags: string[]) => void;
   onClearSearch: () => void;
   isSearchActive: boolean;
@@ -226,6 +227,7 @@ export function Sidebar({
   onMobileClose,
   viewMode,
   onSelectDatasets,
+  onSelectFavorites,
   onSearch,
   onClearSearch,
   isSearchActive,
@@ -260,6 +262,31 @@ export function Sidebar({
               {/* Header */}
               <div className="px-5 py-6 flex items-center justify-between">
                 <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                      viewMode === "favorites"
+                        ? "text-pink-400 bg-pink-400/10"
+                        : "text-gray-500 hover:text-pink-400 hover:bg-pink-400/10"
+                    }`}
+                    onClick={onSelectFavorites}
+                    title="お気に入り"
+                  >
+                    <svg
+                      className="size-5"
+                      viewBox="0 0 24 24"
+                      fill={viewMode === "favorites" ? "currentColor" : "none"}
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
+                      />
+                    </svg>
+                  </button>
                   <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
                     R
                   </span>
@@ -429,6 +456,33 @@ export function Sidebar({
         {/* Header */}
         <div className="px-5 py-6 flex items-center justify-between">
           <div className="flex items-center gap-3">
+            <motion.button
+              type="button"
+              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                viewMode === "favorites"
+                  ? "text-pink-400 bg-pink-400/10"
+                  : "text-gray-500 hover:text-pink-400 hover:bg-pink-400/10"
+              }`}
+              onClick={onSelectFavorites}
+              title="お気に入り"
+              animate={{ opacity: expanded ? 1 : 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              <svg
+                className="size-5"
+                viewBox="0 0 24 24"
+                fill={viewMode === "favorites" ? "currentColor" : "none"}
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
+                />
+              </svg>
+            </motion.button>
             <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
               R
             </span>

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -262,6 +262,9 @@ export function Sidebar({
               {/* Header */}
               <div className="px-5 py-6 flex items-center justify-between">
                 <div className="flex items-center gap-3">
+                  <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
+                    R
+                  </span>
                   <button
                     type="button"
                     className={`p-1.5 rounded-lg transition-colors shrink-0 ${
@@ -287,9 +290,6 @@ export function Sidebar({
                       />
                     </svg>
                   </button>
-                  <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
-                    R
-                  </span>
                   <div>
                     <h1 className="text-sm font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent whitespace-nowrap">
                       Requirements
@@ -456,6 +456,9 @@ export function Sidebar({
         {/* Header */}
         <div className="px-5 py-6 flex items-center justify-between">
           <div className="flex items-center gap-3">
+            <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
+              R
+            </span>
             <motion.button
               type="button"
               className={`p-1.5 rounded-lg transition-colors shrink-0 ${
@@ -483,9 +486,6 @@ export function Sidebar({
                 />
               </svg>
             </motion.button>
-            <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
-              R
-            </span>
             <motion.div animate={{ opacity: expanded ? 1 : 0 }} transition={{ duration: 0.2 }}>
               <h1 className="text-sm font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent whitespace-nowrap">
                 Requirements


### PR DESCRIPTION
## Summary

- viewerにお気に入り機能を追加
- アプリ（overview）・機能（feature）・図解（diagram）単位でのお気に入り登録が可能
- お気に入りページから一覧表示・解除・データセットへの追加が可能
- お気に入りデータは `gen/favorite.json` に保存

Closes #48

## Changes

- `viewer/server.ts`: GET/POST/DELETE `/api/favorites` エンドポイント追加
- `viewer/src/api.ts`: FavoriteItem型・API関数追加
- `viewer/src/components/FavoritePage.tsx`: お気に入り一覧ページ（新規）
- `viewer/src/components/Sidebar.tsx`: 左上にハートアイコン追加
- `viewer/src/App.tsx`: favorites viewMode・URL同期・ブラウザバック対応
- `viewer/src/components/AppView.tsx`: overview/feature/diagramにお気に入りトグルボタン追加
- `CLAUDE.md`: ドキュメント更新

## Test plan

- [ ] Sidebarのハートアイコンクリックでお気に入りページが表示される
- [ ] overview/feature/diagramのハートアイコンでお気に入り追加・解除ができる
- [ ] お気に入りページでアプリ名クリックからアプリ詳細に遷移できる
- [ ] お気に入りページから×ボタンでお気に入り解除ができる
- [ ] お気に入りページからデータセットへの追加ができる（dev mode時）
- [ ] `gen/favorite.json` にデータが正しく保存・削除される
- [ ] ブラウザバック/フォワードで正しく状態が復元される
- [ ] モバイル・デスクトップ両方で正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)