### PR TITLE
feat: データソースを任意テキストファイル対応に拡張し、ダイレクトモードを追加

### DIFF
--- a/.claude/skills/extract-keywords/SKILL.md
+++ b/.claude/skills/extract-keywords/SKILL.md
@@ -25,12 +25,12 @@ allowed-tools: Read, Write, Glob, Bash
 
 ### 1. データ読み込み
 
-対象ディレクトリ内の全データファイル（`news.json`, `youtube.json`, `user_proposal.md` 等）を読み込む。
+対象ディレクトリ内の全データファイルを読み込む。以下の形式に対応:
 
-各データソースから以下のテキスト要素を抽出する:
 - **NewsAPI** (`news.json`): `data.articles[].title` と `data.articles[].description`
 - **YouTube** (`youtube.json`): `data.items[].snippet.title` と `data.items[].snippet.description`
 - **ユーザー提案** (`user_proposal.md`): Markdownテキスト全体。`##` 見出し単位でセクション分割して読み込む
+- **任意のテキストファイル** (`*.md`, `*.txt`): ディレクトリ内の上記以外の `.md` / `.txt` ファイルも自動的に読み込む。`.md` は `##` 見出し単位で分割、`.txt` はファイル全体を1エントリとして扱う
 
 ### 2. キーワード・トレンド抽出
 

--- a/.claude/skills/generate-requirements/SKILL.md
+++ b/.claude/skills/generate-requirements/SKILL.md
@@ -12,8 +12,14 @@ allowed-tools: Read, Write, Glob, Bash
 
 ## 対象の決定
 
+### 通常モード（keyword.jsonベース）
 - `$ARGUMENTS` が指定されている場合: `gen/data_source/$ARGUMENTS/keyword.json` を使用
 - 指定がない場合: `gen/data_source/` 配下で最新のサブディレクトリ内の `keyword.json` を使用
+
+### ダイレクトモード（`--direct` オプション使用時）
+- キーワード抽出をスキップし、テキストデータから直接要件を生成する
+- `keyword.json` は不要。ディレクトリ内の全テキストファイル（`.json`, `.md`, `.txt`）を直接読み込む
+- ユーザーが書いた提案やメモの意図を尊重し、キーワード抽出を介さずに要件を詳細化する
 
 現在のdata_source:
 
@@ -57,13 +63,16 @@ mkdir -p gen/requirements/{app_name}/{features,diagrams}
 
 ## 手順
 
-### ステップ1: keyword.json 読み込み
+### ステップ1: データ読み込み
 
-対象ディレクトリの `keyword.json` を読み込み、キーワードとトレンドを把握する。
+**通常モード**: 対象ディレクトリの `keyword.json` を読み込み、キーワードとトレンドを把握する。
+
+**ダイレクトモード**: 対象ディレクトリ内の全テキストファイル（`*.json`（`keyword.json`除く）, `*.md`, `*.txt`）を読み込み、内容を把握する。
 
 ### ステップ2: アプリ案の構想
 
-keyword.jsonの内容を元に、以下を思考する:
+**通常モード**: keyword.jsonの内容を元に、以下を思考する。
+**ダイレクトモード**: テキストデータの内容を直接読み込み、ユーザーの意図を尊重しながら以下を思考する:
 
 - どのキーワード・トレンドの組み合わせが有望か
 - ターゲットユーザーは誰か、どんな課題を抱えているか
@@ -92,6 +101,8 @@ Bashで `mkdir -p gen/requirements/{app_name}/features` を実行する。
 - `description`: このアプリ案に至った思考の経緯
 
 **データセットモードの場合**: `dataset` フィールドを追加し、`source.directory` を `dataset://{データセット名}` 形式にする。`dataset.sourceApps` にはデータセットに含まれる全アイテム（appName, type, featureId, title）を列挙する。詳細は[テンプレート参照](templates.md)の「データセットモード用」セクションを参照。
+
+**ダイレクトモードの場合**: `keywords` 配列は空配列 `[]` とし、`description` にはテキストデータからどのようにアプリ案を導いたかの経緯を記載する。
 
 **出力先**: `gen/requirements/{app_name}/_source_info.json`
 

--- a/USECASE.md
+++ b/USECASE.md
@@ -89,11 +89,23 @@ pnpm extract -- --target 2025_02_09_14_30_00
 | 過去の特定データから再抽出 | `pnpm extract -- --target 2025_01_15_10_00_00` |
 | どのデータがあるか確認してから実行 | `ls gen/data_source/` → `pnpm extract -- --target <選んだディレクトリ>` |
 
+#### 対応データソース
+
+以下のファイル形式をデータソースとして自動認識する:
+
+- `*.json`（`keyword.json` を除く）: APIから取得した構造化データ（news.json, youtube.json等）
+- `*.md`: Markdownテキスト（`##` 見出し単位でセクション分割して読み込み）
+- `*.txt`: プレーンテキスト（ファイル全体を1エントリとして読み込み）
+
 #### 入出力
 
 ```
-# 入力
-gen/data_source/2025_02_09_14_30_00/news.json
+# 入力（対応する全ファイルが自動読み込みされる）
+gen/data_source/2025_02_09_14_30_00/
+├── news.json           # APIデータ
+├── user_proposal.md    # ユーザー提案（任意）
+├── ideas.txt           # テキストメモ（任意）
+└── research_notes.md   # 調査メモ（任意）
 
 # 出力（同じディレクトリに追加される）
 gen/data_source/2025_02_09_14_30_00/keyword.json
@@ -103,7 +115,7 @@ gen/data_source/2025_02_09_14_30_00/keyword.json
 
 ### `pnpm generate` - 要件生成
 
-キーワードからアプリ案を構想し、要件定義（overview + diagrams + features）を自動生成する。
+キーワードまたはテキストデータからアプリ案を構想し、要件定義（overview + diagrams + features）を自動生成する。
 
 #### 基本パターン
 
@@ -113,6 +125,12 @@ pnpm generate
 
 # 特定のdata_sourceを指定
 pnpm generate -- --target 2025_02_09_14_30_00
+
+# ダイレクトモード（キーワード抽出をスキップし、テキストデータから直接生成）
+pnpm generate -- --direct
+
+# ダイレクトモード + 特定のdata_sourceを指定
+pnpm generate -- --direct --target 2025_02_09_14_30_00
 
 # データセットモード（既存要件の組み合わせから新アプリを生成）
 pnpm generate -- --dataset-source gen/datasets/my_dataset.md --dataset-name my_dataset
@@ -124,7 +142,24 @@ pnpm generate -- --dataset-source gen/datasets/my_dataset.md --dataset-name my_d
 |---------|---------|
 | 新しいアプリ案を生成 | `pnpm generate` |
 | 過去のキーワードからやり直し | `pnpm generate -- --target 2025_01_15_10_00_00` |
+| ユーザーの思いつきメモから直接生成 | `pnpm generate -- --direct` |
 | 既存アプリの組み合わせで新アプリ | `pnpm generate -- --dataset-source <file> --dataset-name <name>` |
+
+#### ダイレクトモード（`--direct`）
+
+キーワード抽出を介さず、テキストデータの内容を直接読み込んで要件を生成するモード。以下のようなケースで有用:
+
+- ユーザーが書いたアプリ案メモ（`user_proposal.md`等）をそのまま詳細化したい
+- キーワード化するとユーザーとAIの解釈不一致が生じる場合
+- 構造化されていないテキストデータを入力にしたい
+
+```bash
+# data_source/ にテキストファイルを配置
+echo "SNSの投稿を自動分類するアプリ" > gen/data_source/2025_02_09_14_30_00/idea.txt
+
+# ダイレクトモードで生成（keyword.json不要）
+pnpm generate -- --direct --target 2025_02_09_14_30_00
+```
 
 #### 出力構造
 
@@ -132,7 +167,10 @@ pnpm generate -- --dataset-source gen/datasets/my_dataset.md --dataset-name my_d
 gen/requirements/{app_name}/
 ├── _source_info.json    # メタデータ（ソース情報、キーワード、タグ）
 ├── overview.md          # アプリ概要（コンセプト、機能一覧、技術スタック等）
-├── diagrams.md          # 設計図（画面遷移図、ユーザーフロー、システム構成図）
+├── memo.md              # メモ（Viewerから編集可能、dev modeのみ）
+├── diagrams/            # 設計図（Mermaid記法）
+│   ├── 01_screen_transition.md   # 画面遷移図（必須）
+│   └── 02_user_flow.md           # ユーザーフロー等
 └── features/
     ├── 01_feature_name.md   # 各機能の詳細仕様
     ├── 02_feature_name.md
@@ -217,13 +255,13 @@ tsx scripts/validate-requirements.ts trust-lens
 
 #### 検証項目
 
-- ディレクトリ・ファイルの存在（overview.md, diagrams.md, features/, _source_info.json）
+- ディレクトリ・ファイルの存在（overview.md, diagrams/, features/, _source_info.json）
 - 命名規則（app_name: kebab-case、feature: nn_snake_case.md）
-- overview.mdの必須セクション（コンセプト、ターゲットユーザー、機能一覧、マネタイズ、技術スタック、運用方針）
-- diagrams.mdのD2コードブロック・シーケンス図の存在
+- overview.mdの必須セクション（コンセプト、ターゲットユーザー、機能一覧、マネタイズ、コスト分析、技術スタック、運用方針）
+- diagrams/配下のMermaid記法の図解ファイル
 - 各featureの必須セクション（概要、画面構成、ユーザーフロー、データモデル、API設計、非機能要件）
 - overview.mdの機能数とfeatureファイル数の一致
-- _source_info.jsonのスキーマ検証（tags、keywords等）
+- _source_info.jsonのスキーマ検証（tags、keywords等。keywordsは空配列も許可）
 
 ---
 
@@ -242,6 +280,12 @@ pnpm pipeline -- --skip-collect
 
 # 収集＋抽出をスキップ（既にkeyword.jsonがある場合）
 pnpm pipeline -- --skip-collect --skip-extract
+
+# ダイレクトモード（テキストデータから直接要件生成、キーワード抽出スキップ）
+pnpm pipeline -- --skip-collect --direct
+
+# ダイレクトモード + 特定のdata_sourceを指定
+pnpm pipeline -- --skip-collect --direct --source 2025_02_09_14_30_00
 
 # 特定のdata_sourceを使ってパイプライン実行
 pnpm pipeline -- --source 2025_02_09_14_30_00
@@ -263,6 +307,7 @@ pnpm pipeline -- --regenerate trust-lens --memo "技術スタックをNext.jsに
 | 初めて実行 / 最新トレンドで全自動 | `pnpm pipeline` |
 | APIクォータ節約（既存データ再利用） | `pnpm pipeline -- --skip-collect` |
 | キーワードを手動調整した後に再生成 | `pnpm pipeline -- --skip-collect --skip-extract` |
+| テキストメモから直接アプリ案を生成 | `pnpm pipeline -- --skip-collect --direct` |
 | 過去の特定データで再実行 | `pnpm pipeline -- --source 2025_01_15_10_00_00` |
 | Viewerで作ったデータセットから生成 | `pnpm pipeline -- --dataset my_dataset` |
 | 既存アプリをmemoベースで再生成 | `pnpm pipeline -- --regenerate <app_name>` |
@@ -276,11 +321,19 @@ pnpm pipeline
   │
   ├─ [1] collect    ← --skip-collect で省略可
   │     ↓
-  ├─ [2] extract    ← --skip-extract で省略可
+  ├─ [2] extract    ← --skip-extract で省略可 / --direct で自動スキップ
   │     ↓
-  ├─ [3] generate
+  ├─ [3] generate   ← --direct でダイレクトモード（テキスト直接入力）
   │     ↓
   └─ [4] validate   ← 新規生成アプリのみ自動検証
+
+pnpm pipeline --direct   ← ダイレクトモード（キーワード抽出スキップ）
+  │
+  ├─ [1] collect    ← --skip-collect で省略可
+  ├─ [2] extract    → 自動スキップ
+  ├─ [3] generate   ← テキストデータから直接要件生成
+  │     ↓
+  └─ [4] validate   ← 新規生成アプリを検証
 
 pnpm pipeline --regenerate <app>   ← 再生成モード（collect/extractスキップ）
   │
@@ -308,7 +361,8 @@ pnpm viewer
 
 - アプリ一覧の閲覧・検索（全文検索 / タグ検索）
 - Overview / Source Info / Diagrams / Features / Memo タブ切り替え
-- D2図解のSVGレンダリング表示
+- Mermaid図解のレンダリング表示
+- お気に入り管理
 - データセットの作成・管理
 - Commit & Push（devモードのみ）
 
@@ -408,12 +462,32 @@ pnpm regenerate trust-lens -- --memo "ターゲットを個人投資家に絞り
 pnpm viewer
 ```
 
-### 6. 手動でdiagrams.mdを編集した後の検証
+### 6. ユーザーの思いつきメモから直接アプリ案を生成
+
+```bash
+# data_source/ にテキストファイルを手動配置
+mkdir -p gen/data_source/my_idea
+cat > gen/data_source/my_idea/proposal.md << 'EOF'
+## ペットの健康管理アプリ
+毎日の食事・運動・体重を記録し、獣医との共有もできる
+## 特徴
+- 写真で食事記録
+- 散歩のGPSトラッキング
+EOF
+
+# ダイレクトモードで直接要件生成（キーワード抽出をスキップ）
+pnpm pipeline -- --skip-collect --direct --source my_idea
+
+# ビューワーで確認
+pnpm viewer
+```
+
+### 7. 手動でdiagramsを編集した後の検証
 
 ```bash
 # 編集後にバリデーション
 pnpm generate:validate my-app
 
-# ビューワーでD2図解の表示確認
+# ビューワーでMermaid図解の表示確認
 pnpm viewer
 ```

--- a/scripts/extract.sh
+++ b/scripts/extract.sh
@@ -54,21 +54,18 @@ if [[ ! -d "$DATA_DIR" ]]; then
   exit 1
 fi
 
-# データファイルが1つ以上存在するか（*.json（keyword.json除く）または user_proposal.md）
+# データファイルが1つ以上存在するか（*.json（keyword.json除く）/ *.md / *.txt）
 JSON_COUNT=$(find "$DATA_DIR" -maxdepth 1 -name "*.json" ! -name "keyword.json" | wc -l | tr -d ' ')
-HAS_PROPOSAL=false
-if [[ -f "${DATA_DIR}/user_proposal.md" ]]; then
-  HAS_PROPOSAL=true
-fi
+TEXT_COUNT=$(find "$DATA_DIR" -maxdepth 1 \( -name "*.md" -o -name "*.txt" \) | wc -l | tr -d ' ')
 
-if [[ "$JSON_COUNT" -eq 0 ]] && ! $HAS_PROPOSAL; then
-  echo "エラー: ${DATA_DIR} にデータファイル（*.json / user_proposal.md）がありません。"
+if [[ "$JSON_COUNT" -eq 0 ]] && [[ "$TEXT_COUNT" -eq 0 ]]; then
+  echo "エラー: ${DATA_DIR} にデータファイル（*.json / *.md / *.txt）がありません。"
   exit 1
 fi
 
 FILE_DESC="${JSON_COUNT} JSONファイル"
-if $HAS_PROPOSAL; then
-  FILE_DESC="${FILE_DESC} + user_proposal.md"
+if [[ "$TEXT_COUNT" -gt 0 ]]; then
+  FILE_DESC="${FILE_DESC} + ${TEXT_COUNT} テキストファイル"
 fi
 
 echo "=== キーワード抽出 ==="

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -50,22 +50,25 @@ TARGET_DIR=""
 DATASET_SOURCE=""
 DATASET_NAME=""
 SKIP_AGENTS=false
+DIRECT_MODE=false
 while [[ $# -gt 0 ]]; do
   case $1 in
     --target) TARGET_DIR="$2"; shift 2 ;;
     --dataset-source) DATASET_SOURCE="$2"; shift 2 ;;
     --dataset-name) DATASET_NAME="$2"; shift 2 ;;
     --skip-agents) SKIP_AGENTS=true; shift ;;
+    --direct) DIRECT_MODE=true; shift ;;
     -h|--help)
-      echo "Usage: $0 [--target <data_source_subdir>] [--dataset-source <file> --dataset-name <name>] [--skip-agents]"
+      echo "Usage: $0 [--target <data_source_subdir>] [--dataset-source <file> --dataset-name <name>] [--skip-agents] [--direct]"
       echo ""
-      echo "keyword.jsonまたはデータセットソースを元にアプリ要件を生成します。"
+      echo "keyword.json、テキストデータ、またはデータセットソースを元にアプリ要件を生成します。"
       echo ""
       echo "Options:"
       echo "  --target          data_source配下のサブディレクトリ名（省略時は最新）"
       echo "  --dataset-source  データセットソースファイルパス"
       echo "  --dataset-name    データセット名"
       echo "  --skip-agents     外部エージェント（codex/gemini）をスキップ"
+      echo "  --direct          キーワード抽出をスキップし、テキストデータから直接要件生成"
       exit 0
       ;;
     --) shift ;;
@@ -126,7 +129,7 @@ tsx scripts/validate-requirements.ts <生成したapp_name>"
 fi
 
 # =============================================================================
-# 通常モード（keyword.jsonベース）
+# ダイレクトモード・通常モード共通: 対象ディレクトリ決定
 # =============================================================================
 # 1. --target オプション → 2. app.config.yaml の pipeline.default_source → 3. 対話選択（直近7件）
 if [[ -z "$TARGET_DIR" ]]; then
@@ -141,9 +144,89 @@ if [[ -z "$TARGET_DIR" ]]; then
   fi
 fi
 
+# =============================================================================
+# ダイレクトモード（テキストデータから直接要件生成、keyword.json不要）
+# =============================================================================
+if $DIRECT_MODE; then
+  DATA_DIR="${DATA_SOURCE_DIR}/${TARGET_DIR}"
+  if [[ ! -d "$DATA_DIR" ]]; then
+    echo "エラー: ${DATA_DIR} が存在しません。"
+    exit 1
+  fi
+
+  # テキストファイルの存在確認（*.json（keyword.json除く）/ *.md / *.txt）
+  TEXT_FILES=$(find "$DATA_DIR" -maxdepth 1 \( -name "*.md" -o -name "*.txt" -o \( -name "*.json" ! -name "keyword.json" \) \) | sort)
+  if [[ -z "$TEXT_FILES" ]]; then
+    echo "エラー: ${DATA_DIR} にデータファイルがありません。"
+    exit 1
+  fi
+
+  FILE_LIST=$(echo "$TEXT_FILES" | while read -r f; do basename "$f"; done | paste -sd ", " -)
+  echo "=== 要件生成（ダイレクトモード） ==="
+  echo "対象: ${DATA_DIR}"
+  echo "ファイル: ${FILE_LIST}"
+  echo ""
+
+  # 制約条件の表示
+  HAS_CONSTRAINTS=false
+  [[ -n "$CONSTRAINT_PLATFORM" || -n "$CONSTRAINT_BUDGET" || -n "$CONSTRAINT_DIFFICULTY" || -n "$CONSTRAINT_TEAM_SIZE" ]] && HAS_CONSTRAINTS=true
+  [[ -n "$CONSTRAINT_TS_FRONTEND" || -n "$CONSTRAINT_TS_BACKEND" || -n "$CONSTRAINT_TS_DATABASE" || -n "$CONSTRAINT_TS_HOSTING" || -n "$CONSTRAINT_TS_AUTH" || -n "$CONSTRAINT_TS_OTHER" ]] && HAS_CONSTRAINTS=true
+  if $HAS_CONSTRAINTS; then
+    echo "--- 制約条件 ---"
+    [[ -n "$CONSTRAINT_PLATFORM" ]] && echo "  platform: ${CONSTRAINT_PLATFORM}"
+    [[ -n "$CONSTRAINT_BUDGET" ]] && echo "  budget: ${CONSTRAINT_BUDGET}"
+    [[ -n "$CONSTRAINT_DIFFICULTY" ]] && echo "  difficulty: ${CONSTRAINT_DIFFICULTY}"
+    [[ -n "$CONSTRAINT_TEAM_SIZE" ]] && echo "  team_size: ${CONSTRAINT_TEAM_SIZE}"
+    echo ""
+  fi
+
+  CONSTRAINTS_CONTEXT=""
+  if [[ -n "$CONSTRAINTS_PROMPT" ]]; then
+    CONSTRAINTS_CONTEXT="
+## 制約条件
+以下の制約条件が設定されています。アプリ案の構想・技術スタック選定・機能スコープに反映してください。
+${CONSTRAINTS_PROMPT}"
+  fi
+
+  PERSPECTIVES_CONTEXT=""
+  if [[ -n "$PERSPECTIVES_PROMPT" ]]; then
+    PERSPECTIVES_CONTEXT="
+## 生成観点
+以下の生成観点が設定されています。アプリの体験設計・機能設計・マネタイズ戦略に深く反映してください。
+また、_source_info.json の perspectives フィールドに適用した観点を記録してください。
+${PERSPECTIVES_PROMPT}"
+  fi
+
+  PROMPT="以下のディレクトリ内のテキストデータを全て読み込み、上記の要件生成スキルの手順に従ってアプリの要件を生成してください。
+対象ディレクトリ: ${DATA_DIR}
+
+これはダイレクトモードです。keyword.jsonは使用しません。
+テキストデータの内容を直接読み込み、そこからアプリのアイデアを構想してください。
+ユーザーが書いた提案やメモがそのまま含まれている可能性があります。
+内容の意図を尊重し、キーワード抽出を介さずに直接要件を詳細化してください。
+
+_source_info.json の source.directory には「${TARGET_DIR}」を、
+keywords 配列は空配列 [] としてください。
+description にはテキストデータからどのようにアプリ案を導いたかの経緯を記載してください。
+${CONSTRAINTS_CONTEXT}
+${PERSPECTIVES_CONTEXT}
+
+生成完了後、以下のバリデーションスクリプトを実行して構造を検証してください:
+tsx scripts/validate-requirements.ts <生成したapp_name>"
+
+  run_interruptible claude -p "$PROMPT" \
+    --append-system-prompt-file "$PROMPT_FILE" \
+    --allowedTools "Read" "Write" "Glob" "Bash(mkdir:*)" "Bash(find:*)" "Bash(tsx:*)"
+
+  exit 0
+fi
+
+# =============================================================================
+# 通常モード（keyword.jsonベース）
+# =============================================================================
 KEYWORD_FILE="${DATA_SOURCE_DIR}/${TARGET_DIR}/keyword.json"
 if [[ ! -f "$KEYWORD_FILE" ]]; then
-  echo "エラー: ${KEYWORD_FILE} が見つかりません。先に /extract-keywords を実行してください。"
+  echo "エラー: ${KEYWORD_FILE} が見つかりません。先に /extract-keywords を実行するか、--direct オプションを使用してください。"
   exit 1
 fi
 

--- a/scripts/lib/data-source.ts
+++ b/scripts/lib/data-source.ts
@@ -156,21 +156,61 @@ export function extractYoutubeTexts(data: unknown): ArticleText[] {
 export function extractUserProposalTexts(dirName: string): ArticleText[] {
   const filePath = join(DATA_SOURCE_DIR, dirName, USER_PROPOSAL_FILE);
   if (!existsSync(filePath)) return [];
+  return extractMarkdownTexts(filePath, "ユーザー提案");
+}
+
+/** Markdownファイルからテキスト要素を抽出（## 見出し単位で分割） */
+function extractMarkdownTexts(filePath: string, defaultTitle: string): ArticleText[] {
   const content = readFileSync(filePath, "utf-8").trim();
   if (!content) return [];
 
-  // Markdownの見出し(##)単位でセクションに分割
   const sections = content.split(/^## /m).filter(Boolean);
   if (sections.length <= 1) {
-    // 見出しがないか1セクションのみの場合はそのまま1エントリとして返す
-    return [{ title: "ユーザー提案", description: content }];
+    return [{ title: defaultTitle, description: content }];
   }
   return sections.map((section) => {
     const lines = section.split("\n");
-    const title = lines[0]?.trim() || "ユーザー提案";
+    const title = lines[0]?.trim() || defaultTitle;
     const description = lines.slice(1).join("\n").trim();
     return { title, description };
   });
+}
+
+/** テキストファイル対応の拡張子一覧 */
+const TEXT_FILE_EXTENSIONS = [".md", ".txt"];
+
+/** 既知のファイル名（個別処理で扱うもの） */
+const KNOWN_FILES = new Set(["news.json", "youtube.json", "keyword.json", USER_PROPOSAL_FILE]);
+
+/** 任意のテキストファイルからテキスト要素を抽出 */
+export function extractTextFileTexts(dirName: string): ArticleText[] {
+  const dirPath = join(DATA_SOURCE_DIR, dirName);
+  if (!existsSync(dirPath)) return [];
+
+  const files = readdirSync(dirPath).filter((f) => {
+    if (KNOWN_FILES.has(f)) return false;
+    return TEXT_FILE_EXTENSIONS.some((ext) => f.endsWith(ext));
+  });
+
+  const texts: ArticleText[] = [];
+  for (const file of files) {
+    const filePath = join(dirPath, file);
+    if (file.endsWith(".md")) {
+      texts.push(...extractMarkdownTexts(filePath, file));
+    } else {
+      // .txt: ファイル全体を1エントリとして読み込み
+      const content = readFileSync(filePath, "utf-8").trim();
+      if (content) {
+        texts.push({ title: file, description: content });
+      }
+    }
+  }
+  return texts;
+}
+
+/** 指定ディレクトリ内にテキストファイル（.md, .txt、既知ファイル除く）が存在するか */
+export function hasTextFiles(dirName: string): boolean {
+  return extractTextFileTexts(dirName).length > 0;
 }
 
 /** 指定ディレクトリ内の全データソースからテキストを統合取得 */
@@ -184,6 +224,7 @@ export function loadAllTexts(dirName: string): ArticleText[] {
   if (youtube) texts.push(...extractYoutubeTexts(youtube));
 
   texts.push(...extractUserProposalTexts(dirName));
+  texts.push(...extractTextFileTexts(dirName));
 
   return texts;
 }
@@ -191,4 +232,14 @@ export function loadAllTexts(dirName: string): ArticleText[] {
 /** 指定ディレクトリに user_proposal.md が存在するか */
 export function hasUserProposal(dirName: string): boolean {
   return existsSync(join(DATA_SOURCE_DIR, dirName, USER_PROPOSAL_FILE));
+}
+
+/** テキストファイルの一覧を返す（.md, .txt、既知ファイル除く） */
+export function listTextFiles(dirName: string): string[] {
+  const dirPath = join(DATA_SOURCE_DIR, dirName);
+  if (!existsSync(dirPath)) return [];
+  return readdirSync(dirPath).filter((f) => {
+    if (KNOWN_FILES.has(f)) return false;
+    return TEXT_FILE_EXTENSIONS.some((ext) => f.endsWith(ext));
+  });
 }

--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -14,6 +14,7 @@ import { DATA_SOURCE_DIR, DATASETS_DIR, REQUIREMENTS_DIR } from "./lib/paths.js"
 interface PipelineOptions {
   skipCollect: boolean;
   skipExtract: boolean;
+  direct: boolean;
   source?: string;
   dataset?: string;
   regenerate?: string;
@@ -42,7 +43,7 @@ interface Dataset {
 
 // --- 引数パース ---
 function parseArgs(argv: string[]): PipelineOptions {
-  const opts: PipelineOptions = { skipCollect: false, skipExtract: false };
+  const opts: PipelineOptions = { skipCollect: false, skipExtract: false, direct: false };
   let i = 0;
   while (i < argv.length) {
     switch (argv[i]) {
@@ -51,6 +52,11 @@ function parseArgs(argv: string[]): PipelineOptions {
         i++;
         break;
       case "--skip-extract":
+        opts.skipExtract = true;
+        i++;
+        break;
+      case "--direct":
+        opts.direct = true;
         opts.skipExtract = true;
         i++;
         break;
@@ -107,6 +113,7 @@ function printHelp(): void {
 Options:
   --skip-collect        既存データを使いキーワード抽出から開始
   --skip-extract        既存キーワードを使い要件生成のみ実行
+  --direct              キーワード抽出をスキップし、テキストデータから直接要件生成
   --source <dir>        使用する data_source サブディレクトリを指定
   --dataset <name>      データセットをソースとして要件生成（collect/extractスキップ）
   --regenerate <app>    既存アプリ要件をmemo.mdベースで再生成
@@ -382,7 +389,10 @@ async function main() {
   console.log(`対象ディレクトリ: ${DATA_SOURCE_DIR}/${targetDir}\n`);
 
   // Step 2: extract
-  if (opts.skipExtract) {
+  if (opts.direct) {
+    console.log("[Step 2] extract: スキップ（ダイレクトモード）\n");
+    results.push({ name: "extract", status: "skipped" });
+  } else if (opts.skipExtract) {
     console.log("[Step 2] extract: スキップ\n");
     const keywordPath = resolve(DATA_SOURCE_DIR, targetDir, "keyword.json");
     if (!existsSync(keywordPath)) {
@@ -412,9 +422,14 @@ async function main() {
 
   // Step 3: generate
   const appsBefore = new Set(listRequirementApps());
-  console.log("[Step 3] generate: 要件生成を開始...\n");
+  const generateLabel = opts.direct ? "要件生成（ダイレクトモード）" : "要件生成";
+  console.log(`[Step 3] generate: ${generateLabel}を開始...\n`);
   try {
-    await runStep("bash", ["scripts/generate.sh", "--target", targetDir]);
+    const generateArgs = ["scripts/generate.sh", "--target", targetDir];
+    if (opts.direct) {
+      generateArgs.push("--direct");
+    }
+    await runStep("bash", generateArgs);
     console.log("");
     results.push({ name: "generate", status: "success" });
   } catch (err) {

--- a/scripts/validate-requirements.ts
+++ b/scripts/validate-requirements.ts
@@ -159,8 +159,8 @@ function validate(appName: string): ValidationError[] {
       if (!data.source?.collected_at) {
         errors.push({ file: "_source_info.json", message: "source.collected_atが未設定です" });
       }
-      if (!Array.isArray(data.keywords) || data.keywords.length === 0) {
-        errors.push({ file: "_source_info.json", message: "keywordsが空または未設定です" });
+      if (!Array.isArray(data.keywords)) {
+        errors.push({ file: "_source_info.json", message: "keywordsが未設定です（空配列は許可）" });
       }
       if (!data.description) {
         errors.push({ file: "_source_info.json", message: "descriptionが未設定です" });

--- a/viewer/src/components/CommandRunner.tsx
+++ b/viewer/src/components/CommandRunner.tsx
@@ -68,14 +68,20 @@ const COMMANDS: CommandDef[] = [
     id: "generate",
     label: "generate",
     description:
-      "キーワードからアプリ案を構想し、要件定義を自動生成する。データセットモードでは既存要件の組み合わせから新アプリを生成。",
+      "キーワードまたはテキストデータからアプリ案を構想し、要件定義を自動生成する。ダイレクトモードではキーワード抽出をスキップして直接生成。データセットモードでは既存要件の組み合わせから新アプリを生成。",
     options: [
       {
         id: "target",
-        label: "データソース（通常モード）",
+        label: "データソース",
         type: "select",
         dynamicChoicesUrl: "/api/commands/data-sources",
         argFlag: "--target",
+      },
+      {
+        id: "direct",
+        label: "ダイレクトモード（キーワード抽出スキップ、テキストから直接生成）",
+        type: "checkbox",
+        argFlag: "--direct",
       },
       {
         id: "datasetSource",
@@ -144,7 +150,8 @@ const COMMANDS: CommandDef[] = [
   {
     id: "pipeline",
     label: "pipeline",
-    description: "collect → extract → generate → validate を一括実行する。",
+    description:
+      "collect → extract → generate → validate を一括実行する。ダイレクトモードではextractをスキップしてテキストから直接生成。",
     options: [
       {
         id: "skipCollect",
@@ -157,6 +164,12 @@ const COMMANDS: CommandDef[] = [
         label: "extractをスキップ",
         type: "checkbox",
         argFlag: "--skip-extract",
+      },
+      {
+        id: "direct",
+        label: "ダイレクトモード（extractスキップ、テキストから直接生成）",
+        type: "checkbox",
+        argFlag: "--direct",
       },
       {
         id: "source",


### PR DESCRIPTION
## Summary

- データソースとして任意の `.md` / `.txt` テキストファイルを受け入れ可能に拡張
- `--direct` オプションによりキーワード抽出をスキップしてテキストデータから直接要件生成するモードを追加
- ユーザーの思いつき案（`user_proposal.md` 以外のテキストファイル含む）をキーワード化せずに直接要件の詳細化へ進めるようになった

Closes #12

## Changes

- `scripts/lib/data-source.ts`: 汎用テキストファイル読み込み関数 `extractTextFileTexts()` を追加し、`loadAllTexts()` で自動検出
- `scripts/extract.sh`: データファイル存在チェックを `*.md` / `*.txt` にも対応
- `scripts/generate.sh`: `--direct` オプションでキーワード不要の要件生成モードを追加
- `scripts/pipeline.ts`: `--direct` オプションを追加（extract スキップ + generate 連携）
- `scripts/validate-requirements.ts`: `keywords` 空配列を許容（ダイレクトモード対応）
- `.claude/skills/extract-keywords/SKILL.md`: 汎用テキストファイル対応の記述追加
- `.claude/skills/generate-requirements/SKILL.md`: ダイレクトモードの手順追加

## Test plan

- [ ] `gen/data_source/` に `.md` や `.txt` ファイルを配置して `pnpm extract` が認識すること
- [ ] `pnpm generate --direct` でキーワード抽出なしに要件が生成されること
- [ ] `pnpm pipeline --direct --skip-collect --source <dir>` でダイレクトモードパイプラインが動作すること
- [ ] 通常モード（`keyword.json` ベース）に影響がないこと
- [ ] バリデーションが `keywords: []` でもパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)