### PR TITLE
feat: app.config.yaml を編集できる設定ビューワーを追加

### DIFF
--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { parse } from "yaml";
+import { parse, stringify } from "yaml";
 
 const execAsync = promisify(exec);
 
@@ -455,6 +455,23 @@ app.get("/api/search", async (c) => {
   } catch {
     return c.json({ results: [], resultType: "grep" });
   }
+});
+
+// --- Config API ---
+app.get("/api/config", (c) => {
+  const configPath = resolve(projectRoot, "app.config.yaml");
+  if (!existsSync(configPath)) return c.json({ error: "Not found" }, 404);
+  const raw = readFileSync(configPath, "utf-8");
+  return c.json(parse(raw));
+});
+
+app.put("/api/config", async (c) => {
+  if (!isDev) return c.json({ error: "Dev mode only" }, 403);
+  const configPath = resolve(projectRoot, "app.config.yaml");
+  const body = await c.req.json();
+  const yaml = stringify(body, { lineWidth: 120 });
+  writeFileSync(configPath, yaml, "utf-8");
+  return c.json({ success: true });
 });
 
 // --- Favorites API ---

--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { parse, stringify } from "yaml";
+import { type Document, isMap, parse, parseDocument } from "yaml";
 
 const execAsync = promisify(exec);
 
@@ -465,12 +465,60 @@ app.get("/api/config", (c) => {
   return c.json(parse(raw));
 });
 
+// Document APIでコメントを保持したまま値を差分更新する
+function applyToDocument(
+  doc: Document,
+  incoming: Record<string, unknown>,
+  path: (string | number)[] = [],
+) {
+  const node = path.length === 0 ? doc.contents : doc.getIn(path, true);
+
+  for (const [key, value] of Object.entries(incoming)) {
+    const childPath = [...path, key];
+    if (value === null || value === undefined) {
+      // null/undefined → キーごと削除ではなく null をセット（コメント付きキーを残す）
+      doc.setIn(childPath, null);
+    } else if (Array.isArray(value)) {
+      doc.setIn(childPath, value);
+    } else if (typeof value === "object") {
+      // 既存ノードがマップなら再帰、なければ丸ごとセット
+      const existing = doc.getIn(childPath, true);
+      if (isMap(existing)) {
+        applyToDocument(doc, value as Record<string, unknown>, childPath);
+        // incoming に無いキーを削除
+        for (const item of existing.items) {
+          const k = typeof item.key === "object" && "value" in item.key ? item.key.value : item.key;
+          if (!(String(k) in (value as Record<string, unknown>))) {
+            doc.deleteIn([...childPath, String(k)]);
+          }
+        }
+      } else {
+        doc.setIn(childPath, value);
+      }
+    } else {
+      doc.setIn(childPath, value);
+    }
+  }
+
+  // トップレベルで incoming に無いキーを削除
+  if (isMap(node)) {
+    for (const item of node.items) {
+      const k = typeof item.key === "object" && "value" in item.key ? item.key.value : item.key;
+      if (!(String(k) in incoming)) {
+        doc.deleteIn([...path, String(k)]);
+      }
+    }
+  }
+}
+
 app.put("/api/config", async (c) => {
   if (!isDev) return c.json({ error: "Dev mode only" }, 403);
   const configPath = resolve(projectRoot, "app.config.yaml");
+  const raw = readFileSync(configPath, "utf-8");
+  const doc = parseDocument(raw);
   const body = await c.req.json();
-  const yaml = stringify(body, { lineWidth: 120 });
-  writeFileSync(configPath, yaml, "utf-8");
+  applyToDocument(doc, body);
+  writeFileSync(configPath, doc.toString(), "utf-8");
   return c.json({ success: true });
 });
 

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -13,6 +13,7 @@ import {
 } from "./api";
 import { type AppTab, AppView } from "./components/AppView";
 import { CommandRunner } from "./components/CommandRunner";
+import { ConfigEditor } from "./components/ConfigEditor";
 import { DatasetManager } from "./components/DatasetManager";
 import { FavoritePage } from "./components/FavoritePage";
 import { SearchView } from "./components/SearchView";
@@ -20,7 +21,7 @@ import { Sidebar } from "./components/Sidebar";
 import { ToastProvider } from "./components/Toast";
 import { useIsMobile } from "./hooks/useIsMobile";
 
-type ViewMode = "apps" | "datasets" | "favorites" | "commands";
+type ViewMode = "apps" | "datasets" | "favorites" | "commands" | "config";
 
 function buildUrl(state: {
   viewMode: ViewMode;
@@ -42,6 +43,8 @@ function buildUrl(state: {
     url.searchParams.set("view", "favorites");
   } else if (state.viewMode === "commands") {
     url.searchParams.set("view", "commands");
+  } else if (state.viewMode === "config") {
+    url.searchParams.set("view", "config");
   } else {
     if (state.app) url.searchParams.set("app", state.app);
     if (state.feature) url.searchParams.set("feature", state.feature);
@@ -105,8 +108,11 @@ export function App() {
     const isDatasetView = viewParam === "datasets";
     const isFavoritesView = viewParam === "favorites";
     const isCommandsView = viewParam === "commands";
-    // URL から datasets/favorites/commands ビュー復元
-    if (isCommandsView) {
+    const isConfigView = viewParam === "config";
+    // URL から datasets/favorites/commands/config ビュー復元
+    if (isConfigView) {
+      setViewMode("config");
+    } else if (isCommandsView) {
       setViewMode("commands");
     } else if (isFavoritesView) {
       setViewMode("favorites");
@@ -142,13 +148,15 @@ export function App() {
         tabParam && ["overview", "source-info", "diagrams", "features", "memo"].includes(tabParam)
           ? tabParam
           : undefined;
-      const currentViewMode = isCommandsView
-        ? "commands"
-        : isFavoritesView
-          ? "favorites"
-          : isDatasetView
-            ? "datasets"
-            : "apps";
+      const currentViewMode = isConfigView
+        ? "config"
+        : isCommandsView
+          ? "commands"
+          : isFavoritesView
+            ? "favorites"
+            : isDatasetView
+              ? "datasets"
+              : "apps";
       window.history.replaceState(
         {},
         "",
@@ -168,7 +176,11 @@ export function App() {
     const handlePopState = () => {
       const params = new URLSearchParams(window.location.search);
       const viewParam = params.get("view");
-      if (viewParam === "commands") {
+      if (viewParam === "config") {
+        setViewMode("config");
+        setSelectedFeature(null);
+        setSelectedTab("overview");
+      } else if (viewParam === "commands") {
         setViewMode("commands");
         setSelectedFeature(null);
         setSelectedTab("overview");
@@ -229,6 +241,14 @@ export function App() {
     setSearchActive(false);
     if (isMobile) setMobileSidebarOpen(false);
     window.history.pushState({}, "", buildUrl({ viewMode: "commands" }));
+  };
+
+  const handleSelectConfig = () => {
+    setViewMode("config");
+    setSelectedFeature(null);
+    setSearchActive(false);
+    if (isMobile) setMobileSidebarOpen(false);
+    window.history.pushState({}, "", buildUrl({ viewMode: "config" }));
   };
 
   const handleSelectFavorites = () => {
@@ -434,13 +454,15 @@ export function App() {
               </svg>
             </button>
             <span className="text-sm font-semibold text-gray-200 truncate">
-              {viewMode === "commands"
-                ? "コマンド実行"
-                : viewMode === "favorites"
-                  ? "お気に入り"
-                  : viewMode === "datasets"
-                    ? "データセット"
-                    : (selectedApp ?? "Requirements Viewer")}
+              {viewMode === "config"
+                ? "設定"
+                : viewMode === "commands"
+                  ? "コマンド実行"
+                  : viewMode === "favorites"
+                    ? "お気に入り"
+                    : viewMode === "datasets"
+                      ? "データセット"
+                      : (selectedApp ?? "Requirements Viewer")}
             </span>
           </div>
         )}
@@ -458,6 +480,7 @@ export function App() {
           onSelectDatasets={handleSelectDatasets}
           onSelectFavorites={handleSelectFavorites}
           onSelectCommands={handleSelectCommands}
+          onSelectConfig={handleSelectConfig}
           onSearch={handleSearch}
           onClearSearch={handleClearSearch}
           isSearchActive={searchActive}
@@ -471,7 +494,9 @@ export function App() {
               : "mb-3 mr-3 rounded-2xl bg-gray-900 shadow-2xl shadow-black/50 ring-1 ring-gray-800"
           }`}
         >
-          {viewMode === "commands" ? (
+          {viewMode === "config" ? (
+            <ConfigEditor isMobile={isMobile} isDev={isDev} />
+          ) : viewMode === "commands" ? (
             <CommandRunner isMobile={isMobile} isDev={isDev} />
           ) : viewMode === "favorites" ? (
             <FavoritePage

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -249,6 +249,57 @@ export async function removeFavorite(item: FavoriteItem): Promise<{ success: boo
   return res.json();
 }
 
+// --- Config API ---
+
+export interface AppConfig {
+  output_base_dir?: string;
+  collect?: {
+    sources?: Record<
+      string,
+      {
+        enabled?: boolean;
+        api_key_env?: string;
+        endpoint?: string;
+        params?: Record<string, string | number>;
+        output_file?: string;
+      }
+    >;
+  };
+  pipeline?: {
+    default_source?: string;
+  };
+  generate?: {
+    constraints?: Record<string, string>;
+    perspectives?: {
+      mode?: string;
+      items?: string[];
+    };
+    agents?: Record<
+      string,
+      {
+        enabled?: boolean;
+        model?: string;
+        sandbox?: string;
+        roles?: string[];
+      }
+    >;
+  };
+}
+
+export async function fetchConfig(): Promise<AppConfig> {
+  const res = await fetch(`${BASE}/config`);
+  return res.json();
+}
+
+export async function saveConfig(config: AppConfig): Promise<{ success: boolean }> {
+  const res = await fetch(`${BASE}/config`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(config),
+  });
+  return res.json();
+}
+
 // --- Commands API ---
 
 export async function fetchDataSources(): Promise<string[]> {

--- a/viewer/src/components/ConfigEditor.tsx
+++ b/viewer/src/components/ConfigEditor.tsx
@@ -1,0 +1,886 @@
+import { AnimatePresence, motion } from "motion/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type AppConfig, fetchConfig, saveConfig } from "../api";
+
+interface ConfigEditorProps {
+  isMobile: boolean;
+  isDev: boolean;
+}
+
+// 選択肢定義
+const COUNTRY_OPTIONS = [
+  { value: "us", label: "US (アメリカ)" },
+  { value: "jp", label: "JP (日本)" },
+  { value: "gb", label: "GB (イギリス)" },
+  { value: "de", label: "DE (ドイツ)" },
+  { value: "fr", label: "FR (フランス)" },
+  { value: "cn", label: "CN (中国)" },
+  { value: "kr", label: "KR (韓国)" },
+  { value: "in", label: "IN (インド)" },
+  { value: "au", label: "AU (オーストラリア)" },
+  { value: "ca", label: "CA (カナダ)" },
+];
+
+const CATEGORY_OPTIONS = [
+  { value: "business", label: "business (ビジネス)" },
+  { value: "technology", label: "technology (テクノロジー)" },
+  { value: "science", label: "science (科学)" },
+  { value: "health", label: "health (健康)" },
+  { value: "sports", label: "sports (スポーツ)" },
+  { value: "entertainment", label: "entertainment (エンタメ)" },
+  { value: "general", label: "general (一般)" },
+];
+
+const REGION_CODE_OPTIONS = [
+  { value: "JP", label: "JP (日本)" },
+  { value: "US", label: "US (アメリカ)" },
+  { value: "GB", label: "GB (イギリス)" },
+  { value: "DE", label: "DE (ドイツ)" },
+  { value: "FR", label: "FR (フランス)" },
+  { value: "KR", label: "KR (韓国)" },
+  { value: "IN", label: "IN (インド)" },
+];
+
+const VIDEO_CATEGORY_OPTIONS = [
+  { value: "0", label: "0 - 全体" },
+  { value: "1", label: "1 - 映画" },
+  { value: "10", label: "10 - 音楽" },
+  { value: "20", label: "20 - ゲーム" },
+  { value: "28", label: "28 - 科学技術" },
+  { value: "25", label: "25 - ニュース" },
+  { value: "17", label: "17 - スポーツ" },
+];
+
+const PLATFORM_OPTIONS = [
+  { value: "frontend-only", label: "frontend-only (フロントエンドのみ)" },
+  { value: "fullstack", label: "fullstack (フルスタック)" },
+  { value: "mobile-android", label: "mobile-android (Android)" },
+  { value: "mobile-ios", label: "mobile-ios (iOS)" },
+  { value: "mobile-cross", label: "mobile-cross (クロスプラットフォーム)" },
+];
+
+const BUDGET_OPTIONS = [
+  { value: "free", label: "free (0円)" },
+  { value: "low", label: "low (〜5千円/月)" },
+  { value: "moderate", label: "moderate (〜5万円/月)" },
+  { value: "high", label: "high (上限なし)" },
+];
+
+const DIFFICULTY_OPTIONS = [
+  { value: "easy", label: "easy (簡単)" },
+  { value: "medium", label: "medium (中級)" },
+  { value: "hard", label: "hard (上級)" },
+];
+
+const TEAM_SIZE_OPTIONS = [
+  { value: "solo", label: "solo (1人)" },
+  { value: "small", label: "small (2-3人)" },
+  { value: "medium", label: "medium (4-8人)" },
+  { value: "large", label: "large (9人以上)" },
+];
+
+const PERSPECTIVE_MODE_OPTIONS = [
+  { value: "single", label: "single (先頭1つのみ)" },
+  { value: "combine", label: "combine (複数を掛け合わせ)" },
+  { value: "random", label: "random (ランダム選択)" },
+];
+
+const PERSPECTIVE_ITEMS = [
+  { value: "kindness", label: "kindness", desc: "ユーザーに寄り添う優しいUX設計" },
+  { value: "cunning", label: "cunning", desc: "巧妙なマネタイズ・行動設計" },
+  { value: "frustration", label: "frustration", desc: "フラストレーション駆動の設計" },
+  { value: "dopamine", label: "dopamine", desc: "中毒性のある体験設計" },
+  { value: "target-focus", label: "target-focus", desc: "ターゲット層に特化した設計" },
+];
+
+const AGENT_ROLE_OPTIONS = [
+  { value: "researcher", desc: "トレンド・技術の外部調査" },
+  { value: "designer", desc: "アプリコンセプト案を提案" },
+  { value: "reviewer", desc: "要件の品質・完全性チェック" },
+  { value: "enhancer", desc: "レビュー結果に基づく要件の修正" },
+];
+
+// --- UI部品 ---
+
+function SectionHeader({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="mb-4">
+      <h2 className="text-base font-bold text-gray-100">{title}</h2>
+      <p className="text-xs text-gray-500 mt-0.5">{description}</p>
+    </div>
+  );
+}
+
+function FieldLabel({
+  label,
+  description,
+  htmlFor,
+}: {
+  label: string;
+  description: string;
+  htmlFor?: string;
+}) {
+  return (
+    <div className="mb-1.5">
+      <label htmlFor={htmlFor} className="text-sm font-medium text-gray-300">
+        {label}
+      </label>
+      <p className="text-[11px] text-gray-500 mt-0.5">{description}</p>
+    </div>
+  );
+}
+
+function Toggle({
+  checked,
+  onChange,
+  disabled,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      className={`relative inline-flex h-6 w-11 shrink-0 rounded-full transition-colors ${
+        checked ? "bg-indigo-500" : "bg-gray-700"
+      } ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+      onClick={() => !disabled && onChange(!checked)}
+    >
+      <span
+        className={`inline-block size-5 rounded-full bg-white shadow transform transition-transform mt-0.5 ${
+          checked ? "translate-x-5.5" : "translate-x-0.5"
+        }`}
+      />
+    </button>
+  );
+}
+
+function SelectField({
+  value,
+  options,
+  onChange,
+  disabled,
+  allowEmpty,
+  id,
+}: {
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (v: string) => void;
+  disabled?: boolean;
+  allowEmpty?: boolean;
+  id?: string;
+}) {
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      className="w-full px-3 py-1.5 text-sm bg-gray-800 border border-gray-700/50 rounded-lg text-gray-200 focus:outline-none focus:border-indigo-500/50 focus:ring-1 focus:ring-indigo-500/20 disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {allowEmpty && <option value="">未設定</option>}
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function NumberField({
+  value,
+  onChange,
+  disabled,
+  min,
+  max,
+  id,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+  disabled?: boolean;
+  min?: number;
+  max?: number;
+  id?: string;
+}) {
+  return (
+    <input
+      id={id}
+      type="number"
+      value={value}
+      onChange={(e) => onChange(Number(e.target.value))}
+      disabled={disabled}
+      min={min}
+      max={max}
+      className="w-full px-3 py-1.5 text-sm bg-gray-800 border border-gray-700/50 rounded-lg text-gray-200 focus:outline-none focus:border-indigo-500/50 focus:ring-1 focus:ring-indigo-500/20 disabled:opacity-50 disabled:cursor-not-allowed"
+    />
+  );
+}
+
+function TextField({
+  value,
+  onChange,
+  disabled,
+  placeholder,
+  id,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  id?: string;
+}) {
+  return (
+    <input
+      id={id}
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      placeholder={placeholder}
+      className="w-full px-3 py-1.5 text-sm bg-gray-800 border border-gray-700/50 rounded-lg text-gray-200 placeholder-gray-600 focus:outline-none focus:border-indigo-500/50 focus:ring-1 focus:ring-indigo-500/20 disabled:opacity-50 disabled:cursor-not-allowed"
+    />
+  );
+}
+
+function CheckboxGroup({
+  options,
+  selected,
+  onChange,
+  disabled,
+}: {
+  options: { value: string; desc: string }[];
+  selected: string[];
+  onChange: (values: string[]) => void;
+  disabled?: boolean;
+}) {
+  const toggle = (val: string) => {
+    if (disabled) return;
+    onChange(selected.includes(val) ? selected.filter((v) => v !== val) : [...selected, val]);
+  };
+  return (
+    <div className="space-y-1.5">
+      {options.map((o) => (
+        <label
+          key={o.value}
+          className={`flex items-center gap-2.5 px-3 py-2 rounded-lg border transition-colors ${
+            selected.includes(o.value)
+              ? "border-indigo-500/40 bg-indigo-500/10"
+              : "border-gray-700/30 bg-gray-800/50"
+          } ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:bg-gray-800/80"}`}
+        >
+          <input
+            type="checkbox"
+            checked={selected.includes(o.value)}
+            onChange={() => toggle(o.value)}
+            disabled={disabled}
+            className="accent-indigo-500"
+          />
+          <div>
+            <span className="text-sm text-gray-200 font-medium">{o.value}</span>
+            <span className="text-xs text-gray-500 ml-2">{o.desc}</span>
+          </div>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+// --- メインコンポーネント ---
+
+export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
+  const [config, setConfig] = useState<AppConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    fetchConfig()
+      .then(setConfig)
+      .finally(() => setLoading(false));
+  }, []);
+
+  const persistConfig = useCallback(
+    (updated: AppConfig) => {
+      setConfig(updated);
+      if (!isDev) return;
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(async () => {
+        setSaving(true);
+        try {
+          await saveConfig(updated);
+          setSaveMessage("保存しました");
+        } catch {
+          setSaveMessage("保存に失敗しました");
+        } finally {
+          setSaving(false);
+          setTimeout(() => setSaveMessage(null), 2000);
+        }
+      }, 400);
+    },
+    [isDev],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center text-gray-500 text-sm">
+        読み込み中...
+      </div>
+    );
+  }
+
+  if (!config) {
+    return (
+      <div className="flex h-full items-center justify-center text-gray-500 text-sm">
+        設定ファイルが見つかりません
+      </div>
+    );
+  }
+
+  const disabled = !isDev;
+
+  // ヘルパー: collect.sources の特定ソースを更新
+  const updateSource = (
+    sourceName: string,
+    updater: (
+      src: NonNullable<NonNullable<AppConfig["collect"]>["sources"]>[string],
+    ) => NonNullable<NonNullable<AppConfig["collect"]>["sources"]>[string],
+  ) => {
+    const sources = config.collect?.sources ?? {};
+    const src = sources[sourceName] ?? {};
+    persistConfig({
+      ...config,
+      collect: { ...config.collect, sources: { ...sources, [sourceName]: updater(src) } },
+    });
+  };
+
+  // ヘルパー: generate を更新
+  const updateGenerate = (patch: Partial<NonNullable<AppConfig["generate"]>>) => {
+    persistConfig({
+      ...config,
+      generate: { ...config.generate, ...patch },
+    });
+  };
+
+  // ヘルパー: generate.agents の特定エージェントを更新
+  const updateAgent = (
+    agentName: string,
+    updater: (
+      agent: NonNullable<NonNullable<AppConfig["generate"]>["agents"]>[string],
+    ) => NonNullable<NonNullable<AppConfig["generate"]>["agents"]>[string],
+  ) => {
+    const agents = config.generate?.agents ?? {};
+    const agent = agents[agentName] ?? {};
+    updateGenerate({ agents: { ...agents, [agentName]: updater(agent) } });
+  };
+
+  const newsapi = config.collect?.sources?.newsapi;
+  const youtube = config.collect?.sources?.youtube;
+  const constraints = config.generate?.constraints ?? {};
+  const perspectives = config.generate?.perspectives;
+  const agents = config.generate?.agents ?? {};
+
+  return (
+    <div className="h-full overflow-y-auto dark-scrollbar">
+      <div className={`${isMobile ? "px-4 py-6" : "px-8 py-8"} max-w-3xl mx-auto space-y-8`}>
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-lg font-bold text-gray-100">app.config.yaml</h1>
+            <p className="text-xs text-gray-500 mt-1">
+              アプリケーション設定の編集
+              {!isDev && "（読み取り専用 - dev modeで編集可能）"}
+            </p>
+          </div>
+          <AnimatePresence>
+            {(saving || saveMessage) && (
+              <motion.span
+                className={`text-xs px-3 py-1 rounded-full ${
+                  saving
+                    ? "bg-gray-800 text-gray-400"
+                    : saveMessage?.includes("失敗")
+                      ? "bg-red-500/20 text-red-400"
+                      : "bg-emerald-500/20 text-emerald-400"
+                }`}
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.9 }}
+              >
+                {saving ? "保存中..." : saveMessage}
+              </motion.span>
+            )}
+          </AnimatePresence>
+        </div>
+
+        {/* --- 共通設定 --- */}
+        <section className="rounded-xl border border-gray-800 bg-gray-900/50 p-5">
+          <SectionHeader title="共通設定" description="複数フェーズから参照される基本設定" />
+          <div>
+            <FieldLabel
+              label="output_base_dir"
+              description="生成データの出力先ベースディレクトリ"
+              htmlFor="output_base_dir"
+            />
+            <TextField
+              id="output_base_dir"
+              value={config.output_base_dir ?? "gen"}
+              onChange={(v) => persistConfig({ ...config, output_base_dir: v })}
+              disabled={disabled}
+              placeholder="gen"
+            />
+          </div>
+        </section>
+
+        {/* --- Collect フェーズ --- */}
+        <section className="rounded-xl border border-gray-800 bg-gray-900/50 p-5 space-y-6">
+          <SectionHeader
+            title="Collect フェーズ"
+            description="外部APIからトレンド情報を収集する設定"
+          />
+
+          {/* NewsAPI */}
+          <div className="rounded-lg border border-gray-800/50 bg-gray-800/30 p-4 space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-200">NewsAPI</h3>
+                <p className="text-[11px] text-gray-500">ニュースのトップヘッドラインを取得</p>
+              </div>
+              <Toggle
+                checked={newsapi?.enabled ?? false}
+                onChange={(v) => updateSource("newsapi", (s) => ({ ...s, enabled: v }))}
+                disabled={disabled}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <FieldLabel
+                  label="country"
+                  description="ニュースの取得対象国"
+                  htmlFor="newsapi-country"
+                />
+                <SelectField
+                  id="newsapi-country"
+                  value={String(newsapi?.params?.country ?? "us")}
+                  options={COUNTRY_OPTIONS}
+                  onChange={(v) =>
+                    updateSource("newsapi", (s) => ({
+                      ...s,
+                      params: { ...s.params, country: v },
+                    }))
+                  }
+                  disabled={disabled}
+                />
+              </div>
+              <div>
+                <FieldLabel
+                  label="category"
+                  description="ニュースのカテゴリ"
+                  htmlFor="newsapi-category"
+                />
+                <SelectField
+                  id="newsapi-category"
+                  value={String(newsapi?.params?.category ?? "business")}
+                  options={CATEGORY_OPTIONS}
+                  onChange={(v) =>
+                    updateSource("newsapi", (s) => ({
+                      ...s,
+                      params: { ...s.params, category: v },
+                    }))
+                  }
+                  disabled={disabled}
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <FieldLabel
+                  label="pageSize"
+                  description="取得する記事数（最大100）"
+                  htmlFor="newsapi-pagesize"
+                />
+                <NumberField
+                  id="newsapi-pagesize"
+                  value={Number(newsapi?.params?.pageSize ?? 20)}
+                  onChange={(v) =>
+                    updateSource("newsapi", (s) => ({
+                      ...s,
+                      params: { ...s.params, pageSize: v },
+                    }))
+                  }
+                  disabled={disabled}
+                  min={1}
+                  max={100}
+                />
+              </div>
+              <div>
+                <FieldLabel
+                  label="output_file"
+                  description="出力ファイル名"
+                  htmlFor="newsapi-output"
+                />
+                <TextField
+                  id="newsapi-output"
+                  value={newsapi?.output_file ?? "news.json"}
+                  onChange={(v) => updateSource("newsapi", (s) => ({ ...s, output_file: v }))}
+                  disabled={disabled}
+                />
+              </div>
+            </div>
+            <div>
+              <FieldLabel
+                label="api_key_env"
+                description="APIキーの環境変数名（.envに定義）"
+                htmlFor="newsapi-apikey"
+              />
+              <TextField
+                id="newsapi-apikey"
+                value={newsapi?.api_key_env ?? "NEWS_API_KEY"}
+                onChange={(v) => updateSource("newsapi", (s) => ({ ...s, api_key_env: v }))}
+                disabled={disabled}
+              />
+            </div>
+          </div>
+
+          {/* YouTube */}
+          <div className="rounded-lg border border-gray-800/50 bg-gray-800/30 p-4 space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-200">YouTube Data API</h3>
+                <p className="text-[11px] text-gray-500">人気動画ランキングを取得</p>
+              </div>
+              <Toggle
+                checked={youtube?.enabled ?? false}
+                onChange={(v) => updateSource("youtube", (s) => ({ ...s, enabled: v }))}
+                disabled={disabled}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <FieldLabel
+                  label="regionCode"
+                  description="動画の取得対象地域"
+                  htmlFor="youtube-region"
+                />
+                <SelectField
+                  id="youtube-region"
+                  value={String(youtube?.params?.regionCode ?? "JP")}
+                  options={REGION_CODE_OPTIONS}
+                  onChange={(v) =>
+                    updateSource("youtube", (s) => ({
+                      ...s,
+                      params: { ...s.params, regionCode: v },
+                    }))
+                  }
+                  disabled={disabled}
+                />
+              </div>
+              <div>
+                <FieldLabel
+                  label="videoCategoryId"
+                  description="動画カテゴリ"
+                  htmlFor="youtube-category"
+                />
+                <SelectField
+                  id="youtube-category"
+                  value={String(youtube?.params?.videoCategoryId ?? "0")}
+                  options={VIDEO_CATEGORY_OPTIONS}
+                  onChange={(v) =>
+                    updateSource("youtube", (s) => ({
+                      ...s,
+                      params: { ...s.params, videoCategoryId: v },
+                    }))
+                  }
+                  disabled={disabled}
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <FieldLabel
+                  label="maxResults"
+                  description="取得する動画数（最大50）"
+                  htmlFor="youtube-maxresults"
+                />
+                <NumberField
+                  id="youtube-maxresults"
+                  value={Number(youtube?.params?.maxResults ?? 20)}
+                  onChange={(v) =>
+                    updateSource("youtube", (s) => ({
+                      ...s,
+                      params: { ...s.params, maxResults: v },
+                    }))
+                  }
+                  disabled={disabled}
+                  min={1}
+                  max={50}
+                />
+              </div>
+              <div>
+                <FieldLabel
+                  label="output_file"
+                  description="出力ファイル名"
+                  htmlFor="youtube-output"
+                />
+                <TextField
+                  id="youtube-output"
+                  value={youtube?.output_file ?? "youtube.json"}
+                  onChange={(v) => updateSource("youtube", (s) => ({ ...s, output_file: v }))}
+                  disabled={disabled}
+                />
+              </div>
+            </div>
+            <div>
+              <FieldLabel
+                label="api_key_env"
+                description="APIキーの環境変数名（.envに定義）"
+                htmlFor="youtube-apikey"
+              />
+              <TextField
+                id="youtube-apikey"
+                value={youtube?.api_key_env ?? "YOUTUBE_API_KEY"}
+                onChange={(v) => updateSource("youtube", (s) => ({ ...s, api_key_env: v }))}
+                disabled={disabled}
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* --- Generate フェーズ --- */}
+        <section className="rounded-xl border border-gray-800 bg-gray-900/50 p-5 space-y-6">
+          <SectionHeader
+            title="Generate フェーズ"
+            description="キーワードからアプリ案を生成する際の制約・観点を設定"
+          />
+
+          {/* Constraints */}
+          <div className="rounded-lg border border-gray-800/50 bg-gray-800/30 p-4 space-y-4">
+            <h3 className="text-sm font-semibold text-gray-200">制約条件 (constraints)</h3>
+            <p className="text-[11px] text-gray-500">
+              生成されるアプリ案の技術構成・規模を制御。未設定の項目はAIが自由に判断
+            </p>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <FieldLabel
+                  label="platform"
+                  description="対象プラットフォーム"
+                  htmlFor="constraints-platform"
+                />
+                <SelectField
+                  id="constraints-platform"
+                  value={constraints.platform ?? ""}
+                  options={PLATFORM_OPTIONS}
+                  onChange={(v) =>
+                    updateGenerate({
+                      constraints: v
+                        ? { ...constraints, platform: v }
+                        : (() => {
+                            const { platform: _, ...rest } = constraints;
+                            return rest;
+                          })(),
+                    })
+                  }
+                  disabled={disabled}
+                  allowEmpty
+                />
+              </div>
+              <div>
+                <FieldLabel
+                  label="budget"
+                  description="月額予算の目安"
+                  htmlFor="constraints-budget"
+                />
+                <SelectField
+                  id="constraints-budget"
+                  value={constraints.budget ?? ""}
+                  options={BUDGET_OPTIONS}
+                  onChange={(v) =>
+                    updateGenerate({
+                      constraints: v
+                        ? { ...constraints, budget: v }
+                        : (() => {
+                            const { budget: _, ...rest } = constraints;
+                            return rest;
+                          })(),
+                    })
+                  }
+                  disabled={disabled}
+                  allowEmpty
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <FieldLabel
+                  label="difficulty"
+                  description="開発難易度"
+                  htmlFor="constraints-difficulty"
+                />
+                <SelectField
+                  id="constraints-difficulty"
+                  value={constraints.difficulty ?? ""}
+                  options={DIFFICULTY_OPTIONS}
+                  onChange={(v) =>
+                    updateGenerate({
+                      constraints: v
+                        ? { ...constraints, difficulty: v }
+                        : (() => {
+                            const { difficulty: _, ...rest } = constraints;
+                            return rest;
+                          })(),
+                    })
+                  }
+                  disabled={disabled}
+                  allowEmpty
+                />
+              </div>
+              <div>
+                <FieldLabel
+                  label="team_size"
+                  description="チーム規模"
+                  htmlFor="constraints-teamsize"
+                />
+                <SelectField
+                  id="constraints-teamsize"
+                  value={constraints.team_size ?? ""}
+                  options={TEAM_SIZE_OPTIONS}
+                  onChange={(v) =>
+                    updateGenerate({
+                      constraints: v
+                        ? { ...constraints, team_size: v }
+                        : (() => {
+                            const { team_size: _, ...rest } = constraints;
+                            return rest;
+                          })(),
+                    })
+                  }
+                  disabled={disabled}
+                  allowEmpty
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Perspectives */}
+          <div className="rounded-lg border border-gray-800/50 bg-gray-800/30 p-4 space-y-4">
+            <h3 className="text-sm font-semibold text-gray-200">生成観点 (perspectives)</h3>
+            <p className="text-[11px] text-gray-500">
+              アプリ案の体験設計・マネタイズ戦略の方向性を指定
+            </p>
+            <div>
+              <FieldLabel label="mode" description="観点の適用モード" htmlFor="perspectives-mode" />
+              <SelectField
+                id="perspectives-mode"
+                value={perspectives?.mode ?? ""}
+                options={PERSPECTIVE_MODE_OPTIONS}
+                onChange={(v) =>
+                  updateGenerate({
+                    perspectives: v ? { ...perspectives, mode: v } : undefined,
+                  })
+                }
+                disabled={disabled}
+                allowEmpty
+              />
+            </div>
+            {perspectives?.mode && perspectives.mode !== "random" && (
+              <div>
+                <FieldLabel label="items" description="適用する観点を選択" />
+                <CheckboxGroup
+                  options={PERSPECTIVE_ITEMS}
+                  selected={perspectives?.items ?? []}
+                  onChange={(items) => updateGenerate({ perspectives: { ...perspectives, items } })}
+                  disabled={disabled}
+                />
+              </div>
+            )}
+            {perspectives?.mode === "random" && (
+              <p className="text-xs text-gray-500 italic px-1">
+                random モードではランダムに1〜3個の観点が自動選択されます（items は無視）
+              </p>
+            )}
+          </div>
+
+          {/* Agents */}
+          <div className="rounded-lg border border-gray-800/50 bg-gray-800/30 p-4 space-y-4">
+            <h3 className="text-sm font-semibold text-gray-200">マルチエージェント (agents)</h3>
+            <p className="text-[11px] text-gray-500">
+              要件生成の各フェーズで活用するエージェントの設定
+            </p>
+
+            {Object.entries(agents).map(([name, agent]) => (
+              <div
+                key={name}
+                className="rounded-lg border border-gray-700/30 bg-gray-900/50 p-4 space-y-3"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h4 className="text-sm font-semibold text-gray-200 capitalize">{name}</h4>
+                    {agent.model && (
+                      <span className="text-[11px] text-gray-500">model: {agent.model}</span>
+                    )}
+                  </div>
+                  <Toggle
+                    checked={agent.enabled ?? false}
+                    onChange={(v) => updateAgent(name, (a) => ({ ...a, enabled: v }))}
+                    disabled={disabled}
+                  />
+                </div>
+                <div>
+                  <FieldLabel
+                    label="model"
+                    description="使用するモデル名"
+                    htmlFor={`agent-${name}-model`}
+                  />
+                  <TextField
+                    id={`agent-${name}-model`}
+                    value={agent.model ?? ""}
+                    onChange={(v) => updateAgent(name, (a) => ({ ...a, model: v }))}
+                    disabled={disabled}
+                    placeholder="例: o4-mini, gemini-2.5-pro"
+                  />
+                </div>
+                <div>
+                  <FieldLabel label="roles" description="割り当てる役割" />
+                  <CheckboxGroup
+                    options={AGENT_ROLE_OPTIONS}
+                    selected={agent.roles ?? []}
+                    onChange={(roles) => updateAgent(name, (a) => ({ ...a, roles }))}
+                    disabled={disabled}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* --- Pipeline --- */}
+        <section className="rounded-xl border border-gray-800 bg-gray-900/50 p-5">
+          <SectionHeader title="Pipeline" description="パイプライン共通の設定" />
+          <div>
+            <FieldLabel
+              label="default_source"
+              description="デフォルトのdata_sourceディレクトリ名（空欄で最新を自動検出）"
+              htmlFor="pipeline-source"
+            />
+            <TextField
+              id="pipeline-source"
+              value={config.pipeline?.default_source ?? ""}
+              onChange={(v) =>
+                persistConfig({
+                  ...config,
+                  pipeline: v ? { ...config.pipeline, default_source: v } : undefined,
+                })
+              }
+              disabled={disabled}
+              placeholder="例: 2026_02_10_01_54_10（空欄で自動検出）"
+            />
+          </div>
+        </section>
+
+        {/* spacer */}
+        <div className="h-8" />
+      </div>
+    </div>
+  );
+}

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -11,10 +11,11 @@ interface SidebarProps {
   isMobile: boolean;
   mobileOpen: boolean;
   onMobileClose: () => void;
-  viewMode: "apps" | "datasets" | "favorites" | "commands";
+  viewMode: "apps" | "datasets" | "favorites" | "commands" | "config";
   onSelectDatasets: () => void;
   onSelectFavorites: () => void;
   onSelectCommands: () => void;
+  onSelectConfig: () => void;
   onSearch: (query: string, tags: string[]) => void;
   onClearSearch: () => void;
   isSearchActive: boolean;
@@ -230,6 +231,7 @@ export function Sidebar({
   onSelectDatasets,
   onSelectFavorites,
   onSelectCommands,
+  onSelectConfig,
   onSearch,
   onClearSearch,
   isSearchActive,
@@ -314,6 +316,31 @@ export function Sidebar({
                         strokeLinejoin="round"
                         strokeWidth={2}
                         d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                      viewMode === "config"
+                        ? "text-gray-300 bg-gray-700/50"
+                        : "text-gray-500 hover:text-gray-300 hover:bg-gray-700/30"
+                    }`}
+                    onClick={onSelectConfig}
+                    title="設定"
+                  >
+                    <svg
+                      className="size-5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28ZM15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
                       />
                     </svg>
                   </button>
@@ -537,6 +564,33 @@ export function Sidebar({
                   strokeLinejoin="round"
                   strokeWidth={2}
                   d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"
+                />
+              </svg>
+            </motion.button>
+            <motion.button
+              type="button"
+              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                viewMode === "config"
+                  ? "text-gray-300 bg-gray-700/50"
+                  : "text-gray-500 hover:text-gray-300 hover:bg-gray-700/30"
+              }`}
+              onClick={onSelectConfig}
+              title="設定"
+              animate={{ opacity: expanded ? 1 : 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              <svg
+                className="size-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28ZM15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
                 />
               </svg>
             </motion.button>


### PR DESCRIPTION
## Summary

app.config.yaml をViewer上で閲覧・編集できる設定ページを追加。

Closes #60

## Changes

- `GET /api/config` / `PUT /api/config` エンドポイント追加（PUTはdev modeのみ）
- `fetchConfig()` / `saveConfig()` クライアントAPI関数追加
- `ConfigEditor` コンポーネント新規作成
  - YAML階層構造をそのまま画面セクションに反映
  - 各項目に説明文を付与
  - `enabled` はトグルスイッチ、`country`/`category`/`platform`/`budget`等は選択肢ベース
  - テキスト入力は必要最小限（`api_key_env`、`output_file`等）
  - 変更時にデバウンス(400ms)で即時YAML保存
- `ViewMode` に `"config"` 追加、URL対応（`?view=config`）
- サイドバーに歯車アイコンの設定ボタン追加（デスクトップ/モバイル両対応）

## Test plan

- [ ] `pnpm viewer` でdev server起動
- [ ] サイドバーの歯車アイコンクリックで設定ページ表示
- [ ] 各セクション（共通設定、Collect、Generate、Pipeline）が表示される
- [ ] 選択肢フィールド（country, category, platform, budget等）がドロップダウンで動作
- [ ] トグルスイッチ（enabled）が動作
- [ ] 値変更後にapp.config.yamlに即時反映される
- [ ] ブラウザバック/フォワードが正常動作（`?view=config`）
- [ ] モバイル表示でも正常にレイアウトされる
- [ ] 本番モード（production）では読み取り専用表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)