### PR TITLE
feat: コマンド実行ページをViewerに追加

### DIFF
--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -563,9 +563,6 @@ const ALLOWED_COMMANDS: Record<string, { bin: string; baseArgs: string[] }> = {
   regenerate: { bin: "bash", baseArgs: ["scripts/regenerate.sh"] },
   validate: { bin: "tsx", baseArgs: ["scripts/validate-requirements.ts"] },
   pipeline: { bin: "tsx", baseArgs: ["scripts/pipeline.ts"] },
-  format: { bin: "pnpm", baseArgs: ["run", "format"] },
-  lint: { bin: "pnpm", baseArgs: ["run", "lint"] },
-  check: { bin: "pnpm", baseArgs: ["run", "check"] },
 };
 
 let activeCommandProcess: ChildProcess | null = null;

--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -1,4 +1,4 @@
-import { exec, spawn } from "node:child_process";
+import { type ChildProcess, exec, spawn } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -48,6 +48,20 @@ function loadDatasetsDir(): string {
 }
 
 const DATASETS_DIR = loadDatasetsDir();
+
+function loadDataSourceDir(): string {
+  try {
+    const configPath = resolve(projectRoot, "app.config.yaml");
+    const raw = readFileSync(configPath, "utf-8");
+    const config = parse(raw) as { output_base_dir?: string };
+    const base = config.output_base_dir ?? "gen";
+    return resolve(projectRoot, base, "data_source");
+  } catch {
+    return resolve(projectRoot, "gen", "data_source");
+  }
+}
+
+const DATA_SOURCE_DIR = loadDataSourceDir();
 
 interface DatasetItem {
   appName: string;
@@ -538,6 +552,141 @@ app.post("/api/git/commit-push", async (c) => {
   }
 
   return c.json({ success: true, output: logs.join("\n") });
+});
+
+// --- Commands API (dev mode only) ---
+
+const ALLOWED_COMMANDS: Record<string, { bin: string; baseArgs: string[] }> = {
+  collect: { bin: "tsx", baseArgs: ["scripts/collect.ts"] },
+  extract: { bin: "bash", baseArgs: ["scripts/extract.sh"] },
+  generate: { bin: "bash", baseArgs: ["scripts/generate.sh"] },
+  regenerate: { bin: "bash", baseArgs: ["scripts/regenerate.sh"] },
+  validate: { bin: "tsx", baseArgs: ["scripts/validate-requirements.ts"] },
+  pipeline: { bin: "tsx", baseArgs: ["scripts/pipeline.ts"] },
+  format: { bin: "pnpm", baseArgs: ["run", "format"] },
+  lint: { bin: "pnpm", baseArgs: ["run", "lint"] },
+  check: { bin: "pnpm", baseArgs: ["run", "check"] },
+};
+
+let activeCommandProcess: ChildProcess | null = null;
+
+app.get("/api/commands/data-sources", (c) => {
+  if (!existsSync(DATA_SOURCE_DIR)) return c.json([]);
+  return c.json(
+    readdirSync(DATA_SOURCE_DIR, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .sort()
+      .reverse(),
+  );
+});
+
+app.get("/api/commands/apps", (c) => {
+  if (!existsSync(REQUIREMENTS_DIR)) return c.json([]);
+  return c.json(
+    readdirSync(REQUIREMENTS_DIR, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .sort(),
+  );
+});
+
+app.get("/api/commands/collect-sources", (c) => {
+  try {
+    const configPath = resolve(projectRoot, "app.config.yaml");
+    const raw = readFileSync(configPath, "utf-8");
+    const config = parse(raw) as {
+      collect?: { sources?: Record<string, { enabled?: boolean }> };
+    };
+    return c.json(Object.keys(config.collect?.sources ?? {}));
+  } catch {
+    return c.json([]);
+  }
+});
+
+app.get("/api/commands/dataset-names", (c) => {
+  if (!existsSync(DATASETS_DIR)) return c.json([]);
+  return c.json(
+    readdirSync(DATASETS_DIR)
+      .filter((f) => f.endsWith(".json"))
+      .map((f) => f.replace(".json", ""))
+      .sort(),
+  );
+});
+
+app.post("/api/commands/execute", async (c) => {
+  if (!isDev) return c.json({ error: "Dev mode only" }, 403);
+
+  const body = await c.req.json<{ command: string; args: string[] }>();
+  const cmdDef = ALLOWED_COMMANDS[body.command];
+  if (!cmdDef) return c.json({ error: "Unknown command" }, 400);
+
+  const allArgs = [...cmdDef.baseArgs, ...(body.args ?? [])];
+  const encoder = new TextEncoder();
+
+  const child = spawn(cmdDef.bin, allArgs, {
+    cwd: projectRoot,
+    env: { ...process.env, FORCE_COLOR: "0" },
+  });
+  activeCommandProcess = child;
+
+  const readable = new ReadableStream({
+    start(controller) {
+      const send = (type: string, data: string) => {
+        try {
+          controller.enqueue(encoder.encode(`${JSON.stringify({ type, data })}\n`));
+        } catch {}
+      };
+
+      send("start", `$ ${body.command}${body.args?.length ? ` ${body.args.join(" ")}` : ""}`);
+
+      child.stdout?.on("data", (chunk: Buffer) => send("stdout", chunk.toString()));
+      child.stderr?.on("data", (chunk: Buffer) => send("stderr", chunk.toString()));
+
+      child.on("close", (code) => {
+        send("exit", String(code ?? 1));
+        activeCommandProcess = null;
+        try {
+          controller.close();
+        } catch {}
+      });
+      child.on("error", (err) => {
+        send("error", err.message);
+        activeCommandProcess = null;
+        try {
+          controller.close();
+        } catch {}
+      });
+    },
+    cancel() {
+      if (child.pid) {
+        try {
+          process.kill(child.pid, "SIGTERM");
+        } catch {}
+      }
+      activeCommandProcess = null;
+    },
+  });
+
+  return new Response(readable, {
+    headers: {
+      "Content-Type": "application/x-ndjson",
+      "Cache-Control": "no-cache",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+});
+
+app.post("/api/commands/abort", (c) => {
+  if (!isDev) return c.json({ error: "Dev mode only" }, 403);
+  if (activeCommandProcess?.pid) {
+    try {
+      process.kill(activeCommandProcess.pid, "SIGTERM");
+    } catch {}
+    activeCommandProcess = null;
+    return c.json({ success: true });
+  }
+  return c.json({ success: false, message: "No active command" });
 });
 
 // --- Server ---

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -12,6 +12,7 @@ import {
   type TagSearchResult,
 } from "./api";
 import { type AppTab, AppView } from "./components/AppView";
+import { CommandRunner } from "./components/CommandRunner";
 import { DatasetManager } from "./components/DatasetManager";
 import { FavoritePage } from "./components/FavoritePage";
 import { SearchView } from "./components/SearchView";
@@ -19,7 +20,7 @@ import { Sidebar } from "./components/Sidebar";
 import { ToastProvider } from "./components/Toast";
 import { useIsMobile } from "./hooks/useIsMobile";
 
-type ViewMode = "apps" | "datasets" | "favorites";
+type ViewMode = "apps" | "datasets" | "favorites" | "commands";
 
 function buildUrl(state: {
   viewMode: ViewMode;
@@ -39,6 +40,8 @@ function buildUrl(state: {
     if (state.dataset) url.searchParams.set("dataset", state.dataset);
   } else if (state.viewMode === "favorites") {
     url.searchParams.set("view", "favorites");
+  } else if (state.viewMode === "commands") {
+    url.searchParams.set("view", "commands");
   } else {
     if (state.app) url.searchParams.set("app", state.app);
     if (state.feature) url.searchParams.set("feature", state.feature);
@@ -101,8 +104,11 @@ export function App() {
     const viewParam = params.get("view");
     const isDatasetView = viewParam === "datasets";
     const isFavoritesView = viewParam === "favorites";
-    // URL から datasets/favorites ビュー復元
-    if (isFavoritesView) {
+    const isCommandsView = viewParam === "commands";
+    // URL から datasets/favorites/commands ビュー復元
+    if (isCommandsView) {
+      setViewMode("commands");
+    } else if (isFavoritesView) {
       setViewMode("favorites");
     } else if (isDatasetView) {
       setViewMode("datasets");
@@ -136,7 +142,13 @@ export function App() {
         tabParam && ["overview", "source-info", "diagrams", "features", "memo"].includes(tabParam)
           ? tabParam
           : undefined;
-      const currentViewMode = isFavoritesView ? "favorites" : isDatasetView ? "datasets" : "apps";
+      const currentViewMode = isCommandsView
+        ? "commands"
+        : isFavoritesView
+          ? "favorites"
+          : isDatasetView
+            ? "datasets"
+            : "apps";
       window.history.replaceState(
         {},
         "",
@@ -156,7 +168,11 @@ export function App() {
     const handlePopState = () => {
       const params = new URLSearchParams(window.location.search);
       const viewParam = params.get("view");
-      if (viewParam === "favorites") {
+      if (viewParam === "commands") {
+        setViewMode("commands");
+        setSelectedFeature(null);
+        setSelectedTab("overview");
+      } else if (viewParam === "favorites") {
         setViewMode("favorites");
         setSelectedFeature(null);
         setSelectedTab("overview");
@@ -205,6 +221,14 @@ export function App() {
     setSearchActive(false);
     if (isMobile) setMobileSidebarOpen(false);
     window.history.pushState({}, "", buildUrl({ viewMode: "datasets", dataset: selectedDataset }));
+  };
+
+  const handleSelectCommands = () => {
+    setViewMode("commands");
+    setSelectedFeature(null);
+    setSearchActive(false);
+    if (isMobile) setMobileSidebarOpen(false);
+    window.history.pushState({}, "", buildUrl({ viewMode: "commands" }));
   };
 
   const handleSelectFavorites = () => {
@@ -410,11 +434,13 @@ export function App() {
               </svg>
             </button>
             <span className="text-sm font-semibold text-gray-200 truncate">
-              {viewMode === "favorites"
-                ? "お気に入り"
-                : viewMode === "datasets"
-                  ? "データセット"
-                  : (selectedApp ?? "Requirements Viewer")}
+              {viewMode === "commands"
+                ? "コマンド実行"
+                : viewMode === "favorites"
+                  ? "お気に入り"
+                  : viewMode === "datasets"
+                    ? "データセット"
+                    : (selectedApp ?? "Requirements Viewer")}
             </span>
           </div>
         )}
@@ -431,6 +457,7 @@ export function App() {
           viewMode={viewMode}
           onSelectDatasets={handleSelectDatasets}
           onSelectFavorites={handleSelectFavorites}
+          onSelectCommands={handleSelectCommands}
           onSearch={handleSearch}
           onClearSearch={handleClearSearch}
           isSearchActive={searchActive}
@@ -444,7 +471,9 @@ export function App() {
               : "mb-3 mr-3 rounded-2xl bg-gray-900 shadow-2xl shadow-black/50 ring-1 ring-gray-800"
           }`}
         >
-          {viewMode === "favorites" ? (
+          {viewMode === "commands" ? (
+            <CommandRunner isMobile={isMobile} isDev={isDev} />
+          ) : viewMode === "favorites" ? (
             <FavoritePage
               isMobile={isMobile}
               isDev={isDev}

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -249,6 +249,83 @@ export async function removeFavorite(item: FavoriteItem): Promise<{ success: boo
   return res.json();
 }
 
+// --- Commands API ---
+
+export async function fetchDataSources(): Promise<string[]> {
+  const res = await fetch(`${BASE}/commands/data-sources`);
+  return res.json();
+}
+
+export async function fetchRequirementApps(): Promise<string[]> {
+  const res = await fetch(`${BASE}/commands/apps`);
+  return res.json();
+}
+
+export async function fetchCollectSources(): Promise<string[]> {
+  const res = await fetch(`${BASE}/commands/collect-sources`);
+  return res.json();
+}
+
+export async function fetchDatasetNames(): Promise<string[]> {
+  const res = await fetch(`${BASE}/commands/dataset-names`);
+  return res.json();
+}
+
+export interface CommandEvent {
+  type: "start" | "stdout" | "stderr" | "exit" | "error";
+  data: string;
+}
+
+export async function executeCommand(
+  command: string,
+  args: string[],
+  onEvent: (event: CommandEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const res = await fetch(`${BASE}/commands/execute`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ command, args }),
+    signal,
+  });
+
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.error || "Unknown error");
+  }
+
+  if (!res.body) throw new Error("Response body is null");
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+    for (const line of lines) {
+      if (line.trim()) {
+        try {
+          onEvent(JSON.parse(line) as CommandEvent);
+        } catch {}
+      }
+    }
+  }
+
+  if (buffer.trim()) {
+    try {
+      onEvent(JSON.parse(buffer) as CommandEvent);
+    } catch {}
+  }
+}
+
+export async function abortCommand(): Promise<{ success: boolean }> {
+  const res = await fetch(`${BASE}/commands/abort`, { method: "POST" });
+  return res.json();
+}
+
 // --- Git API ---
 
 export interface GitResult {

--- a/viewer/src/components/CommandRunner.tsx
+++ b/viewer/src/components/CommandRunner.tsx
@@ -1,0 +1,554 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { abortCommand, type CommandEvent, executeCommand } from "../api";
+
+// --- Types ---
+
+interface LogEntry {
+  id: number;
+  type: CommandEvent["type"];
+  text: string;
+}
+
+interface OptionDef {
+  id: string;
+  label: string;
+  type: "select" | "checkbox" | "text";
+  dynamicChoicesUrl?: string;
+  argFlag?: string;
+  positional?: boolean;
+  placeholder?: string;
+  required?: boolean;
+}
+
+interface CommandDef {
+  id: string;
+  label: string;
+  description: string;
+  category: "pipeline" | "quality";
+  options: OptionDef[];
+}
+
+// --- Command Definitions ---
+
+const COMMANDS: CommandDef[] = [
+  {
+    id: "collect",
+    label: "collect",
+    description: "外部API（NewsAPI等）からトレンド情報を取得し、data_sourceに保存する。",
+    category: "pipeline",
+    options: [
+      {
+        id: "only",
+        label: "ソース指定",
+        type: "select",
+        dynamicChoicesUrl: "/api/commands/collect-sources",
+        argFlag: "--only",
+      },
+      {
+        id: "dryRun",
+        label: "dry-run（API呼び出しなしで確認）",
+        type: "checkbox",
+        argFlag: "--dry-run",
+      },
+    ],
+  },
+  {
+    id: "extract",
+    label: "extract",
+    description: "収集データからキーワードを抽出し、keyword.jsonを生成する。",
+    category: "pipeline",
+    options: [
+      {
+        id: "target",
+        label: "データソース",
+        type: "select",
+        dynamicChoicesUrl: "/api/commands/data-sources",
+        argFlag: "--target",
+      },
+    ],
+  },
+  {
+    id: "generate",
+    label: "generate",
+    description: "キーワードからアプリ案を構想し、要件定義を自動生成する。",
+    category: "pipeline",
+    options: [
+      {
+        id: "target",
+        label: "データソース",
+        type: "select",
+        dynamicChoicesUrl: "/api/commands/data-sources",
+        argFlag: "--target",
+      },
+    ],
+  },
+  {
+    id: "regenerate",
+    label: "regenerate",
+    description: "既存アプリ要件をmemo.mdの内容を最優先指示として再生成する。",
+    category: "pipeline",
+    options: [
+      {
+        id: "appName",
+        label: "アプリ名",
+        type: "select",
+        dynamicChoicesUrl: "/api/commands/apps",
+        positional: true,
+        required: true,
+      },
+      {
+        id: "memo",
+        label: "メモ",
+        type: "text",
+        argFlag: "--memo",
+        placeholder: "改善指示を入力...",
+      },
+      {
+        id: "skipAgents",
+        label: "外部エージェントをスキップ",
+        type: "checkbox",
+        argFlag: "--skip-agents",
+      },
+    ],
+  },
+  {
+    id: "validate",
+    label: "validate",
+    description: "生成された要件の構造・内容を自動検証する。未指定時は全アプリを検証。",
+    category: "pipeline",
+    options: [
+      {
+        id: "appName",
+        label: "アプリ名（空で全て検証）",
+        type: "select",
+        dynamicChoicesUrl: "/api/commands/apps",
+        positional: true,
+      },
+    ],
+  },
+  {
+    id: "pipeline",
+    label: "pipeline",
+    description: "collect → extract → generate → validate を一括実行する。",
+    category: "pipeline",
+    options: [
+      {
+        id: "skipCollect",
+        label: "collectをスキップ",
+        type: "checkbox",
+        argFlag: "--skip-collect",
+      },
+      {
+        id: "skipExtract",
+        label: "extractをスキップ",
+        type: "checkbox",
+        argFlag: "--skip-extract",
+      },
+      {
+        id: "source",
+        label: "データソース指定",
+        type: "select",
+        dynamicChoicesUrl: "/api/commands/data-sources",
+        argFlag: "--source",
+      },
+      {
+        id: "dataset",
+        label: "データセット",
+        type: "select",
+        dynamicChoicesUrl: "/api/commands/dataset-names",
+        argFlag: "--dataset",
+      },
+      {
+        id: "regenerateApp",
+        label: "再生成対象アプリ",
+        type: "select",
+        dynamicChoicesUrl: "/api/commands/apps",
+        argFlag: "--regenerate",
+      },
+      {
+        id: "memo",
+        label: "メモ（再生成時）",
+        type: "text",
+        argFlag: "--memo",
+        placeholder: "改善指示を入力...",
+      },
+    ],
+  },
+  {
+    id: "format",
+    label: "format",
+    description: "Biomeでコードフォーマットを実行する。",
+    category: "quality",
+    options: [],
+  },
+  {
+    id: "lint",
+    label: "lint",
+    description: "Biomeでリントチェックを実行する。",
+    category: "quality",
+    options: [],
+  },
+  {
+    id: "check",
+    label: "check",
+    description: "Biomeでフォーマット＋リントの一括チェック・修正を行う。",
+    category: "quality",
+    options: [],
+  },
+];
+
+// --- Helpers ---
+
+function buildArgs(command: CommandDef, values: Record<string, string | boolean>): string[] {
+  const positional: string[] = [];
+  const flags: string[] = [];
+  for (const opt of command.options) {
+    const val = values[opt.id];
+    if (opt.type === "checkbox" && val === true && opt.argFlag) {
+      flags.push(opt.argFlag);
+    } else if ((opt.type === "select" || opt.type === "text") && typeof val === "string" && val) {
+      if (opt.positional) {
+        positional.push(val);
+      } else if (opt.argFlag) {
+        flags.push(opt.argFlag, val);
+      }
+    }
+  }
+  return [...positional, ...flags];
+}
+
+// --- Component ---
+
+interface CommandRunnerProps {
+  isMobile: boolean;
+  isDev: boolean;
+}
+
+export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
+  const [selectedCommandId, setSelectedCommandId] = useState("collect");
+  const [optionValues, setOptionValues] = useState<Record<string, string | boolean>>({});
+  const [dynamicChoices, setDynamicChoices] = useState<Record<string, string[]>>({});
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [running, setRunning] = useState(false);
+  const logEndRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const logIdRef = useRef(0);
+  const logsLenRef = useRef(0);
+
+  const selectedCommand = COMMANDS.find((c) => c.id === selectedCommandId) ?? COMMANDS[0];
+
+  const fetchDynamicChoices = useCallback(() => {
+    const urls = new Set<string>();
+    for (const cmd of COMMANDS) {
+      for (const opt of cmd.options) {
+        if (opt.dynamicChoicesUrl) urls.add(opt.dynamicChoicesUrl);
+      }
+    }
+    if (urls.size === 0) return;
+
+    Promise.all(
+      [...urls].map(async (url) => {
+        try {
+          const res = await fetch(url);
+          return [url, await res.json()] as [string, string[]];
+        } catch {
+          return [url, []] as [string, string[]];
+        }
+      }),
+    ).then((results) => {
+      const choices: Record<string, string[]> = {};
+      for (const [url, data] of results) {
+        choices[url] = data;
+      }
+      setDynamicChoices(choices);
+    });
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchDynamicChoices();
+  }, [fetchDynamicChoices]);
+
+  // Auto-scroll logs
+  useEffect(() => {
+    if (logs.length > logsLenRef.current) {
+      logEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+    logsLenRef.current = logs.length;
+  });
+
+  const handleCommandChange = useCallback((cmdId: string) => {
+    setSelectedCommandId(cmdId);
+    setOptionValues({});
+  }, []);
+
+  const setOptionValue = useCallback((optId: string, value: string | boolean) => {
+    setOptionValues((prev) => ({ ...prev, [optId]: value }));
+  }, []);
+
+  const handleExecute = useCallback(async () => {
+    if (running) return;
+
+    // Validate required
+    for (const opt of selectedCommand.options) {
+      if (opt.required && !optionValues[opt.id]) {
+        setLogs((prev) => [
+          ...prev,
+          {
+            id: logIdRef.current++,
+            type: "error",
+            text: `エラー: 「${opt.label}」は必須です。`,
+          },
+        ]);
+        return;
+      }
+    }
+
+    setRunning(true);
+    const args = buildArgs(selectedCommand, optionValues);
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      await executeCommand(
+        selectedCommand.id,
+        args,
+        (event) => {
+          setLogs((prev) => [
+            ...prev,
+            { id: logIdRef.current++, type: event.type, text: event.data },
+          ]);
+        },
+        controller.signal,
+      );
+    } catch (err) {
+      if ((err as Error).name !== "AbortError") {
+        setLogs((prev) => [
+          ...prev,
+          {
+            id: logIdRef.current++,
+            type: "error",
+            text: `接続エラー: ${(err as Error).message}`,
+          },
+        ]);
+      }
+    } finally {
+      setRunning(false);
+      abortRef.current = null;
+      fetchDynamicChoices();
+    }
+  }, [running, selectedCommand, optionValues, fetchDynamicChoices]);
+
+  const handleAbort = useCallback(() => {
+    abortRef.current?.abort();
+    abortCommand().catch(() => {});
+  }, []);
+
+  const handleClearLogs = useCallback(() => {
+    setLogs([]);
+  }, []);
+
+  if (!isDev) {
+    return (
+      <div className="flex h-full items-center justify-center text-gray-500 text-sm">
+        コマンド実行は開発モードでのみ使用可能です
+      </div>
+    );
+  }
+
+  const pipelineCommands = COMMANDS.filter((c) => c.category === "pipeline");
+  const qualityCommands = COMMANDS.filter((c) => c.category === "quality");
+
+  return (
+    <div className={`flex h-full ${isMobile ? "flex-col" : "flex-row"}`}>
+      {/* Left Pane */}
+      <div
+        className={`${
+          isMobile ? "h-[45%] border-b" : "w-[380px] shrink-0 border-r"
+        } border-gray-800 flex flex-col overflow-hidden`}
+      >
+        <div className="flex-1 overflow-y-auto p-4 space-y-4 dark-scrollbar">
+          {/* Pipeline commands */}
+          <div>
+            <h3 className="text-[10px] font-semibold uppercase tracking-wider text-gray-600 mb-2">
+              パイプライン
+            </h3>
+            <div className="grid grid-cols-3 gap-1.5">
+              {pipelineCommands.map((cmd) => (
+                <button
+                  key={cmd.id}
+                  type="button"
+                  className={`px-2 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                    selectedCommandId === cmd.id
+                      ? "bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/40"
+                      : "bg-gray-800/50 text-gray-400 hover:bg-gray-800 hover:text-gray-300"
+                  }`}
+                  onClick={() => handleCommandChange(cmd.id)}
+                >
+                  {cmd.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Quality commands */}
+          <div>
+            <h3 className="text-[10px] font-semibold uppercase tracking-wider text-gray-600 mb-2">
+              コード品質
+            </h3>
+            <div className="grid grid-cols-3 gap-1.5">
+              {qualityCommands.map((cmd) => (
+                <button
+                  key={cmd.id}
+                  type="button"
+                  className={`px-2 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                    selectedCommandId === cmd.id
+                      ? "bg-emerald-500/20 text-emerald-300 ring-1 ring-emerald-500/40"
+                      : "bg-gray-800/50 text-gray-400 hover:bg-gray-800 hover:text-gray-300"
+                  }`}
+                  onClick={() => handleCommandChange(cmd.id)}
+                >
+                  {cmd.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Description */}
+          <div className="rounded-lg bg-gray-800/30 border border-gray-800 p-3">
+            <p className="text-xs text-gray-400 leading-relaxed">{selectedCommand.description}</p>
+          </div>
+
+          {/* Options */}
+          {selectedCommand.options.length > 0 && (
+            <div className="space-y-3">
+              <h3 className="text-[10px] font-semibold uppercase tracking-wider text-gray-600">
+                オプション
+              </h3>
+              {selectedCommand.options.map((opt) => (
+                <div key={opt.id}>
+                  {opt.type === "checkbox" ? (
+                    <label className="flex items-center gap-2 cursor-pointer group">
+                      <input
+                        type="checkbox"
+                        checked={!!optionValues[opt.id]}
+                        onChange={(e) => setOptionValue(opt.id, e.target.checked)}
+                        className="rounded border-gray-600 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30 focus:ring-offset-0"
+                      />
+                      <span className="text-xs text-gray-400 group-hover:text-gray-300">
+                        {opt.label}
+                      </span>
+                    </label>
+                  ) : opt.type === "select" ? (
+                    <label className="block">
+                      <span className="block text-xs text-gray-500 mb-1">
+                        {opt.label}
+                        {opt.required && <span className="text-red-400 ml-0.5">*</span>}
+                      </span>
+                      <select
+                        value={(optionValues[opt.id] as string) || ""}
+                        onChange={(e) => setOptionValue(opt.id, e.target.value)}
+                        className="w-full px-2 py-1.5 text-xs bg-gray-800 border border-gray-700 rounded-lg text-gray-200 focus:outline-none focus:border-indigo-500/50 focus:ring-1 focus:ring-indigo-500/20"
+                      >
+                        <option value="">
+                          {opt.required ? "選択してください" : "指定なし（デフォルト）"}
+                        </option>
+                        {(dynamicChoices[opt.dynamicChoicesUrl || ""] || []).map((choice) => (
+                          <option key={choice} value={choice}>
+                            {choice}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  ) : (
+                    <label className="block">
+                      <span className="block text-xs text-gray-500 mb-1">{opt.label}</span>
+                      <input
+                        type="text"
+                        value={(optionValues[opt.id] as string) || ""}
+                        onChange={(e) => setOptionValue(opt.id, e.target.value)}
+                        placeholder={opt.placeholder}
+                        className="w-full px-2 py-1.5 text-xs bg-gray-800 border border-gray-700 rounded-lg text-gray-200 placeholder-gray-600 focus:outline-none focus:border-indigo-500/50 focus:ring-1 focus:ring-indigo-500/20"
+                      />
+                    </label>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Execute / Abort */}
+        <div className="p-4 border-t border-gray-800 flex gap-2">
+          {running ? (
+            <button
+              type="button"
+              className="flex-1 px-4 py-2 rounded-lg text-xs font-semibold bg-red-500/20 text-red-300 hover:bg-red-500/30 ring-1 ring-red-500/30 transition-colors"
+              onClick={handleAbort}
+            >
+              中止
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="flex-1 px-4 py-2 rounded-lg text-xs font-semibold bg-indigo-500/20 text-indigo-300 hover:bg-indigo-500/30 ring-1 ring-indigo-500/30 transition-colors"
+              onClick={handleExecute}
+            >
+              実行
+            </button>
+          )}
+          <button
+            type="button"
+            className="px-3 py-2 rounded-lg text-xs text-gray-500 hover:text-gray-300 hover:bg-gray-800 transition-colors"
+            onClick={handleClearLogs}
+            title="ログクリア"
+          >
+            クリア
+          </button>
+        </div>
+      </div>
+
+      {/* Right Pane: Log Output */}
+      <div className="flex-1 flex flex-col overflow-hidden bg-gray-950">
+        <div className="px-4 py-2 border-b border-gray-800 flex items-center justify-between">
+          <span className="text-xs font-medium text-gray-500">ログ出力</span>
+          {running && (
+            <span className="flex items-center gap-1.5 text-xs text-indigo-400">
+              <span className="size-1.5 rounded-full bg-indigo-400 animate-pulse" />
+              実行中...
+            </span>
+          )}
+        </div>
+        <div className="flex-1 overflow-y-auto p-4 font-mono text-xs dark-scrollbar">
+          {logs.length === 0 ? (
+            <div className="text-gray-600 text-center mt-8">
+              コマンドを選択して「実行」を押してください
+            </div>
+          ) : (
+            logs.map((entry) => (
+              <div
+                key={entry.id}
+                className={`whitespace-pre-wrap break-all leading-relaxed ${
+                  entry.type === "start"
+                    ? "text-blue-400 font-semibold mt-2 first:mt-0"
+                    : entry.type === "stderr"
+                      ? "text-yellow-400/80"
+                      : entry.type === "error"
+                        ? "text-red-400"
+                        : entry.type === "exit"
+                          ? entry.text === "0"
+                            ? "text-emerald-400 font-semibold mt-1"
+                            : "text-red-400 font-semibold mt-1"
+                          : "text-gray-300"
+                }`}
+              >
+                {entry.type === "exit" ? `プロセス終了 (コード: ${entry.text})` : entry.text}
+              </div>
+            ))
+          )}
+          <div ref={logEndRef} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/viewer/src/components/CommandRunner.tsx
+++ b/viewer/src/components/CommandRunner.tsx
@@ -24,7 +24,6 @@ interface CommandDef {
   id: string;
   label: string;
   description: string;
-  category: "pipeline" | "quality";
   options: OptionDef[];
 }
 
@@ -35,7 +34,6 @@ const COMMANDS: CommandDef[] = [
     id: "collect",
     label: "collect",
     description: "外部API（NewsAPI等）からトレンド情報を取得し、data_sourceに保存する。",
-    category: "pipeline",
     options: [
       {
         id: "only",
@@ -56,7 +54,6 @@ const COMMANDS: CommandDef[] = [
     id: "extract",
     label: "extract",
     description: "収集データからキーワードを抽出し、keyword.jsonを生成する。",
-    category: "pipeline",
     options: [
       {
         id: "target",
@@ -70,15 +67,35 @@ const COMMANDS: CommandDef[] = [
   {
     id: "generate",
     label: "generate",
-    description: "キーワードからアプリ案を構想し、要件定義を自動生成する。",
-    category: "pipeline",
+    description:
+      "キーワードからアプリ案を構想し、要件定義を自動生成する。データセットモードでは既存要件の組み合わせから新アプリを生成。",
     options: [
       {
         id: "target",
-        label: "データソース",
+        label: "データソース（通常モード）",
         type: "select",
         dynamicChoicesUrl: "/api/commands/data-sources",
         argFlag: "--target",
+      },
+      {
+        id: "datasetSource",
+        label: "データセットソースファイル（データセットモード）",
+        type: "text",
+        argFlag: "--dataset-source",
+        placeholder: "gen/datasets/my_dataset_source.md",
+      },
+      {
+        id: "datasetName",
+        label: "データセット名（データセットモード）",
+        type: "text",
+        argFlag: "--dataset-name",
+        placeholder: "my_dataset",
+      },
+      {
+        id: "skipAgents",
+        label: "外部エージェントをスキップ",
+        type: "checkbox",
+        argFlag: "--skip-agents",
       },
     ],
   },
@@ -86,7 +103,6 @@ const COMMANDS: CommandDef[] = [
     id: "regenerate",
     label: "regenerate",
     description: "既存アプリ要件をmemo.mdの内容を最優先指示として再生成する。",
-    category: "pipeline",
     options: [
       {
         id: "appName",
@@ -115,7 +131,6 @@ const COMMANDS: CommandDef[] = [
     id: "validate",
     label: "validate",
     description: "生成された要件の構造・内容を自動検証する。未指定時は全アプリを検証。",
-    category: "pipeline",
     options: [
       {
         id: "appName",
@@ -130,7 +145,6 @@ const COMMANDS: CommandDef[] = [
     id: "pipeline",
     label: "pipeline",
     description: "collect → extract → generate → validate を一括実行する。",
-    category: "pipeline",
     options: [
       {
         id: "skipCollect",
@@ -173,27 +187,6 @@ const COMMANDS: CommandDef[] = [
         placeholder: "改善指示を入力...",
       },
     ],
-  },
-  {
-    id: "format",
-    label: "format",
-    description: "Biomeでコードフォーマットを実行する。",
-    category: "quality",
-    options: [],
-  },
-  {
-    id: "lint",
-    label: "lint",
-    description: "Biomeでリントチェックを実行する。",
-    category: "quality",
-    options: [],
-  },
-  {
-    id: "check",
-    label: "check",
-    description: "Biomeでフォーマット＋リントの一括チェック・修正を行う。",
-    category: "quality",
-    options: [],
   },
 ];
 
@@ -356,9 +349,6 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
     );
   }
 
-  const pipelineCommands = COMMANDS.filter((c) => c.category === "pipeline");
-  const qualityCommands = COMMANDS.filter((c) => c.category === "quality");
-
   return (
     <div className={`flex h-full ${isMobile ? "flex-col" : "flex-row"}`}>
       {/* Left Pane */}
@@ -368,50 +358,22 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
         } border-gray-800 flex flex-col overflow-hidden`}
       >
         <div className="flex-1 overflow-y-auto p-4 space-y-4 dark-scrollbar">
-          {/* Pipeline commands */}
-          <div>
-            <h3 className="text-[10px] font-semibold uppercase tracking-wider text-gray-600 mb-2">
-              パイプライン
-            </h3>
-            <div className="grid grid-cols-3 gap-1.5">
-              {pipelineCommands.map((cmd) => (
-                <button
-                  key={cmd.id}
-                  type="button"
-                  className={`px-2 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-                    selectedCommandId === cmd.id
-                      ? "bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/40"
-                      : "bg-gray-800/50 text-gray-400 hover:bg-gray-800 hover:text-gray-300"
-                  }`}
-                  onClick={() => handleCommandChange(cmd.id)}
-                >
-                  {cmd.label}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {/* Quality commands */}
-          <div>
-            <h3 className="text-[10px] font-semibold uppercase tracking-wider text-gray-600 mb-2">
-              コード品質
-            </h3>
-            <div className="grid grid-cols-3 gap-1.5">
-              {qualityCommands.map((cmd) => (
-                <button
-                  key={cmd.id}
-                  type="button"
-                  className={`px-2 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-                    selectedCommandId === cmd.id
-                      ? "bg-emerald-500/20 text-emerald-300 ring-1 ring-emerald-500/40"
-                      : "bg-gray-800/50 text-gray-400 hover:bg-gray-800 hover:text-gray-300"
-                  }`}
-                  onClick={() => handleCommandChange(cmd.id)}
-                >
-                  {cmd.label}
-                </button>
-              ))}
-            </div>
+          {/* Command selector */}
+          <div className="flex flex-wrap gap-1.5">
+            {COMMANDS.map((cmd) => (
+              <button
+                key={cmd.id}
+                type="button"
+                className={`px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                  selectedCommandId === cmd.id
+                    ? "bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/40"
+                    : "bg-gray-800/50 text-gray-400 hover:bg-gray-800 hover:text-gray-300"
+                }`}
+                onClick={() => handleCommandChange(cmd.id)}
+              >
+                {cmd.label}
+              </button>
+            ))}
           </div>
 
           {/* Description */}

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -11,9 +11,10 @@ interface SidebarProps {
   isMobile: boolean;
   mobileOpen: boolean;
   onMobileClose: () => void;
-  viewMode: "apps" | "datasets" | "favorites";
+  viewMode: "apps" | "datasets" | "favorites" | "commands";
   onSelectDatasets: () => void;
   onSelectFavorites: () => void;
+  onSelectCommands: () => void;
   onSearch: (query: string, tags: string[]) => void;
   onClearSearch: () => void;
   isSearchActive: boolean;
@@ -228,6 +229,7 @@ export function Sidebar({
   viewMode,
   onSelectDatasets,
   onSelectFavorites,
+  onSelectCommands,
   onSearch,
   onClearSearch,
   isSearchActive,
@@ -429,6 +431,39 @@ export function Sidebar({
                     />
                   </svg>
                   データセット管理
+                </button>
+
+                {/* Commands */}
+                <p className="px-3 mt-6 mb-2 text-[10px] font-semibold uppercase tracking-[0.15em] text-gray-600 whitespace-nowrap">
+                  Commands
+                </p>
+                <button
+                  type="button"
+                  className={`
+                    w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-[13px] whitespace-nowrap
+                    ${
+                      viewMode === "commands"
+                        ? "bg-cyan-500/15 text-cyan-400 font-semibold shadow-lg shadow-cyan-500/5"
+                        : "text-gray-400 hover:bg-white/[0.04] hover:text-gray-200"
+                    }
+                  `}
+                  onClick={onSelectCommands}
+                >
+                  <svg
+                    aria-hidden="true"
+                    className={`size-4 shrink-0 ${viewMode === "commands" ? "text-cyan-400" : "text-gray-600"}`}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.5}
+                      d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"
+                    />
+                  </svg>
+                  コマンド実行
                 </button>
               </nav>
 
@@ -659,6 +694,44 @@ export function Sidebar({
               />
             </svg>
             データセット管理
+          </motion.button>
+
+          {/* Commands */}
+          <motion.p
+            className="px-3 mt-6 mb-2 text-[10px] font-semibold uppercase tracking-[0.15em] text-gray-600 whitespace-nowrap"
+            animate={{ opacity: expanded ? 1 : 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            Commands
+          </motion.p>
+          <motion.button
+            type="button"
+            whileHover={{ x: 2 }}
+            className={`
+              group w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-[13px] whitespace-nowrap
+              ${
+                viewMode === "commands"
+                  ? "bg-cyan-500/15 text-cyan-400 font-semibold shadow-lg shadow-cyan-500/5"
+                  : "text-gray-400 hover:bg-white/[0.04] hover:text-gray-200"
+              }
+            `}
+            onClick={onSelectCommands}
+          >
+            <svg
+              aria-hidden="true"
+              className={`size-4 shrink-0 ${viewMode === "commands" ? "text-cyan-400" : "text-gray-600 group-hover:text-gray-500"}`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"
+              />
+            </svg>
+            コマンド実行
           </motion.button>
         </nav>
 

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -292,6 +292,31 @@ export function Sidebar({
                       />
                     </svg>
                   </button>
+                  <button
+                    type="button"
+                    className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                      viewMode === "commands"
+                        ? "text-cyan-400 bg-cyan-400/10"
+                        : "text-gray-500 hover:text-cyan-400 hover:bg-cyan-400/10"
+                    }`}
+                    onClick={onSelectCommands}
+                    title="コマンド実行"
+                  >
+                    <svg
+                      className="size-5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"
+                      />
+                    </svg>
+                  </button>
                   <div>
                     <h1 className="text-sm font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent whitespace-nowrap">
                       Requirements
@@ -432,39 +457,6 @@ export function Sidebar({
                   </svg>
                   データセット管理
                 </button>
-
-                {/* Commands */}
-                <p className="px-3 mt-6 mb-2 text-[10px] font-semibold uppercase tracking-[0.15em] text-gray-600 whitespace-nowrap">
-                  Commands
-                </p>
-                <button
-                  type="button"
-                  className={`
-                    w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-[13px] whitespace-nowrap
-                    ${
-                      viewMode === "commands"
-                        ? "bg-cyan-500/15 text-cyan-400 font-semibold shadow-lg shadow-cyan-500/5"
-                        : "text-gray-400 hover:bg-white/[0.04] hover:text-gray-200"
-                    }
-                  `}
-                  onClick={onSelectCommands}
-                >
-                  <svg
-                    aria-hidden="true"
-                    className={`size-4 shrink-0 ${viewMode === "commands" ? "text-cyan-400" : "text-gray-600"}`}
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={1.5}
-                      d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"
-                    />
-                  </svg>
-                  コマンド実行
-                </button>
               </nav>
 
               {/* Footer */}
@@ -518,6 +510,33 @@ export function Sidebar({
                   strokeLinejoin="round"
                   strokeWidth={2}
                   d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
+                />
+              </svg>
+            </motion.button>
+            <motion.button
+              type="button"
+              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                viewMode === "commands"
+                  ? "text-cyan-400 bg-cyan-400/10"
+                  : "text-gray-500 hover:text-cyan-400 hover:bg-cyan-400/10"
+              }`}
+              onClick={onSelectCommands}
+              title="コマンド実行"
+              animate={{ opacity: expanded ? 1 : 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              <svg
+                className="size-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"
                 />
               </svg>
             </motion.button>
@@ -694,44 +713,6 @@ export function Sidebar({
               />
             </svg>
             データセット管理
-          </motion.button>
-
-          {/* Commands */}
-          <motion.p
-            className="px-3 mt-6 mb-2 text-[10px] font-semibold uppercase tracking-[0.15em] text-gray-600 whitespace-nowrap"
-            animate={{ opacity: expanded ? 1 : 0 }}
-            transition={{ duration: 0.2 }}
-          >
-            Commands
-          </motion.p>
-          <motion.button
-            type="button"
-            whileHover={{ x: 2 }}
-            className={`
-              group w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-[13px] whitespace-nowrap
-              ${
-                viewMode === "commands"
-                  ? "bg-cyan-500/15 text-cyan-400 font-semibold shadow-lg shadow-cyan-500/5"
-                  : "text-gray-400 hover:bg-white/[0.04] hover:text-gray-200"
-              }
-            `}
-            onClick={onSelectCommands}
-          >
-            <svg
-              aria-hidden="true"
-              className={`size-4 shrink-0 ${viewMode === "commands" ? "text-cyan-400" : "text-gray-600 group-hover:text-gray-500"}`}
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"
-              />
-            </svg>
-            コマンド実行
           </motion.button>
         </nav>
 


### PR DESCRIPTION
## Summary

- USECASE.mdで定義されているコマンドをViewer上から実行できるページを作成
- 左ペインにコマンド選択・オプション設定UI、右ペインにリアルタイムログ表示
- ndjsonストリーミングでプロセス出力をリアルタイム配信

Closes #59

## Changes

- `viewer/server.ts`: コマンド実行API（`POST /api/commands/execute`）、補助API（data-sources/apps/collect-sources/dataset-names）、中止API追加
- `viewer/src/api.ts`: コマンド実行・中止のAPIクライアント関数追加
- `viewer/src/components/CommandRunner.tsx`: 新規作成。コマンド選択、オプション設定（選択式/チェックボックス/テキスト入力）、リアルタイムログ表示
- `viewer/src/App.tsx`: `commands` viewMode追加、URL同期対応
- `viewer/src/components/Sidebar.tsx`: 「コマンド実行」ナビゲーション追加

## Test plan

- [ ] `pnpm viewer` でViewerを起動し、サイドバーの「コマンド実行」をクリック
- [ ] 各コマンド（collect, extract, generate等）を選択してオプションが動的に表示されることを確認
- [ ] `format`コマンドを実行し、リアルタイムでログが右ペインに表示されることを確認
- [ ] `collect --dry-run` を実行し、オプションが正しくコマンドに渡されることを確認
- [ ] 実行中に「中止」ボタンでプロセスを停止できることを確認
- [ ] URLに`?view=commands`が反映され、ブラウザバック/リロードで復元されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)