### PR TITLE
feat: 要件生成時に設定ファイルをディレクトリに含める

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -45,6 +45,21 @@ RESEARCH_CONTEXT="${TMPDIR_AGENTS}/research_context.md"
 DESIGN_CONTEXT="${TMPDIR_AGENTS}/design_context.md"
 REVIEW_RESULT="${TMPDIR_AGENTS}/review_result.md"
 
+# 新規生成されたアプリにapp.config.yamlをコピー
+copy_config_to_new_apps() {
+  local apps_after
+  apps_after=$(ls -1 "${REQUIREMENTS_DIR}" 2>/dev/null || true)
+  local new_apps
+  new_apps=$(comm -13 <(echo "$APPS_BEFORE" | sort) <(echo "$apps_after" | sort) 2>/dev/null || true)
+
+  if [[ -n "$new_apps" ]]; then
+    for app_name in $new_apps; do
+      cp "$CONFIG_FILE" "${REQUIREMENTS_DIR}/${app_name}/_config.yaml"
+      echo "  設定ファイルをコピー: ${app_name}/_config.yaml"
+    done
+  fi
+}
+
 # --- 引数処理 ---
 TARGET_DIR=""
 DATASET_SOURCE=""
@@ -96,6 +111,9 @@ trap 'rm -rf "$TMPDIR_AGENTS" "$PROMPT_FILE"' EXIT
 
 create_prompt_file "$PROMPT_FILE"
 
+# --- 生成前のアプリ一覧を記録（新規アプリ検出用、全モード共通） ---
+APPS_BEFORE=$(ls -1 "${REQUIREMENTS_DIR}" 2>/dev/null || true)
+
 # =============================================================================
 # データセットモード
 # =============================================================================
@@ -125,6 +143,7 @@ tsx scripts/validate-requirements.ts <生成したapp_name>"
     --append-system-prompt-file "$PROMPT_FILE" \
     --allowedTools "Read" "Write" "Glob" "Bash(mkdir:*)" "Bash(find:*)" "Bash(tsx:*)"
 
+  copy_config_to_new_apps
   exit 0
 fi
 
@@ -218,6 +237,7 @@ tsx scripts/validate-requirements.ts <生成したapp_name>"
     --append-system-prompt-file "$PROMPT_FILE" \
     --allowedTools "Read" "Write" "Glob" "Bash(mkdir:*)" "Bash(find:*)" "Bash(tsx:*)"
 
+  copy_config_to_new_apps
   exit 0
 fi
 
@@ -363,6 +383,7 @@ run_interruptible claude -p "$PROMPT" \
   --append-system-prompt-file "$PROMPT_FILE" \
   --allowedTools "Read" "Write" "Glob" "Bash(mkdir:*)" "Bash(find:*)" "Bash(tsx:*)"
 
+copy_config_to_new_apps
 echo ""
 
 # =============================================================================

--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -213,6 +213,13 @@ app.get("/api/apps/:name/source-info", (c) => {
   return c.json(info);
 });
 
+app.get("/api/apps/:name/config", (c) => {
+  const name = c.req.param("name");
+  const configPath = join(REQUIREMENTS_DIR, name, "_config.yaml");
+  if (!existsSync(configPath)) return c.json({ error: "Not found" }, 404);
+  return c.json({ content: readFileSync(configPath, "utf-8") });
+});
+
 app.get("/api/tags", (c) => {
   const tagsPath = resolve(projectRoot, "gen", "tags.json");
   if (!existsSync(tagsPath)) return c.json([]);

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -59,6 +59,12 @@ export async function fetchSourceInfo(appName: string): Promise<SourceInfo> {
   return res.json();
 }
 
+export async function fetchAppGenerationConfig(appName: string): Promise<MarkdownContent | null> {
+  const res = await fetch(`${BASE}/apps/${appName}/config`);
+  if (!res.ok) return null;
+  return res.json();
+}
+
 export async function fetchTags(): Promise<string[]> {
   const res = await fetch(`${BASE}/tags`);
   return res.json();

--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -527,6 +527,7 @@ export function AppView({
                   >
                     <SourceInfoView
                       info={sourceInfo}
+                      configYaml={configYaml}
                       onNavigateToDataset={onNavigateToDataset}
                       onNavigateToApp={onNavigateToApp}
                     />

--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -6,6 +6,7 @@ import {
   type DiagramFile,
   type FavoriteItem,
   type Feature,
+  fetchAppGenerationConfig,
   fetchDiagrams,
   fetchFavorites,
   fetchFeatureDetail,
@@ -59,6 +60,7 @@ export function AppView({
 }) {
   const [overview, setOverview] = useState("");
   const [sourceInfo, setSourceInfo] = useState<SourceInfo | null>(null);
+  const [configYaml, setConfigYaml] = useState<string | null>(null);
   const [diagrams, setDiagrams] = useState<DiagramFile[]>([]);
   const [features, setFeatures] = useState<Feature[]>([]);
   const [featureContent, setFeatureContent] = useState("");
@@ -124,6 +126,9 @@ export function AppView({
       fetchSourceInfo(appName)
         .then((r) => setSourceInfo(r))
         .catch(() => setSourceInfo(null)),
+      fetchAppGenerationConfig(appName)
+        .then((r) => setConfigYaml(r?.content ?? null))
+        .catch(() => setConfigYaml(null)),
       fetchDiagrams(appName)
         .then(setDiagrams)
         .catch(() => setDiagrams([])),
@@ -366,6 +371,7 @@ export function AppView({
                 >
                   <SourceInfoView
                     info={sourceInfo}
+                    configYaml={configYaml}
                     onNavigateToDataset={onNavigateToDataset}
                     onNavigateToApp={onNavigateToApp}
                   />
@@ -762,10 +768,12 @@ export function AppView({
 
 function SourceInfoView({
   info,
+  configYaml,
   onNavigateToDataset,
   onNavigateToApp,
 }: {
   info: SourceInfo | null;
+  configYaml?: string | null;
   onNavigateToDataset?: (datasetName: string) => void;
   onNavigateToApp?: (appName: string) => void;
 }) {
@@ -920,6 +928,18 @@ function SourceInfoView({
             生成の経緯
           </h3>
           <p className="text-sm text-gray-300 leading-relaxed">{info.description}</p>
+        </section>
+      )}
+
+      {/* Config */}
+      {configYaml && (
+        <section>
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+            生成時の設定
+          </h3>
+          <pre className="p-3 rounded-lg bg-gray-800/50 border border-gray-700/30 text-xs text-gray-300 overflow-x-auto whitespace-pre leading-relaxed">
+            {configYaml}
+          </pre>
         </section>
       )}
     </div>


### PR DESCRIPTION
## Summary

要件生成時に`app.config.yaml`を各アプリディレクトリに`_config.yaml`としてコピーし、Viewerから生成時の設定を確認できるようにしました。

Closes #5

## Changes

- `scripts/generate.sh`: 全モード（通常/ダイレクト/データセット）で生成後に`app.config.yaml`を`_config.yaml`としてコピーする`copy_config_to_new_apps`関数を追加
- `viewer/server.ts`: `GET /api/apps/:name/config` エンドポイント追加
- `viewer/src/api.ts`: `fetchAppGenerationConfig` 関数追加
- `viewer/src/components/AppView.tsx`: `SourceInfoView` に「生成時の設定」セクション追加（YAMLそのまま表示）

## Test plan

- [ ] `pnpm generate` で新規要件を生成し、`gen/requirements/{app_name}/_config.yaml` が作成されることを確認
- [ ] `pnpm viewer` でViewerを起動し、Source Infoタブに「生成時の設定」セクションが表示されることを確認
- [ ] `_config.yaml` が存在しないアプリではセクションが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)