### PR TITLE
feat: pipeline, generateの完了時にSlack通知を送信

### DIFF
--- a/SLACK_NOTIFICATION.md
+++ b/SLACK_NOTIFICATION.md
@@ -27,7 +27,7 @@
 `.env` ファイルに以下を追加:
 
 ```env
-SLACK_BOT_TOKEN=xoxb-your-bot-token
+SLACK_BOT_USER_OAUTH_TOKEN=xoxb-your-bot-token
 ```
 
 ### 3. 設定ファイルの確認
@@ -38,7 +38,7 @@ SLACK_BOT_TOKEN=xoxb-your-bot-token
 notifications:
   slack:
     enabled: true
-    token_env: SLACK_BOT_TOKEN
+    token_env: SLACK_BOT_USER_OAUTH_TOKEN
 ```
 
 ## 設定項目
@@ -46,7 +46,7 @@ notifications:
 | 項目 | 説明 | デフォルト |
 |------|------|-----------|
 | `enabled` | Slack通知の有効/無効 | `true` |
-| `token_env` | Bot Tokenを格納する環境変数名 | `SLACK_BOT_TOKEN` |
+| `token_env` | Bot Tokenを格納する環境変数名 | `SLACK_BOT_USER_OAUTH_TOKEN` |
 
 ## 通知タイミング
 
@@ -88,7 +88,7 @@ notifications:
 
 ### 通知が届かない場合
 
-1. `.env` の `SLACK_BOT_TOKEN` が正しく設定されているか確認
+1. `.env` の `SLACK_BOT_USER_OAUTH_TOKEN` が正しく設定されているか確認
 2. `app.config.yaml` の `notifications.slack.enabled` が `true` か確認
 3. Appが `#requirements_notify` チャンネルに招待されているか確認
 4. Bot Token Scopesに `chat:write` が含まれているか確認
@@ -99,7 +99,7 @@ notifications:
 
 ```bash
 curl -X POST 'https://slack.com/api/chat.postMessage' \
-  -d "token=$SLACK_BOT_TOKEN" \
+  -d "token=$SLACK_BOT_USER_OAUTH_TOKEN" \
   -d 'channel=#requirements_notify' \
   -d 'text=テスト通知'
 ```

--- a/SLACK_NOTIFICATION.md
+++ b/SLACK_NOTIFICATION.md
@@ -2,6 +2,8 @@
 
 `pipeline` および `generate` の完了時にSlackへ通知を送信する機能です。
 
+通知先チャンネル: `#requirements_notify`
+
 ## 前提条件
 
 - Slackワークスペースへのアクセス権限
@@ -9,42 +11,42 @@
 
 ## セットアップ手順
 
-### 1. Slack Appの作成とIncoming Webhookの取得
+### 1. Slack Appの作成とBot Tokenの取得
 
 1. [Slack API](https://api.slack.com/apps) にアクセス
 2. **Create New App** → **From scratch** を選択
 3. App名（例: `Requirements Creator`）とワークスペースを指定して作成
-4. 左メニューの **Incoming Webhooks** をクリック
-5. **Activate Incoming Webhooks** をONにする
-6. **Add New Webhook to Workspace** をクリック
-7. 通知先のチャンネルを選択して **Allow**
-8. 生成された **Webhook URL** をコピー
+4. 左メニューの **OAuth & Permissions** をクリック
+5. **Scopes** → **Bot Token Scopes** に `chat:write` を追加
+6. ページ上部の **Install to Workspace** をクリックして承認
+7. 表示された **Bot User OAuth Token**（`xoxb-` で始まる）をコピー
+8. 通知先チャンネル `#requirements_notify` にAppを招待（チャンネル内で `/invite @AppName`）
 
 ### 2. 環境変数の設定
 
 `.env` ファイルに以下を追加:
 
 ```env
-SLACK_WEBHOOK_URL=<your-slack-webhook-url>
+SLACK_BOT_TOKEN=xoxb-your-bot-token
 ```
 
-### 3. 設定ファイルの有効化
+### 3. 設定ファイルの確認
 
-`app.config.yaml` の `notifications.slack.enabled` を `true` に変更:
+`app.config.yaml` の `notifications.slack` が以下のようになっていることを確認:
 
 ```yaml
 notifications:
   slack:
     enabled: true
-    webhook_url_env: SLACK_WEBHOOK_URL
+    token_env: SLACK_BOT_TOKEN
 ```
 
 ## 設定項目
 
 | 項目 | 説明 | デフォルト |
 |------|------|-----------|
-| `enabled` | Slack通知の有効/無効 | `false` |
-| `webhook_url_env` | Webhook URLを格納する環境変数名 | `SLACK_WEBHOOK_URL` |
+| `enabled` | Slack通知の有効/無効 | `true` |
+| `token_env` | Bot Tokenを格納する環境変数名 | `SLACK_BOT_TOKEN` |
 
 ## 通知タイミング
 
@@ -61,13 +63,12 @@ notifications:
 
 ```
 ✅ パイプライン完了
-───────────────
-ステップ結果:
+
   ✅ collect
   ✅ extract
   ✅ generate
   ✅ validate
-───────────────
+
 記事数: 20
 キーワード数: 15
 生成アプリ: my-awesome-app
@@ -77,8 +78,7 @@ notifications:
 
 ```
 ⚠️ パイプライン一部失敗
-───────────────
-ステップ結果:
+
   ✅ collect
   ✅ extract
   ❌ generate
@@ -88,16 +88,18 @@ notifications:
 
 ### 通知が届かない場合
 
-1. `.env` の `SLACK_WEBHOOK_URL` が正しく設定されているか確認
+1. `.env` の `SLACK_BOT_TOKEN` が正しく設定されているか確認
 2. `app.config.yaml` の `notifications.slack.enabled` が `true` か確認
-3. Webhook URLの有効期限が切れていないか確認（Slack Appの設定画面で確認）
+3. Appが `#requirements_notify` チャンネルに招待されているか確認
+4. Bot Token Scopesに `chat:write` が含まれているか確認
 
-### Webhook URLのテスト
+### Bot Tokenのテスト
 
 以下のコマンドで直接テスト可能:
 
 ```bash
-curl -X POST -H 'Content-type: application/json' \
-  --data '{"text":"テスト通知"}' \
-  $SLACK_WEBHOOK_URL
+curl -X POST 'https://slack.com/api/chat.postMessage' \
+  -d "token=$SLACK_BOT_TOKEN" \
+  -d 'channel=#requirements_notify' \
+  -d 'text=テスト通知'
 ```

--- a/SLACK_NOTIFICATION.md
+++ b/SLACK_NOTIFICATION.md
@@ -1,0 +1,103 @@
+# Slack通知セットアップ
+
+`pipeline` および `generate` の完了時にSlackへ通知を送信する機能です。
+
+## 前提条件
+
+- Slackワークスペースへのアクセス権限
+- Slack Appの作成権限（または管理者への依頼）
+
+## セットアップ手順
+
+### 1. Slack Appの作成とIncoming Webhookの取得
+
+1. [Slack API](https://api.slack.com/apps) にアクセス
+2. **Create New App** → **From scratch** を選択
+3. App名（例: `Requirements Creator`）とワークスペースを指定して作成
+4. 左メニューの **Incoming Webhooks** をクリック
+5. **Activate Incoming Webhooks** をONにする
+6. **Add New Webhook to Workspace** をクリック
+7. 通知先のチャンネルを選択して **Allow**
+8. 生成された **Webhook URL** をコピー
+
+### 2. 環境変数の設定
+
+`.env` ファイルに以下を追加:
+
+```env
+SLACK_WEBHOOK_URL=<your-slack-webhook-url>
+```
+
+### 3. 設定ファイルの有効化
+
+`app.config.yaml` の `notifications.slack.enabled` を `true` に変更:
+
+```yaml
+notifications:
+  slack:
+    enabled: true
+    webhook_url_env: SLACK_WEBHOOK_URL
+```
+
+## 設定項目
+
+| 項目 | 説明 | デフォルト |
+|------|------|-----------|
+| `enabled` | Slack通知の有効/無効 | `false` |
+| `webhook_url_env` | Webhook URLを格納する環境変数名 | `SLACK_WEBHOOK_URL` |
+
+## 通知タイミング
+
+| タイミング | コマンド | 通知内容 |
+|-----------|---------|---------|
+| パイプライン完了時 | `pnpm pipeline` | 各ステップの成否、生成アプリ名、記事数・キーワード数 |
+| 要件生成完了時 | `pnpm generate` | 生成完了、新規アプリ名 |
+
+**注意**: `pnpm pipeline` 経由で `generate` が実行された場合、パイプライン側でまとめて通知されます（二重通知なし）。
+
+## 通知メッセージ例
+
+### パイプライン完了時
+
+```
+✅ パイプライン完了
+───────────────
+ステップ結果:
+  ✅ collect
+  ✅ extract
+  ✅ generate
+  ✅ validate
+───────────────
+記事数: 20
+キーワード数: 15
+生成アプリ: my-awesome-app
+```
+
+### 一部失敗時
+
+```
+⚠️ パイプライン一部失敗
+───────────────
+ステップ結果:
+  ✅ collect
+  ✅ extract
+  ❌ generate
+```
+
+## トラブルシューティング
+
+### 通知が届かない場合
+
+1. `.env` の `SLACK_WEBHOOK_URL` が正しく設定されているか確認
+2. `app.config.yaml` の `notifications.slack.enabled` が `true` か確認
+3. Webhook URLの有効期限が切れていないか確認（Slack Appの設定画面で確認）
+
+### Webhook URLのテスト
+
+以下のコマンドで直接テスト可能:
+
+```bash
+curl -X POST -H 'Content-type: application/json' \
+  --data '{"text":"テスト通知"}' \
+  $SLACK_WEBHOOK_URL
+```

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -59,7 +59,7 @@ notifications:
     # Bot Tokenの環境変数名（.envに定義）
     # Slack Appの OAuth & Permissions で取得した xoxb- トークンを設定する
     # 詳細は SLACK_NOTIFICATION.md を参照
-    token_env: SLACK_BOT_TOKEN
+    token_env: SLACK_BOT_USER_OAUTH_TOKEN
 
 # --- パイプライン共通設定 ---
 pipeline:

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -55,11 +55,11 @@ collect:
 # --- 通知設定 ---
 notifications:
   slack:
-    enabled: false
-    # Webhook URLの環境変数名（.envに定義）
-    # Slack Appの Incoming Webhooks で取得したURLを設定する
+    enabled: true
+    # Bot Tokenの環境変数名（.envに定義）
+    # Slack Appの OAuth & Permissions で取得した xoxb- トークンを設定する
     # 詳細は SLACK_NOTIFICATION.md を参照
-    webhook_url_env: SLACK_WEBHOOK_URL
+    token_env: SLACK_BOT_TOKEN
 
 # --- パイプライン共通設定 ---
 pipeline:

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -52,6 +52,15 @@ collect:
 #       url: https://techcrunch.com/feed/
 #   output_file: rss.json
 
+# --- 通知設定 ---
+notifications:
+  slack:
+    enabled: false
+    # Webhook URLの環境変数名（.envに定義）
+    # Slack Appの Incoming Webhooks で取得したURLを設定する
+    # 詳細は SLACK_NOTIFICATION.md を参照
+    webhook_url_env: SLACK_WEBHOOK_URL
+
 # --- パイプライン共通設定 ---
 pipeline:
   # デフォルトで使用する data_source サブディレクトリ名

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -60,6 +60,8 @@ notifications:
     # Slack Appの OAuth & Permissions で取得した xoxb- トークンを設定する
     # 詳細は SLACK_NOTIFICATION.md を参照
     token_env: SLACK_BOT_USER_OAUTH_TOKEN
+    # Viewerへのリンク生成用ホスト（通知メッセージにアプリへのリンクを含める）
+    viewer_host: http://localhost:3001
 
 # --- パイプライン共通設定 ---
 pipeline:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "pipeline": "tsx scripts/pipeline.ts",
     "format": "biome format --write .",
     "lint": "biome lint .",
-    "check": "biome check --write ."
+    "check": "biome check --write .",
+    "test:slack": "tsx scripts/test-slack-notify.ts"
   },
   "packageManager": "pnpm@10.28.0",
   "devDependencies": {

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -385,3 +385,14 @@ if can_run_role "reviewer"; then
 fi
 
 echo "=== 要件生成完了 ==="
+
+# --- Slack通知 ---
+# pipeline.ts 経由の場合はそちらで通知するため、ここでは generate 単体実行時のみ通知
+if [[ -z "${PIPELINE_MODE:-}" ]]; then
+  # 新規アプリを検出（reviewer実行済みの場合は再利用、未実行の場合は検出）
+  if [[ -z "${NEW_APPS:-}" ]]; then
+    APPS_AFTER_NOTIFY=$(ls -1 "${REQUIREMENTS_DIR}" 2>/dev/null || true)
+    NEW_APPS=$(comm -13 <(echo "$APPS_BEFORE" | sort) <(echo "$APPS_AFTER_NOTIFY" | sort) 2>/dev/null || true)
+  fi
+  tsx scripts/lib/slack.ts generate $NEW_APPS 2>/dev/null || true
+fi

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -59,7 +59,7 @@ export interface PerspectivesConfig {
 
 export interface SlackConfig {
   enabled: boolean;
-  webhook_url_env?: string;
+  token_env?: string;
 }
 
 export interface NotificationsConfig {

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -60,6 +60,7 @@ export interface PerspectivesConfig {
 export interface SlackConfig {
   enabled: boolean;
   token_env?: string;
+  viewer_host?: string;
 }
 
 export interface NotificationsConfig {

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -57,9 +57,19 @@ export interface PerspectivesConfig {
   items?: Perspective[];
 }
 
+export interface SlackConfig {
+  enabled: boolean;
+  webhook_url_env?: string;
+}
+
+export interface NotificationsConfig {
+  slack?: SlackConfig;
+}
+
 export interface AppConfig {
   output_base_dir?: string;
   pipeline?: PipelineConfig;
+  notifications?: NotificationsConfig;
   collect: {
     sources: Record<string, SourceConfig>;
   };

--- a/scripts/lib/slack.ts
+++ b/scripts/lib/slack.ts
@@ -1,0 +1,161 @@
+import { loadAppConfig } from "./config.js";
+import "dotenv/config";
+
+export interface SlackNotificationResult {
+  success: boolean;
+  error?: string;
+}
+
+interface SlackBlock {
+  type: string;
+  text?: { type: string; text: string };
+  elements?: { type: string; text: string }[];
+  fields?: { type: string; text: string }[];
+}
+
+function getWebhookUrl(): string | undefined {
+  const config = loadAppConfig();
+  const slackConfig = config.notifications?.slack;
+  if (!slackConfig?.enabled) return undefined;
+  const envKey = slackConfig.webhook_url_env ?? "SLACK_WEBHOOK_URL";
+  return process.env[envKey];
+}
+
+async function postToSlack(
+  webhookUrl: string,
+  blocks: SlackBlock[],
+  text: string,
+): Promise<SlackNotificationResult> {
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text, blocks }),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      return { success: false, error: `Slack API error: ${res.status} ${body}` };
+    }
+    return { success: true };
+  } catch (err) {
+    return {
+      success: false,
+      error: `Slack送信失敗: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+export interface PipelineStepResult {
+  name: string;
+  status: "success" | "skipped" | "failed";
+}
+
+export async function notifyPipelineResult(
+  steps: PipelineStepResult[],
+  opts?: {
+    newApps?: string[];
+    articleCount?: number;
+    keywordCount?: number;
+    mode?: string;
+  },
+): Promise<SlackNotificationResult> {
+  const webhookUrl = getWebhookUrl();
+  if (!webhookUrl) return { success: false, error: "Slack通知が無効または未設定です" };
+
+  const hasFailed = steps.some((s) => s.status === "failed");
+  const emoji = hasFailed ? ":warning:" : ":white_check_mark:";
+  const statusText = hasFailed ? "一部失敗" : "完了";
+  const modeLabel = opts?.mode ? ` (${opts.mode})` : "";
+
+  const stepLines = steps
+    .map((s) => {
+      const icon =
+        s.status === "success" ? ":ok:" : s.status === "failed" ? ":x:" : ":fast_forward:";
+      return `${icon} ${s.name}`;
+    })
+    .join("\n");
+
+  const blocks: SlackBlock[] = [
+    {
+      type: "header",
+      text: { type: "plain_text", text: `${emoji} パイプライン${statusText}${modeLabel}` },
+    },
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: `*ステップ結果:*\n${stepLines}` },
+    },
+  ];
+
+  const details: string[] = [];
+  if (opts?.articleCount !== undefined) {
+    details.push(`記事数: ${opts.articleCount}`);
+  }
+  if (opts?.keywordCount !== undefined) {
+    details.push(`キーワード数: ${opts.keywordCount}`);
+  }
+  if (opts?.newApps && opts.newApps.length > 0) {
+    details.push(`生成アプリ: ${opts.newApps.join(", ")}`);
+  }
+
+  if (details.length > 0) {
+    blocks.push({
+      type: "section",
+      fields: details.map((d) => ({ type: "mrkdwn", text: d })),
+    });
+  }
+
+  blocks.push({
+    type: "context",
+    elements: [
+      { type: "mrkdwn", text: `_${new Date().toLocaleString("ja-JP")}_ | requirements_creator` },
+    ],
+  });
+
+  const fallbackText = `パイプライン${statusText}${modeLabel}`;
+  return postToSlack(webhookUrl, blocks, fallbackText);
+}
+
+export async function notifyGenerateResult(newApps?: string[]): Promise<SlackNotificationResult> {
+  const webhookUrl = getWebhookUrl();
+  if (!webhookUrl) return { success: false, error: "Slack通知が無効または未設定です" };
+
+  const appList = newApps && newApps.length > 0 ? newApps.join(", ") : "（新規アプリなし）";
+
+  const blocks: SlackBlock[] = [
+    {
+      type: "header",
+      text: { type: "plain_text", text: ":white_check_mark: 要件生成完了" },
+    },
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: `*生成アプリ:* ${appList}` },
+    },
+    {
+      type: "context",
+      elements: [
+        { type: "mrkdwn", text: `_${new Date().toLocaleString("ja-JP")}_ | requirements_creator` },
+      ],
+    },
+  ];
+
+  return postToSlack(webhookUrl, blocks, `要件生成完了: ${appList}`);
+}
+
+// CLI用エントリーポイント: generate.sh から呼び出し
+// 使用法: tsx scripts/lib/slack.ts generate [app1] [app2] ...
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (command === "generate") {
+    const apps = args.slice(1);
+    const result = await notifyGenerateResult(apps.length > 0 ? apps : undefined);
+    if (!result.success && result.error !== "Slack通知が無効または未設定です") {
+      console.error(result.error);
+    }
+  }
+}
+
+if (process.argv[1]?.endsWith("slack.ts")) {
+  main();
+}

--- a/scripts/lib/slack.ts
+++ b/scripts/lib/slack.ts
@@ -13,7 +13,7 @@ function getToken(): string | undefined {
   const config = loadAppConfig();
   const slackConfig = config.notifications?.slack;
   if (!slackConfig?.enabled) return undefined;
-  const envKey = slackConfig.token_env ?? "SLACK_BOT_TOKEN";
+  const envKey = slackConfig.token_env ?? "SLACK_BOT_USER_OAUTH_TOKEN";
   return process.env[envKey];
 }
 

--- a/scripts/lib/slack.ts
+++ b/scripts/lib/slack.ts
@@ -1,40 +1,38 @@
 import { loadAppConfig } from "./config.js";
 import "dotenv/config";
 
+const SLACK_API_URL = "https://slack.com/api/chat.postMessage";
+const SLACK_CHANNEL = "#requirements_notify";
+
 export interface SlackNotificationResult {
   success: boolean;
   error?: string;
 }
 
-interface SlackBlock {
-  type: string;
-  text?: { type: string; text: string };
-  elements?: { type: string; text: string }[];
-  fields?: { type: string; text: string }[];
-}
-
-function getWebhookUrl(): string | undefined {
+function getToken(): string | undefined {
   const config = loadAppConfig();
   const slackConfig = config.notifications?.slack;
   if (!slackConfig?.enabled) return undefined;
-  const envKey = slackConfig.webhook_url_env ?? "SLACK_WEBHOOK_URL";
+  const envKey = slackConfig.token_env ?? "SLACK_BOT_TOKEN";
   return process.env[envKey];
 }
 
-async function postToSlack(
-  webhookUrl: string,
-  blocks: SlackBlock[],
-  text: string,
-): Promise<SlackNotificationResult> {
+async function postToSlack(token: string, text: string): Promise<SlackNotificationResult> {
   try {
-    const res = await fetch(webhookUrl, {
+    const params = new URLSearchParams();
+    params.append("token", token);
+    params.append("channel", SLACK_CHANNEL);
+    params.append("text", text);
+
+    const res = await fetch(SLACK_API_URL, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text, blocks }),
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params.toString(),
     });
-    if (!res.ok) {
-      const body = await res.text();
-      return { success: false, error: `Slack API error: ${res.status} ${body}` };
+
+    const data = (await res.json()) as { ok: boolean; error?: string };
+    if (!data.ok) {
+      return { success: false, error: `Slack API error: ${data.error}` };
     }
     return { success: true };
   } catch (err) {
@@ -59,8 +57,8 @@ export async function notifyPipelineResult(
     mode?: string;
   },
 ): Promise<SlackNotificationResult> {
-  const webhookUrl = getWebhookUrl();
-  if (!webhookUrl) return { success: false, error: "Slack通知が無効または未設定です" };
+  const token = getToken();
+  if (!token) return { success: false, error: "Slack通知が無効または未設定です" };
 
   const hasFailed = steps.some((s) => s.status === "failed");
   const emoji = hasFailed ? ":warning:" : ":white_check_mark:";
@@ -71,74 +69,33 @@ export async function notifyPipelineResult(
     .map((s) => {
       const icon =
         s.status === "success" ? ":ok:" : s.status === "failed" ? ":x:" : ":fast_forward:";
-      return `${icon} ${s.name}`;
+      return `  ${icon} ${s.name}`;
     })
     .join("\n");
 
-  const blocks: SlackBlock[] = [
-    {
-      type: "header",
-      text: { type: "plain_text", text: `${emoji} パイプライン${statusText}${modeLabel}` },
-    },
-    {
-      type: "section",
-      text: { type: "mrkdwn", text: `*ステップ結果:*\n${stepLines}` },
-    },
-  ];
+  const lines: string[] = [`${emoji} *パイプライン${statusText}${modeLabel}*`, "", stepLines];
 
-  const details: string[] = [];
   if (opts?.articleCount !== undefined) {
-    details.push(`記事数: ${opts.articleCount}`);
+    lines.push("", `記事数: ${opts.articleCount}`);
   }
   if (opts?.keywordCount !== undefined) {
-    details.push(`キーワード数: ${opts.keywordCount}`);
+    lines.push(`キーワード数: ${opts.keywordCount}`);
   }
   if (opts?.newApps && opts.newApps.length > 0) {
-    details.push(`生成アプリ: ${opts.newApps.join(", ")}`);
+    lines.push(`生成アプリ: ${opts.newApps.join(", ")}`);
   }
 
-  if (details.length > 0) {
-    blocks.push({
-      type: "section",
-      fields: details.map((d) => ({ type: "mrkdwn", text: d })),
-    });
-  }
-
-  blocks.push({
-    type: "context",
-    elements: [
-      { type: "mrkdwn", text: `_${new Date().toLocaleString("ja-JP")}_ | requirements_creator` },
-    ],
-  });
-
-  const fallbackText = `パイプライン${statusText}${modeLabel}`;
-  return postToSlack(webhookUrl, blocks, fallbackText);
+  return postToSlack(token, lines.join("\n"));
 }
 
 export async function notifyGenerateResult(newApps?: string[]): Promise<SlackNotificationResult> {
-  const webhookUrl = getWebhookUrl();
-  if (!webhookUrl) return { success: false, error: "Slack通知が無効または未設定です" };
+  const token = getToken();
+  if (!token) return { success: false, error: "Slack通知が無効または未設定です" };
 
   const appList = newApps && newApps.length > 0 ? newApps.join(", ") : "（新規アプリなし）";
+  const text = `:white_check_mark: *要件生成完了*\n生成アプリ: ${appList}`;
 
-  const blocks: SlackBlock[] = [
-    {
-      type: "header",
-      text: { type: "plain_text", text: ":white_check_mark: 要件生成完了" },
-    },
-    {
-      type: "section",
-      text: { type: "mrkdwn", text: `*生成アプリ:* ${appList}` },
-    },
-    {
-      type: "context",
-      elements: [
-        { type: "mrkdwn", text: `_${new Date().toLocaleString("ja-JP")}_ | requirements_creator` },
-      ],
-    },
-  ];
-
-  return postToSlack(webhookUrl, blocks, `要件生成完了: ${appList}`);
+  return postToSlack(token, text);
 }
 
 // CLI用エントリーポイント: generate.sh から呼び出し

--- a/scripts/lib/slack.ts
+++ b/scripts/lib/slack.ts
@@ -9,12 +9,24 @@ export interface SlackNotificationResult {
   error?: string;
 }
 
-function getToken(): string | undefined {
+interface SlackContext {
+  token: string;
+  viewerHost?: string;
+}
+
+function getSlackContext(): SlackContext | undefined {
   const config = loadAppConfig();
   const slackConfig = config.notifications?.slack;
   if (!slackConfig?.enabled) return undefined;
   const envKey = slackConfig.token_env ?? "SLACK_BOT_USER_OAUTH_TOKEN";
-  return process.env[envKey];
+  const token = process.env[envKey];
+  if (!token) return undefined;
+  return { token, viewerHost: slackConfig.viewer_host };
+}
+
+function appLink(viewerHost: string | undefined, appName: string): string {
+  if (!viewerHost) return appName;
+  return `<${viewerHost}?app=${encodeURIComponent(appName)}|${appName}>`;
 }
 
 async function postToSlack(token: string, text: string): Promise<SlackNotificationResult> {
@@ -57,8 +69,8 @@ export async function notifyPipelineResult(
     mode?: string;
   },
 ): Promise<SlackNotificationResult> {
-  const token = getToken();
-  if (!token) return { success: false, error: "Slack通知が無効または未設定です" };
+  const ctx = getSlackContext();
+  if (!ctx) return { success: false, error: "Slack通知が無効または未設定です" };
 
   const hasFailed = steps.some((s) => s.status === "failed");
   const emoji = hasFailed ? ":warning:" : ":white_check_mark:";
@@ -82,20 +94,25 @@ export async function notifyPipelineResult(
     lines.push(`キーワード数: ${opts.keywordCount}`);
   }
   if (opts?.newApps && opts.newApps.length > 0) {
-    lines.push(`生成アプリ: ${opts.newApps.join(", ")}`);
+    const appLinks = opts.newApps.map((a) => appLink(ctx.viewerHost, a)).join(", ");
+    lines.push(`生成アプリ: ${appLinks}`);
   }
 
-  return postToSlack(token, lines.join("\n"));
+  return postToSlack(ctx.token, lines.join("\n"));
 }
 
 export async function notifyGenerateResult(newApps?: string[]): Promise<SlackNotificationResult> {
-  const token = getToken();
-  if (!token) return { success: false, error: "Slack通知が無効または未設定です" };
+  const ctx = getSlackContext();
+  if (!ctx) return { success: false, error: "Slack通知が無効または未設定です" };
 
-  const appList = newApps && newApps.length > 0 ? newApps.join(", ") : "（新規アプリなし）";
-  const text = `:white_check_mark: *要件生成完了*\n生成アプリ: ${appList}`;
+  if (newApps && newApps.length > 0) {
+    const appLinks = newApps.map((a) => appLink(ctx.viewerHost, a)).join(", ");
+    const text = `:white_check_mark: *要件生成完了*\n生成アプリ: ${appLinks}`;
+    return postToSlack(ctx.token, text);
+  }
 
-  return postToSlack(token, text);
+  const text = `:white_check_mark: *要件生成完了*\n生成アプリ: （新規アプリなし）`;
+  return postToSlack(ctx.token, text);
 }
 
 // CLI用エントリーポイント: generate.sh から呼び出し

--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -9,6 +9,7 @@ import {
   selectDataSource,
 } from "./lib/data-source.js";
 import { DATA_SOURCE_DIR, DATASETS_DIR, REQUIREMENTS_DIR } from "./lib/paths.js";
+import { notifyPipelineResult, type PipelineStepResult } from "./lib/slack.js";
 
 // --- 型定義 ---
 interface PipelineOptions {
@@ -144,7 +145,8 @@ process.on("SIGTERM", cleanup);
 // --- 子プロセス実行ヘルパー ---
 function runStep(cmd: string, args: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { stdio: "inherit", detached: true });
+    const env = { ...process.env, PIPELINE_MODE: "1" };
+    const child = spawn(cmd, args, { stdio: "inherit", detached: true, env });
     activeChild = child;
     child.on("error", (err) => {
       activeChild = null;
@@ -244,7 +246,7 @@ async function main() {
     } catch (err) {
       console.error(`\nregenerate 失敗: ${err instanceof Error ? err.message : err}`);
       results.push({ name: "regenerate", status: "failed" });
-      printSummary(results);
+      await printSummary(results, undefined, undefined, "再生成");
       process.exit(1);
     }
 
@@ -259,7 +261,7 @@ async function main() {
       results.push({ name: "validate", status: "failed" });
     }
 
-    printSummary(results, undefined, [appName]);
+    await printSummary(results, undefined, [appName], "再生成");
     return;
   }
 
@@ -293,7 +295,7 @@ async function main() {
     } catch (err) {
       console.error(`\ngenerate 失敗: ${err instanceof Error ? err.message : err}`);
       results.push({ name: "generate", status: "failed" });
-      printSummary(results);
+      await printSummary(results, undefined, undefined, "データセット");
       process.exit(1);
     }
 
@@ -318,7 +320,7 @@ async function main() {
       results.push({ name: "validate", status: "skipped" });
     }
 
-    printSummary(results, undefined, newApps);
+    await printSummary(results, undefined, newApps, "データセット");
     return;
   }
 
@@ -338,7 +340,7 @@ async function main() {
     } catch (err) {
       console.error(`\ncollect 失敗: ${err instanceof Error ? err.message : err}`);
       results.push({ name: "collect", status: "failed" });
-      printSummary(results);
+      await printSummary(results);
       process.exit(1);
     }
   }
@@ -415,7 +417,7 @@ async function main() {
     } catch (err) {
       console.error(`\nextract 失敗: ${err instanceof Error ? err.message : err}`);
       results.push({ name: "extract", status: "failed" });
-      printSummary(results);
+      await printSummary(results);
       process.exit(1);
     }
   }
@@ -435,7 +437,7 @@ async function main() {
   } catch (err) {
     console.error(`\ngenerate 失敗: ${err instanceof Error ? err.message : err}`);
     results.push({ name: "generate", status: "failed" });
-    printSummary(results);
+    await printSummary(results);
     process.exit(1);
   }
 
@@ -461,10 +463,15 @@ async function main() {
   }
 
   // サマリー
-  printSummary(results, targetDir, newApps);
+  await printSummary(results, targetDir, newApps);
 }
 
-function printSummary(results: StepResult[], targetDir?: string, newApps?: string[]): void {
+async function printSummary(
+  results: StepResult[],
+  targetDir?: string,
+  newApps?: string[],
+  mode?: string,
+): Promise<void> {
   console.log("========================================");
   console.log("パイプライン実行結果:");
   console.log("========================================");
@@ -479,11 +486,14 @@ function printSummary(results: StepResult[], targetDir?: string, newApps?: strin
     console.log(`  ${statusLabel[r.status]}  ${r.name}`);
   }
 
+  let articleCount: number | undefined;
+  let keywordCount: number | undefined;
+
   if (targetDir) {
     const texts = loadAllTexts(targetDir);
     const keywordData = loadJson<{ keywords?: unknown[] }>(targetDir, "keyword.json");
-    const articleCount = texts.length;
-    const keywordCount = keywordData?.keywords?.length ?? 0;
+    articleCount = texts.length;
+    keywordCount = keywordData?.keywords?.length ?? 0;
 
     console.log("");
     if (newApps && newApps.length > 0) {
@@ -506,6 +516,23 @@ function printSummary(results: StepResult[], targetDir?: string, newApps?: strin
     console.log("\n一部ステップが失敗しました。");
   } else {
     console.log("\n全ステップ完了。");
+  }
+
+  // Slack通知
+  const slackSteps: PipelineStepResult[] = results.map((r) => ({
+    name: r.name,
+    status: r.status,
+  }));
+  const slackResult = await notifyPipelineResult(slackSteps, {
+    newApps,
+    articleCount,
+    keywordCount,
+    mode,
+  });
+  if (slackResult.success) {
+    console.log("Slack通知を送信しました。");
+  } else if (slackResult.error && slackResult.error !== "Slack通知が無効または未設定です") {
+    console.error(`Slack通知エラー: ${slackResult.error}`);
   }
 }
 

--- a/scripts/test-slack-notify.ts
+++ b/scripts/test-slack-notify.ts
@@ -1,0 +1,39 @@
+import { notifyPipelineResult, notifyGenerateResult } from "./lib/slack.js";
+
+async function testPipelineSuccess() {
+  console.log("[Test 1] パイプライン成功通知...");
+  const result = await notifyPipelineResult(
+    [
+      { name: "collect", status: "success" },
+      { name: "extract", status: "success" },
+      { name: "generate", status: "success" },
+      { name: "validate", status: "success" },
+    ],
+    {
+      newApps: ["test-awesome-app"],
+      articleCount: 20,
+      keywordCount: 15,
+    },
+  );
+  console.log(result.success ? "  → 送信成功" : `  → 失敗: ${result.error}`);
+  return result.success;
+}
+
+async function testGenerateComplete() {
+  console.log("[Test 2] 要件生成完了通知...");
+  const result = await notifyGenerateResult(["test-app-alpha", "test-app-beta"]);
+  console.log(result.success ? "  → 送信成功" : `  → 失敗: ${result.error}`);
+  return result.success;
+}
+
+async function main() {
+  console.log("=== Slack通知テスト ===\n");
+
+  const r1 = await testPipelineSuccess();
+  const r2 = await testGenerateComplete();
+
+  console.log(`\n結果: ${[r1, r2].filter(Boolean).length}/2 成功`);
+  process.exit(r1 && r2 ? 0 : 1);
+}
+
+main();


### PR DESCRIPTION
## Summary

- pipeline / generate の完了時にSlack Incoming Webhooksで通知を送信する機能を追加
- `app.config.yaml` で通知の有効/無効を制御（デフォルト無効）
- `.env` にWebhook URLを設定する方式

Closes #65

## Changes

- `scripts/lib/slack.ts`: Slack通知ユーティリティ（Block Kit形式のメッセージ送信、CLIエントリーポイント）
- `scripts/lib/config.ts`: `AppConfig`型に`notifications.slack`設定を追加
- `app.config.yaml`: 通知設定セクション追加（`notifications.slack`）
- `scripts/pipeline.ts`: `printSummary`後にSlack通知呼び出し、子プロセスに`PIPELINE_MODE`環境変数を伝播
- `scripts/generate.sh`: 単体実行時のSlack通知追加（`PIPELINE_MODE`で二重通知防止）
- `SLACK_NOTIFICATION.md`: セットアップ手順ドキュメント

## Test plan

- [ ] `app.config.yaml`の`notifications.slack.enabled: false`（デフォルト）でパイプライン実行し、通知が送信されないことを確認
- [ ] `.env`に`SLACK_WEBHOOK_URL`を設定し、`enabled: true`に変更後、`pnpm pipeline`実行でSlack通知が届くことを確認
- [ ] `pnpm generate`単体実行でもSlack通知が届くことを確認
- [ ] `pnpm pipeline`経由の`generate`実行で二重通知されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)