### PR TITLE
fix: スマホ版バグ対応 (#78)

### DIFF
--- a/scripts/test-slack-notify.ts
+++ b/scripts/test-slack-notify.ts
@@ -1,4 +1,4 @@
-import { notifyPipelineResult, notifyGenerateResult } from "./lib/slack.js";
+import { notifyGenerateResult, notifyPipelineResult } from "./lib/slack.js";
 
 async function testPipelineSuccess() {
   console.log("[Test 1] パイプライン成功通知...");

--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -2,7 +2,6 @@ import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useState } from "react";
 import {
   addFavorite,
-  commitAndPush,
   type DiagramFile,
   type FavoriteItem,
   type Feature,
@@ -21,7 +20,6 @@ import { type SwipeDirection, useSwipeTab } from "../hooks/useSwipeTab";
 import { DatasetAddButton } from "./DatasetAddButton";
 import { MarkdownPane } from "./MarkdownPane";
 import { MemoTab } from "./MemoTab";
-import { useToast } from "./Toast";
 
 export type AppTab = "overview" | "source-info" | "diagrams" | "features" | "memo";
 type LeftTab = "overview" | "source-info" | "diagrams" | "memo";
@@ -88,10 +86,7 @@ export function AppView({
   const mobileTab: AppTab = selectedTab;
   const [loading, setLoading] = useState(true);
   const [isDev, setIsDev] = useState(false);
-  const [pushing, setPushing] = useState(false);
   const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
-  const { showToast } = useToast();
-
   useEffect(() => {
     fetchMode().then((r) => setIsDev(r.isDev));
   }, []);
@@ -162,28 +157,6 @@ export function AppView({
     }
   }, [appName, selectedFeature]);
 
-  const handleCommitPush = useCallback(async () => {
-    if (pushing) return;
-    setPushing(true);
-    try {
-      const result = await commitAndPush();
-      showToast({
-        title: result.success ? "Commit & Push 完了" : "Commit & Push 失敗",
-        output: result.output,
-        success: result.success,
-      });
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Unknown error";
-      showToast({
-        title: "Commit & Push エラー",
-        output: message,
-        success: false,
-      });
-    } finally {
-      setPushing(false);
-    }
-  }, [pushing, showToast]);
-
   if (loading) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -226,8 +199,6 @@ export function AppView({
         isFavorited={isFavorited}
         handleToggleFavorite={handleToggleFavorite}
         isDev={isDev}
-        pushing={pushing}
-        handleCommitPush={handleCommitPush}
         onNavigateToDataset={onNavigateToDataset}
         onNavigateToApp={onNavigateToApp}
       />
@@ -308,17 +279,11 @@ export function AppView({
                 onClick={() => handleToggleFavorite("overview", appName)}
               />
             )}
-            {isDev && (
-              <>
-                {leftTab === "overview" && (
-                  <DatasetAddButton
-                    item={{ appName, type: "overview", title: appName }}
-                    isDev={isDev}
-                  />
-                )}
-                <div className="flex-1" />
-                <CommitPushButton pushing={pushing} onClick={handleCommitPush} />
-              </>
+            {isDev && leftTab === "overview" && (
+              <DatasetAddButton
+                item={{ appName, type: "overview", title: appName }}
+                isDev={isDev}
+              />
             )}
           </div>
           {/* Content */}
@@ -327,7 +292,7 @@ export function AppView({
               <MemoTab appName={appName} isMobile={isMobile} isDev={isDev} />
             </div>
           ) : (
-            <div className="flex-1 overflow-y-auto dark-scrollbar p-6 bg-gray-900">
+            <div className="flex-1 overflow-y-auto dark-scrollbar p-6 pb-10 bg-gray-900">
               <AnimatePresence mode="wait">
                 {leftTab === "source-info" ? (
                   <motion.div
@@ -402,7 +367,7 @@ export function AppView({
             />
           </div>
           {/* Content */}
-          <div className="flex-1 overflow-y-auto dark-scrollbar p-6 bg-gray-900">
+          <div className="flex-1 overflow-y-auto dark-scrollbar p-6 pb-10 bg-gray-900">
             <motion.div
               className="space-y-2"
               variants={cardContainerVariants}
@@ -559,7 +524,7 @@ export function AppView({
               </motion.button>
             </div>
             {/* Content */}
-            <div className="flex-1 overflow-y-auto dark-scrollbar p-6 bg-gray-900">
+            <div className="flex-1 overflow-y-auto dark-scrollbar p-6 pb-10 bg-gray-900">
               <AnimatePresence mode="wait">
                 <motion.div
                   key={selectedFeature}
@@ -599,8 +564,6 @@ function MobileLayout({
   isFavorited,
   handleToggleFavorite,
   isDev,
-  pushing,
-  handleCommitPush,
   onNavigateToDataset,
   onNavigateToApp,
 }: {
@@ -627,8 +590,6 @@ function MobileLayout({
     diagramId?: string,
   ) => void;
   isDev: boolean;
-  pushing: boolean;
-  handleCommitPush: () => void;
   onNavigateToDataset?: (datasetName: string) => void;
   onNavigateToApp?: (appName: string) => void;
 }) {
@@ -691,7 +652,7 @@ function MobileLayout({
           </span>
         </div>
         {/* Content */}
-        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-8 bg-gray-900">
+        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-20 bg-gray-900">
           <MarkdownPane content={featureContent} />
         </div>
       </motion.div>
@@ -747,17 +708,8 @@ function MobileLayout({
             onClick={() => handleToggleFavorite("overview", appName)}
           />
         )}
-        {isDev && (
-          <>
-            {mobileTab === "overview" && (
-              <DatasetAddButton
-                item={{ appName, type: "overview", title: appName }}
-                isDev={isDev}
-              />
-            )}
-            <div className="flex-1" />
-            <CommitPushButton pushing={pushing} onClick={handleCommitPush} />
-          </>
+        {isDev && mobileTab === "overview" && (
+          <DatasetAddButton item={{ appName, type: "overview", title: appName }} isDev={isDev} />
         )}
       </div>
       {/* Content */}
@@ -767,7 +719,7 @@ function MobileLayout({
         </div>
       ) : (
         <div
-          className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-8 bg-gray-900"
+          className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-20 bg-gray-900"
           {...swipeHandlers}
         >
           <AnimatePresence mode="wait" initial={false}>
@@ -919,7 +871,7 @@ function SourceInfoView({
             )}
             {info.dataset.sourceApps && info.dataset.sourceApps.length > 0 && (
               <div>
-                <p className="text-[10px] font-semibold uppercase tracking-wider text-gray-500 mb-1.5">
+                <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 mb-1.5">
                   参照元
                 </p>
                 <div className="space-y-1">
@@ -931,7 +883,7 @@ function SourceInfoView({
                         className="flex items-center gap-2 px-2 py-1.5 rounded-lg bg-gray-900/50"
                       >
                         <span
-                          className={`inline-flex shrink-0 items-center justify-center rounded text-[9px] font-bold px-1.5 py-0.5 ${
+                          className={`inline-flex shrink-0 items-center justify-center rounded text-[10px] font-bold px-1.5 py-0.5 ${
                             sa.type === "overview"
                               ? "bg-blue-900/40 text-blue-400"
                               : "bg-purple-900/40 text-purple-400"
@@ -1020,7 +972,7 @@ function SourceInfoView({
               >
                 <span className="text-xs text-gray-200">{kw.word}</span>
                 {kw.relevance != null && (
-                  <span className="text-[10px] text-gray-500 tabular-nums">
+                  <span className="text-[11px] text-gray-500 tabular-nums">
                     {(kw.relevance * 100).toFixed(0)}%
                   </span>
                 )}
@@ -1052,23 +1004,6 @@ function SourceInfoView({
         </section>
       )}
     </div>
-  );
-}
-
-function CommitPushButton({ pushing, onClick }: { pushing: boolean; onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      className={`px-3 py-1 my-1 text-xs font-medium rounded-lg transition-colors ${
-        pushing
-          ? "bg-gray-700 text-gray-400 cursor-not-allowed"
-          : "bg-emerald-700 text-white hover:bg-emerald-600"
-      }`}
-      onClick={onClick}
-      disabled={pushing}
-    >
-      {pushing ? "Push中..." : "Commit & Push"}
-    </button>
   );
 }
 

--- a/viewer/src/components/AppView.tsx
+++ b/viewer/src/components/AppView.tsx
@@ -292,7 +292,7 @@ export function AppView({
               <MemoTab appName={appName} isMobile={isMobile} isDev={isDev} />
             </div>
           ) : (
-            <div className="flex-1 overflow-y-auto dark-scrollbar p-6 pb-10 bg-gray-900">
+            <div className="flex-1 overflow-y-auto dark-scrollbar p-6 pb-16 bg-gray-900">
               <AnimatePresence mode="wait">
                 {leftTab === "source-info" ? (
                   <motion.div
@@ -367,7 +367,7 @@ export function AppView({
             />
           </div>
           {/* Content */}
-          <div className="flex-1 overflow-y-auto dark-scrollbar p-6 pb-10 bg-gray-900">
+          <div className="flex-1 overflow-y-auto dark-scrollbar p-6 pb-16 bg-gray-900">
             <motion.div
               className="space-y-2"
               variants={cardContainerVariants}
@@ -524,7 +524,7 @@ export function AppView({
               </motion.button>
             </div>
             {/* Content */}
-            <div className="flex-1 overflow-y-auto dark-scrollbar p-6 pb-10 bg-gray-900">
+            <div className="flex-1 overflow-y-auto dark-scrollbar p-6 pb-16 bg-gray-900">
               <AnimatePresence mode="wait">
                 <motion.div
                   key={selectedFeature}
@@ -652,7 +652,7 @@ function MobileLayout({
           </span>
         </div>
         {/* Content */}
-        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-20 bg-gray-900">
+        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-32 bg-gray-900">
           <MarkdownPane content={featureContent} />
         </div>
       </motion.div>
@@ -719,7 +719,7 @@ function MobileLayout({
         </div>
       ) : (
         <div
-          className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-20 bg-gray-900"
+          className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-32 bg-gray-900"
           {...swipeHandlers}
         >
           <AnimatePresence mode="wait" initial={false}>

--- a/viewer/src/components/CommandRunner.tsx
+++ b/viewer/src/components/CommandRunner.tsx
@@ -503,6 +503,18 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
                 {cmd.label}
               </button>
             ))}
+            <button
+              type="button"
+              className={`px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                pushing
+                  ? "bg-gray-700 text-gray-400 cursor-not-allowed"
+                  : "bg-emerald-600/20 text-emerald-300 ring-1 ring-emerald-500/40 hover:bg-emerald-600/30"
+              }`}
+              onClick={handleCommitPush}
+              disabled={pushing}
+            >
+              {pushing ? "Push中..." : "Commit & Push"}
+            </button>
           </div>
 
           {/* Description */}
@@ -638,18 +650,6 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
             </span>
           )}
           <div className="flex-1" />
-          <button
-            type="button"
-            className={`px-3 py-1 text-xs font-medium rounded-lg transition-colors ${
-              pushing
-                ? "bg-gray-700 text-gray-400 cursor-not-allowed"
-                : "bg-emerald-700 text-white hover:bg-emerald-600"
-            }`}
-            onClick={handleCommitPush}
-            disabled={pushing}
-          >
-            {pushing ? "Push中..." : "Commit & Push"}
-          </button>
         </div>
         <div className="flex-1 overflow-y-auto p-4 font-mono text-xs dark-scrollbar">
           {logs.length === 0 ? (

--- a/viewer/src/components/CommandRunner.tsx
+++ b/viewer/src/components/CommandRunner.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { abortCommand, type CommandEvent, executeCommand } from "../api";
+import { abortCommand, type CommandEvent, commitAndPush, executeCommand } from "../api";
+import { useToast } from "./Toast";
 
 // --- Types ---
 
@@ -242,6 +243,8 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
   const [dynamicChoices, setDynamicChoices] = useState<Record<string, string[]>>({});
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [running, setRunning] = useState(false);
+  const [pushing, setPushing] = useState(false);
+  const { showToast } = useToast();
   const logEndRef = useRef<HTMLDivElement>(null);
   const abortRef = useRef<AbortController | null>(null);
   const logIdRef = useRef(0);
@@ -445,6 +448,28 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
     setLogs([]);
   }, []);
 
+  const handleCommitPush = useCallback(async () => {
+    if (pushing) return;
+    setPushing(true);
+    try {
+      const result = await commitAndPush();
+      showToast({
+        title: result.success ? "Commit & Push 完了" : "Commit & Push 失敗",
+        output: result.output,
+        success: result.success,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      showToast({
+        title: "Commit & Push エラー",
+        output: message,
+        success: false,
+      });
+    } finally {
+      setPushing(false);
+    }
+  }, [pushing, showToast]);
+
   if (!isDev) {
     return (
       <div className="flex h-full items-center justify-center text-gray-500 text-sm">
@@ -461,8 +486,8 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
           isMobile ? "h-[45%] border-b" : "w-[380px] shrink-0 border-r"
         } border-gray-800 flex flex-col overflow-hidden`}
       >
-        <div className="flex-1 overflow-y-auto p-4 space-y-4 dark-scrollbar">
-          {/* Command selector */}
+        {/* Command selector (固定) */}
+        <div className="p-4 pb-0 space-y-3 shrink-0">
           <div className="flex flex-wrap gap-1.5">
             {COMMANDS.map((cmd) => (
               <button
@@ -484,11 +509,14 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
           <div className="rounded-lg bg-gray-800/30 border border-gray-800 p-3">
             <p className="text-xs text-gray-400 leading-relaxed">{selectedCommand.description}</p>
           </div>
+        </div>
 
+        {/* Options (スクロール可能) */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-4 dark-scrollbar">
           {/* Options */}
           {selectedCommand.options.length > 0 && (
             <div className="space-y-3">
-              <h3 className="text-[10px] font-semibold uppercase tracking-wider text-gray-600">
+              <h3 className="text-[11px] font-semibold uppercase tracking-wider text-gray-600">
                 オプション
               </h3>
               {selectedCommand.options.map((opt) => (
@@ -533,7 +561,7 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
                         {opt.saveUrlPattern && (
                           <button
                             type="button"
-                            className="px-2 py-0.5 text-[10px] font-medium rounded bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-gray-200 transition-colors disabled:opacity-50"
+                            className="px-2 py-0.5 text-[11px] font-medium rounded bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-gray-200 transition-colors disabled:opacity-50"
                             onClick={() => handleSaveMemo(opt)}
                             disabled={memoSaving}
                           >
@@ -601,7 +629,7 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
 
       {/* Right Pane: Log Output */}
       <div className="flex-1 flex flex-col overflow-hidden bg-gray-950">
-        <div className="px-4 py-2 border-b border-gray-800 flex items-center justify-between">
+        <div className="px-4 py-2 border-b border-gray-800 flex items-center gap-2">
           <span className="text-xs font-medium text-gray-500">ログ出力</span>
           {running && (
             <span className="flex items-center gap-1.5 text-xs text-indigo-400">
@@ -609,6 +637,19 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
               実行中...
             </span>
           )}
+          <div className="flex-1" />
+          <button
+            type="button"
+            className={`px-3 py-1 text-xs font-medium rounded-lg transition-colors ${
+              pushing
+                ? "bg-gray-700 text-gray-400 cursor-not-allowed"
+                : "bg-emerald-700 text-white hover:bg-emerald-600"
+            }`}
+            onClick={handleCommitPush}
+            disabled={pushing}
+          >
+            {pushing ? "Push中..." : "Commit & Push"}
+          </button>
         </div>
         <div className="flex-1 overflow-y-auto p-4 font-mono text-xs dark-scrollbar">
           {logs.length === 0 ? (

--- a/viewer/src/components/ConfigEditor.tsx
+++ b/viewer/src/components/ConfigEditor.tsx
@@ -131,7 +131,7 @@ function FieldLabel({
       <label htmlFor={htmlFor} className="text-sm font-medium text-gray-300">
         {label}
       </label>
-      <p className="text-[11px] text-gray-500 mt-0.5">{description}</p>
+      <p className="text-[12px] text-gray-500 mt-0.5">{description}</p>
     </div>
   );
 }
@@ -451,7 +451,7 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
             <div className="flex items-center justify-between">
               <div>
                 <h3 className="text-sm font-semibold text-gray-200">NewsAPI</h3>
-                <p className="text-[11px] text-gray-500">ニュースのトップヘッドラインを取得</p>
+                <p className="text-[12px] text-gray-500">ニュースのトップヘッドラインを取得</p>
               </div>
               <Toggle
                 checked={newsapi?.enabled ?? false}
@@ -554,7 +554,7 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
             <div className="flex items-center justify-between">
               <div>
                 <h3 className="text-sm font-semibold text-gray-200">YouTube Data API</h3>
-                <p className="text-[11px] text-gray-500">人気動画ランキングを取得</p>
+                <p className="text-[12px] text-gray-500">人気動画ランキングを取得</p>
               </div>
               <Toggle
                 checked={youtube?.enabled ?? false}
@@ -664,7 +664,7 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
             <div className="flex items-center justify-between">
               <div>
                 <h3 className="text-sm font-semibold text-gray-200">連想ゲーム方式</h3>
-                <p className="text-[11px] text-gray-500">
+                <p className="text-[12px] text-gray-500">
                   収集データに直接記載されていない関連キーワードも連想で抽出
                 </p>
               </div>
@@ -717,7 +717,7 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
           {/* Constraints */}
           <div className="rounded-lg border border-gray-800/50 bg-gray-800/30 p-4 space-y-4">
             <h3 className="text-sm font-semibold text-gray-200">制約条件 (constraints)</h3>
-            <p className="text-[11px] text-gray-500">
+            <p className="text-[12px] text-gray-500">
               生成されるアプリ案の技術構成・規模を制御。未設定の項目はAIが自由に判断
             </p>
             <div className="grid grid-cols-2 gap-4">
@@ -825,7 +825,7 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
           {/* Perspectives */}
           <div className="rounded-lg border border-gray-800/50 bg-gray-800/30 p-4 space-y-4">
             <h3 className="text-sm font-semibold text-gray-200">生成観点 (perspectives)</h3>
-            <p className="text-[11px] text-gray-500">
+            <p className="text-[12px] text-gray-500">
               アプリ案の体験設計・マネタイズ戦略の方向性を指定
             </p>
             <div>
@@ -864,7 +864,7 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
           {/* Agents */}
           <div className="rounded-lg border border-gray-800/50 bg-gray-800/30 p-4 space-y-4">
             <h3 className="text-sm font-semibold text-gray-200">マルチエージェント (agents)</h3>
-            <p className="text-[11px] text-gray-500">
+            <p className="text-[12px] text-gray-500">
               要件生成の各フェーズで活用するエージェントの設定
             </p>
 
@@ -877,7 +877,7 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
                   <div>
                     <h4 className="text-sm font-semibold text-gray-200 capitalize">{name}</h4>
                     {agent.model && (
-                      <span className="text-[11px] text-gray-500">model: {agent.model}</span>
+                      <span className="text-[12px] text-gray-500">model: {agent.model}</span>
                     )}
                   </div>
                   <Toggle
@@ -939,7 +939,7 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
         </section>
 
         {/* spacer */}
-        <div className="h-8" />
+        <div className="h-20" />
       </div>
     </div>
   );

--- a/viewer/src/components/ConfigEditor.tsx
+++ b/viewer/src/components/ConfigEditor.tsx
@@ -939,7 +939,7 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
         </section>
 
         {/* spacer */}
-        <div className="h-20" />
+        <div className="h-32" />
       </div>
     </div>
   );

--- a/viewer/src/components/DatasetAddButton.tsx
+++ b/viewer/src/components/DatasetAddButton.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import {
   addDatasetItem,
   createDataset,
@@ -19,7 +20,9 @@ export function DatasetAddButton({ item, isDev }: DatasetAddButtonProps) {
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState("");
   const [feedback, setFeedback] = useState<string | null>(null);
-  const ref = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [dropdownPos, setDropdownPos] = useState<{ top: number; right: number } | null>(null);
 
   useEffect(() => {
     if (open) {
@@ -27,17 +30,22 @@ export function DatasetAddButton({ item, isDev }: DatasetAddButtonProps) {
     }
   }, [open]);
 
+  // ドロップダウン位置をボタン位置から計算
   useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-        setCreating(false);
-        setNewName("");
-      }
-    };
-    if (open) document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
+    if (open && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setDropdownPos({
+        top: rect.bottom + 4,
+        right: window.innerWidth - rect.right,
+      });
+    }
   }, [open]);
+
+  const closeDropdown = useCallback(() => {
+    setOpen(false);
+    setCreating(false);
+    setNewName("");
+  }, []);
 
   const showFeedback = useCallback((msg: string) => {
     setFeedback(msg);
@@ -72,8 +80,9 @@ export function DatasetAddButton({ item, isDev }: DatasetAddButtonProps) {
   if (!isDev) return null;
 
   return (
-    <div className="relative" ref={ref}>
+    <div className="relative">
       <button
+        ref={buttonRef}
         type="button"
         className="p-1 rounded-md text-gray-600 hover:text-amber-400 hover:bg-amber-400/10 transition-colors"
         onClick={(e) => {
@@ -93,119 +102,149 @@ export function DatasetAddButton({ item, isDev }: DatasetAddButtonProps) {
         </svg>
       </button>
 
-      <AnimatePresence>
-        {open && (
-          <motion.div
-            className="absolute right-0 top-full mt-1 z-50 w-56 rounded-xl border border-gray-700 bg-gray-800 shadow-xl"
-            initial={{ opacity: 0, y: -4, scale: 0.95 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: -4, scale: 0.95 }}
-            transition={{ duration: 0.15 }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="px-3 py-2 border-b border-gray-700/50">
-              <p className="text-[10px] font-semibold uppercase tracking-wider text-gray-500">
-                データセットに追加
-              </p>
-            </div>
-            <div className="max-h-48 overflow-y-auto dark-scrollbar">
-              {datasets.length === 0 && !creating && (
-                <p className="px-3 py-3 text-xs text-gray-500 text-center">
-                  データセットがありません
-                </p>
-              )}
-              {datasets.map((ds) => (
-                <button
-                  type="button"
-                  key={ds.name}
-                  className="w-full flex items-center gap-2 px-3 py-2 text-xs text-gray-300 hover:bg-gray-700/50 transition-colors text-left"
-                  onClick={() => handleAdd(ds.name)}
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="size-3.5 text-gray-500 shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
-                    />
-                  </svg>
-                  <span className="truncate">{ds.name}</span>
-                  <span className="ml-auto text-[10px] text-gray-600">{ds.items.length}</span>
-                </button>
-              ))}
-            </div>
-            <div className="border-t border-gray-700/50">
-              {creating ? (
-                <div className="flex items-center gap-1 p-2">
-                  <input
-                    type="text"
-                    className="flex-1 min-w-0 px-2 py-1 text-xs bg-gray-900 border border-gray-600 rounded-md text-gray-300 outline-none focus:border-indigo-500"
-                    placeholder="データセット名"
-                    value={newName}
-                    onChange={(e) => setNewName(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") handleCreate();
-                      if (e.key === "Escape") {
-                        setCreating(false);
-                        setNewName("");
-                      }
-                    }}
-                  />
-                  <button
-                    type="button"
-                    className="px-2 py-1 text-xs font-medium rounded-md bg-indigo-600 text-white hover:bg-indigo-500 transition-colors"
-                    onClick={handleCreate}
-                  >
-                    作成
-                  </button>
+      {/* Portal: 透明オーバーレイ + ドロップダウン */}
+      {createPortal(
+        <AnimatePresence>
+          {open && dropdownPos && (
+            <>
+              {/* 透明オーバーレイ: タップでドロップダウンを閉じる & リンク遷移を防止 */}
+              {/* biome-ignore lint/a11y/noStaticElementInteractions: overlay dismissal */}
+              <div
+                role="presentation"
+                className="fixed inset-0 z-[60]"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  closeDropdown();
+                }}
+                onTouchStart={(e) => {
+                  e.stopPropagation();
+                }}
+              />
+              <motion.div
+                ref={dropdownRef}
+                className="fixed z-[61] w-56 rounded-xl border border-gray-700 bg-gray-800 shadow-xl"
+                style={{ top: dropdownPos.top, right: dropdownPos.right }}
+                initial={{ opacity: 0, y: -4, scale: 0.95 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: -4, scale: 0.95 }}
+                transition={{ duration: 0.15 }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <div className="px-3 py-2 border-b border-gray-700/50">
+                  <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-500">
+                    データセットに追加
+                  </p>
                 </div>
-              ) : (
-                <button
-                  type="button"
-                  className="w-full flex items-center gap-2 px-3 py-2 text-xs text-indigo-400 hover:bg-gray-700/50 transition-colors"
-                  onClick={() => setCreating(true)}
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="size-3.5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M12 4v16m8-8H4"
-                    />
-                  </svg>
-                  新規データセット作成
-                </button>
-              )}
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+                <div className="max-h-48 overflow-y-auto dark-scrollbar">
+                  {datasets.length === 0 && !creating && (
+                    <p className="px-3 py-3 text-xs text-gray-500 text-center">
+                      データセットがありません
+                    </p>
+                  )}
+                  {datasets.map((ds) => (
+                    <button
+                      type="button"
+                      key={ds.name}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-xs text-gray-300 hover:bg-gray-700/50 transition-colors text-left"
+                      onClick={() => handleAdd(ds.name)}
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className="size-3.5 text-gray-500 shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                        />
+                      </svg>
+                      <span className="truncate">{ds.name}</span>
+                      <span className="ml-auto text-[11px] text-gray-600">{ds.items.length}</span>
+                    </button>
+                  ))}
+                </div>
+                <div className="border-t border-gray-700/50">
+                  {creating ? (
+                    <div className="flex items-center gap-1 p-2">
+                      <input
+                        type="text"
+                        className="flex-1 min-w-0 px-2 py-1 text-xs bg-gray-900 border border-gray-600 rounded-md text-gray-300 outline-none focus:border-indigo-500"
+                        placeholder="データセット名"
+                        value={newName}
+                        onChange={(e) => setNewName(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") handleCreate();
+                          if (e.key === "Escape") {
+                            setCreating(false);
+                            setNewName("");
+                          }
+                        }}
+                      />
+                      <button
+                        type="button"
+                        className="px-2 py-1 text-xs font-medium rounded-md bg-indigo-600 text-white hover:bg-indigo-500 transition-colors"
+                        onClick={handleCreate}
+                      >
+                        作成
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      className="w-full flex items-center gap-2 px-3 py-2 text-xs text-indigo-400 hover:bg-gray-700/50 transition-colors"
+                      onClick={() => setCreating(true)}
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className="size-3.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M12 4v16m8-8H4"
+                        />
+                      </svg>
+                      新規データセット作成
+                    </button>
+                  )}
+                </div>
+              </motion.div>
+            </>
+          )}
+        </AnimatePresence>,
+        document.body,
+      )}
 
-      <AnimatePresence>
-        {feedback && (
-          <motion.div
-            className="absolute right-0 top-full mt-1 z-50 px-3 py-1.5 rounded-lg bg-gray-700 text-xs text-gray-200 whitespace-nowrap shadow-lg"
-            initial={{ opacity: 0, y: -4 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.15 }}
-          >
-            {feedback}
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {/* フィードバックメッセージ（Portal） */}
+      {createPortal(
+        <AnimatePresence>
+          {feedback && buttonRef.current && (
+            <motion.div
+              className="fixed z-[61] px-3 py-1.5 rounded-lg bg-gray-700 text-xs text-gray-200 whitespace-nowrap shadow-lg"
+              style={{
+                top: buttonRef.current.getBoundingClientRect().bottom + 4,
+                right: window.innerWidth - buttonRef.current.getBoundingClientRect().right,
+              }}
+              initial={{ opacity: 0, y: -4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+            >
+              {feedback}
+            </motion.div>
+          )}
+        </AnimatePresence>,
+        document.body,
+      )}
     </div>
   );
 }

--- a/viewer/src/components/DatasetManager.tsx
+++ b/viewer/src/components/DatasetManager.tsx
@@ -150,7 +150,7 @@ export function DatasetManager({
           <div className="flex-1" />
           {isDev && <CreateButton onClick={() => setCreating(true)} />}
         </div>
-        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-20 bg-gray-900">
+        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-32 bg-gray-900">
           <CreateForm
             show={creating}
             name={newName}
@@ -544,7 +544,7 @@ function DatasetItemList({
   }
 
   return (
-    <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-20 bg-gray-900">
+    <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-32 bg-gray-900">
       <motion.div
         className="space-y-4"
         initial={{ opacity: 0 }}

--- a/viewer/src/components/DatasetManager.tsx
+++ b/viewer/src/components/DatasetManager.tsx
@@ -150,7 +150,7 @@ export function DatasetManager({
           <div className="flex-1" />
           {isDev && <CreateButton onClick={() => setCreating(true)} />}
         </div>
-        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-8 bg-gray-900">
+        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-20 bg-gray-900">
           <CreateForm
             show={creating}
             name={newName}
@@ -342,7 +342,7 @@ function DatasetList({
           </svg>
         </div>
         <p className="text-gray-600 text-xs">データセットがありません</p>
-        <p className="text-gray-700 text-[10px] mt-1">
+        <p className="text-gray-700 text-[11px] mt-1">
           アプリ要件のOverviewやFeatureを組み合わせて保存できます
         </p>
       </div>
@@ -376,8 +376,8 @@ function DatasetList({
             />
           </svg>
           <div className="flex-1 min-w-0">
-            <p className="text-[13px] font-medium truncate">{ds.name}</p>
-            <p className="text-[10px] text-gray-600">{ds.items.length} items</p>
+            <p className="text-[14px] font-medium truncate">{ds.name}</p>
+            <p className="text-[11px] text-gray-600">{ds.items.length} items</p>
           </div>
           {isDev && (
             <button
@@ -453,7 +453,7 @@ function DatasetDetailHeader({
       <span className="px-3 py-2.5 text-xs font-medium text-indigo-400 truncate">
         {dataset.name}
       </span>
-      <span className="text-[10px] text-gray-600">{dataset.items.length} items</span>
+      <span className="text-[11px] text-gray-600">{dataset.items.length} items</span>
       <div className="flex-1" />
       {isDev && (
         <button
@@ -544,7 +544,7 @@ function DatasetItemList({
   }
 
   return (
-    <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-8 bg-gray-900">
+    <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-20 bg-gray-900">
       <motion.div
         className="space-y-4"
         initial={{ opacity: 0 }}
@@ -556,13 +556,13 @@ function DatasetItemList({
             {onSelectApp ? (
               <button
                 type="button"
-                className="text-[10px] font-semibold uppercase tracking-wider text-gray-600 hover:text-indigo-400 mb-2 px-1 transition-colors"
+                className="text-[11px] font-semibold uppercase tracking-wider text-gray-600 hover:text-indigo-400 mb-2 px-1 transition-colors"
                 onClick={() => onSelectApp(appName)}
               >
                 {appName}
               </button>
             ) : (
-              <p className="text-[10px] font-semibold uppercase tracking-wider text-gray-600 mb-2 px-1">
+              <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-600 mb-2 px-1">
                 {appName}
               </p>
             )}
@@ -578,7 +578,7 @@ function DatasetItemList({
                     transition={{ duration: 0.2 }}
                   >
                     <span
-                      className={`inline-flex shrink-0 items-center justify-center rounded-lg text-[10px] font-bold px-2 py-1 ${
+                      className={`inline-flex shrink-0 items-center justify-center rounded-lg text-[11px] font-bold px-2 py-1 ${
                         item.type === "overview"
                           ? "bg-blue-900/40 text-blue-400"
                           : "bg-purple-900/40 text-purple-400"
@@ -624,7 +624,7 @@ function DatasetItemList({
         {/* 生成されたアプリ */}
         {generatedApps.length > 0 && (
           <div className="pt-2 border-t border-gray-700/50">
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-gray-500 mb-2 px-1">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 mb-2 px-1">
               生成されたアプリ
             </p>
             <div className="space-y-1">
@@ -636,7 +636,7 @@ function DatasetItemList({
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ duration: 0.2 }}
                 >
-                  <span className="inline-flex shrink-0 items-center justify-center rounded-lg text-[10px] font-bold px-2 py-1 bg-emerald-900/40 text-emerald-400">
+                  <span className="inline-flex shrink-0 items-center justify-center rounded-lg text-[11px] font-bold px-2 py-1 bg-emerald-900/40 text-emerald-400">
                     APP
                   </span>
                   <div className="flex-1 min-w-0">

--- a/viewer/src/components/FavoritePage.tsx
+++ b/viewer/src/components/FavoritePage.tsx
@@ -224,7 +224,7 @@ export function FavoritePage({
             {previewItem.title ?? previewItem.appName}
           </span>
         </div>
-        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-20 bg-gray-900">
+        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-32 bg-gray-900">
           {previewLoading ? (
             <div className="flex items-center justify-center py-12">
               <motion.div
@@ -442,7 +442,7 @@ export function FavoritePage({
       <div className="flex flex-1 min-h-0">
         {/* List pane */}
         <div
-          className={`overflow-y-auto dark-scrollbar ${isMobile ? "p-4 pb-20" : "p-6 pb-10"} bg-gray-900 ${
+          className={`overflow-y-auto dark-scrollbar ${isMobile ? "p-4 pb-32" : "p-6 pb-16"} bg-gray-900 ${
             previewItem && !isMobile ? "border-r border-gray-700/50" : ""
           }`}
           style={{ flex: previewItem && !isMobile ? "0 0 50%" : "1 1 100%" }}
@@ -495,7 +495,7 @@ export function FavoritePage({
                   </button>
                 </div>
                 {/* Preview content */}
-                <div className="flex-1 overflow-y-auto dark-scrollbar p-6 pb-10 bg-gray-900">
+                <div className="flex-1 overflow-y-auto dark-scrollbar p-6 pb-16 bg-gray-900">
                   <AnimatePresence mode="wait">
                     {previewLoading ? (
                       <motion.div

--- a/viewer/src/components/FavoritePage.tsx
+++ b/viewer/src/components/FavoritePage.tsx
@@ -216,7 +216,7 @@ export function FavoritePage({
             </svg>
           </button>
           <span
-            className={`inline-flex shrink-0 items-center justify-center rounded text-[9px] font-bold px-1.5 py-0.5 ${typeBadgeClass(previewItem.type)}`}
+            className={`inline-flex shrink-0 items-center justify-center rounded text-[10px] font-bold px-1.5 py-0.5 ${typeBadgeClass(previewItem.type)}`}
           >
             {typeLabel(previewItem.type)}
           </span>
@@ -224,7 +224,7 @@ export function FavoritePage({
             {previewItem.title ?? previewItem.appName}
           </span>
         </div>
-        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-8 bg-gray-900">
+        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-20 bg-gray-900">
           {previewLoading ? (
             <div className="flex items-center justify-center py-12">
               <motion.div
@@ -284,7 +284,7 @@ export function FavoritePage({
                   className="flex items-center gap-2 mb-3 group"
                   onClick={() => onSelectApp(group.appName)}
                 >
-                  <span className="inline-flex shrink-0 items-center justify-center rounded text-[9px] font-bold px-1.5 py-0.5 bg-indigo-900/40 text-indigo-400">
+                  <span className="inline-flex shrink-0 items-center justify-center rounded text-[10px] font-bold px-1.5 py-0.5 bg-indigo-900/40 text-indigo-400">
                     APP
                   </span>
                   <span className="text-sm font-semibold text-gray-200 group-hover:text-indigo-300 transition-colors truncate">
@@ -327,7 +327,7 @@ export function FavoritePage({
                           }`}
                         >
                           <span
-                            className={`inline-flex shrink-0 items-center justify-center rounded text-[9px] font-bold px-1.5 py-0.5 ${typeBadgeClass(item.type)}`}
+                            className={`inline-flex shrink-0 items-center justify-center rounded text-[10px] font-bold px-1.5 py-0.5 ${typeBadgeClass(item.type)}`}
                           >
                             {typeLabel(item.type)}
                           </span>
@@ -434,7 +434,7 @@ export function FavoritePage({
         </svg>
         <div>
           <h2 className="text-sm font-bold text-gray-200">お気に入り</h2>
-          <p className="text-[10px] text-gray-500">{favorites.length} 件のお気に入り</p>
+          <p className="text-[11px] text-gray-500">{favorites.length} 件のお気に入り</p>
         </div>
       </div>
 
@@ -442,7 +442,7 @@ export function FavoritePage({
       <div className="flex flex-1 min-h-0">
         {/* List pane */}
         <div
-          className={`overflow-y-auto dark-scrollbar ${isMobile ? "p-4 pb-8" : "p-6"} bg-gray-900 ${
+          className={`overflow-y-auto dark-scrollbar ${isMobile ? "p-4 pb-20" : "p-6 pb-10"} bg-gray-900 ${
             previewItem && !isMobile ? "border-r border-gray-700/50" : ""
           }`}
           style={{ flex: previewItem && !isMobile ? "0 0 50%" : "1 1 100%" }}
@@ -465,7 +465,7 @@ export function FavoritePage({
                 {/* Preview header */}
                 <div className="flex items-center gap-2 px-4 bg-gray-800/50 border-b border-gray-700/50 shrink-0">
                   <span
-                    className={`inline-flex shrink-0 items-center justify-center rounded text-[9px] font-bold px-1.5 py-0.5 ${typeBadgeClass(previewItem.type)}`}
+                    className={`inline-flex shrink-0 items-center justify-center rounded text-[10px] font-bold px-1.5 py-0.5 ${typeBadgeClass(previewItem.type)}`}
                   >
                     {typeLabel(previewItem.type)}
                   </span>
@@ -495,7 +495,7 @@ export function FavoritePage({
                   </button>
                 </div>
                 {/* Preview content */}
-                <div className="flex-1 overflow-y-auto dark-scrollbar p-6 bg-gray-900">
+                <div className="flex-1 overflow-y-auto dark-scrollbar p-6 pb-10 bg-gray-900">
                   <AnimatePresence mode="wait">
                     {previewLoading ? (
                       <motion.div

--- a/viewer/src/components/SearchView.tsx
+++ b/viewer/src/components/SearchView.tsx
@@ -93,7 +93,7 @@ function TagResultsView({
 
   return (
     <motion.div
-      className={`h-full overflow-y-auto dark-scrollbar ${isMobile ? "p-4 pb-8" : "p-6"}`}
+      className={`h-full overflow-y-auto dark-scrollbar ${isMobile ? "p-4 pb-20" : "p-6 pb-10"}`}
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.3 }}
@@ -118,7 +118,7 @@ function TagResultsView({
               {r.tags.map((tag) => (
                 <span
                   key={tag}
-                  className={`inline-flex px-2 py-0.5 rounded-md text-[11px] font-medium ${
+                  className={`inline-flex px-2 py-0.5 rounded-md text-[12px] font-medium ${
                     r.matchedTags.includes(tag)
                       ? "bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/30"
                       : "bg-gray-700/50 text-gray-400"
@@ -165,7 +165,7 @@ function GrepResultsView({
 
   if (isMobile) {
     return (
-      <div className="h-full overflow-y-auto dark-scrollbar p-4 pb-8">
+      <div className="h-full overflow-y-auto dark-scrollbar p-4 pb-20">
         <SearchHeader
           query={query}
           selectedTags={selectedTags}
@@ -297,8 +297,8 @@ function ResultList({
                   onClick={() => onSelectItem(r.app, f.file, f.matches)}
                 >
                   <p className="text-xs font-medium text-gray-300">{f.file}</p>
-                  <p className="text-[11px] text-gray-500 mt-1">{f.matches.length}件のマッチ</p>
-                  <p className="text-[11px] text-gray-400 mt-1 truncate">
+                  <p className="text-[12px] text-gray-500 mt-1">{f.matches.length}件のマッチ</p>
+                  <p className="text-[12px] text-gray-400 mt-1 truncate">
                     <HighlightText text={f.matches[0]?.text ?? ""} query={query} />
                   </p>
                 </button>
@@ -321,14 +321,14 @@ function DetailPane({
   return (
     <div>
       <p className="text-xs font-semibold text-gray-300 mb-1">{item.app}</p>
-      <p className="text-[11px] text-gray-500 mb-4">{item.file}</p>
+      <p className="text-[12px] text-gray-500 mb-4">{item.file}</p>
       <div className="space-y-1">
         {item.matches.map((m) => (
           <div
             key={`${m.line}`}
             className="flex gap-3 px-3 py-2 rounded-lg bg-gray-800/50 border border-gray-700/30"
           >
-            <span className="text-[11px] text-gray-600 font-mono shrink-0 select-none w-8 text-right">
+            <span className="text-[12px] text-gray-600 font-mono shrink-0 select-none w-8 text-right">
               {m.line}
             </span>
             <span className="text-xs text-gray-300 break-all">

--- a/viewer/src/components/SearchView.tsx
+++ b/viewer/src/components/SearchView.tsx
@@ -93,7 +93,7 @@ function TagResultsView({
 
   return (
     <motion.div
-      className={`h-full overflow-y-auto dark-scrollbar ${isMobile ? "p-4 pb-20" : "p-6 pb-10"}`}
+      className={`h-full overflow-y-auto dark-scrollbar ${isMobile ? "p-4 pb-32" : "p-6 pb-16"}`}
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.3 }}
@@ -165,7 +165,7 @@ function GrepResultsView({
 
   if (isMobile) {
     return (
-      <div className="h-full overflow-y-auto dark-scrollbar p-4 pb-20">
+      <div className="h-full overflow-y-auto dark-scrollbar p-4 pb-32">
         <SearchHeader
           query={query}
           selectedTags={selectedTags}

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -322,6 +322,31 @@ export function Sidebar({
                   <button
                     type="button"
                     className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                      viewMode === "datasets"
+                        ? "text-amber-400 bg-amber-400/10"
+                        : "text-gray-500 hover:text-amber-400 hover:bg-amber-400/10"
+                    }`}
+                    onClick={onSelectDatasets}
+                    title="データセット"
+                  >
+                    <svg
+                      className="size-5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    className={`p-1.5 rounded-lg transition-colors shrink-0 ${
                       viewMode === "config"
                         ? "text-gray-300 bg-gray-700/50"
                         : "text-gray-500 hover:text-gray-300 hover:bg-gray-700/30"
@@ -344,12 +369,6 @@ export function Sidebar({
                       />
                     </svg>
                   </button>
-                  <div>
-                    <h1 className="text-sm font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent whitespace-nowrap">
-                      Requirements
-                    </h1>
-                    <p className="text-[11px] text-gray-500 font-medium">Viewer</p>
-                  </div>
                 </div>
                 <button
                   type="button"
@@ -570,6 +589,33 @@ export function Sidebar({
             <motion.button
               type="button"
               className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                viewMode === "datasets"
+                  ? "text-amber-400 bg-amber-400/10"
+                  : "text-gray-500 hover:text-amber-400 hover:bg-amber-400/10"
+              }`}
+              onClick={onSelectDatasets}
+              title="データセット"
+              animate={{ opacity: expanded ? 1 : 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              <svg
+                className="size-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                />
+              </svg>
+            </motion.button>
+            <motion.button
+              type="button"
+              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
                 viewMode === "config"
                   ? "text-gray-300 bg-gray-700/50"
                   : "text-gray-500 hover:text-gray-300 hover:bg-gray-700/30"
@@ -594,12 +640,6 @@ export function Sidebar({
                 />
               </svg>
             </motion.button>
-            <motion.div animate={{ opacity: expanded ? 1 : 0 }} transition={{ duration: 0.2 }}>
-              <h1 className="text-sm font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent whitespace-nowrap">
-                Requirements
-              </h1>
-              <p className="text-[11px] text-gray-500 font-medium">Viewer</p>
-            </motion.div>
           </div>
           <motion.button
             type="button"

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -132,7 +132,7 @@ function SearchInput({
         {/* タグ指定ボタン */}
         <button
           type="button"
-          className={`w-full px-2 py-1 text-[10px] font-medium rounded-md transition-colors ${
+          className={`w-full px-2 py-1 text-[11px] font-medium rounded-md transition-colors ${
             selectedTags.length > 0 || tagDialogOpen
               ? "bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/30"
               : "bg-gray-800/50 text-gray-500 hover:text-gray-300"
@@ -149,7 +149,7 @@ function SearchInput({
               <button
                 key={tag}
                 type="button"
-                className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-500/20 text-indigo-300 hover:bg-indigo-500/30 transition-colors"
+                className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[11px] font-medium bg-indigo-500/20 text-indigo-300 hover:bg-indigo-500/30 transition-colors"
                 onClick={() => toggleTag(tag)}
               >
                 {tag}
@@ -182,7 +182,7 @@ function SearchInput({
               exit={{ opacity: 0, height: 0 }}
               transition={{ duration: 0.15 }}
             >
-              <p className="text-[10px] text-gray-500 font-medium">タグを選択（AND検索）</p>
+              <p className="text-[11px] text-gray-500 font-medium">タグを選択（AND検索）</p>
               <div className="flex flex-wrap gap-1">
                 {allTags.map((tag) => {
                   const isSelected = selectedTags.includes(tag);
@@ -190,7 +190,7 @@ function SearchInput({
                     <button
                       key={tag}
                       type="button"
-                      className={`px-2 py-0.5 rounded-md text-[10px] font-medium transition-colors ${
+                      className={`px-2 py-0.5 rounded-md text-[11px] font-medium transition-colors ${
                         isSelected
                           ? "bg-indigo-500/30 text-indigo-300 ring-1 ring-indigo-500/40"
                           : "bg-gray-700/50 text-gray-400 hover:bg-gray-700/80 hover:text-gray-300"
@@ -204,7 +204,7 @@ function SearchInput({
               </div>
               <button
                 type="button"
-                className="w-full px-2 py-1 text-[10px] font-medium rounded-md bg-indigo-500/20 text-indigo-300 hover:bg-indigo-500/30 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                className="w-full px-2 py-1 text-[11px] font-medium rounded-md bg-indigo-500/20 text-indigo-300 hover:bg-indigo-500/30 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                 disabled={!canSearch}
                 onClick={handleTagSearch}
               >
@@ -348,7 +348,7 @@ export function Sidebar({
                     <h1 className="text-sm font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent whitespace-nowrap">
                       Requirements
                     </h1>
-                    <p className="text-[10px] text-gray-500 font-medium">Viewer</p>
+                    <p className="text-[11px] text-gray-500 font-medium">Viewer</p>
                   </div>
                 </div>
                 <button
@@ -384,7 +384,7 @@ export function Sidebar({
 
               {/* Navigation */}
               <nav className="flex-1 overflow-y-auto dark-scrollbar px-3 pb-4">
-                <p className="px-3 mb-2 text-[10px] font-semibold uppercase tracking-[0.15em] text-gray-600 whitespace-nowrap">
+                <p className="px-3 mb-2 text-[11px] font-semibold uppercase tracking-[0.15em] text-gray-600 whitespace-nowrap">
                   Apps
                 </p>
                 <div className="space-y-0.5">
@@ -393,7 +393,7 @@ export function Sidebar({
                       type="button"
                       key={app.name}
                       className={`
-                        w-full flex items-start gap-3 px-3 py-2.5 rounded-lg text-[13px] text-left
+                        w-full flex items-start gap-3 px-3 py-2.5 rounded-lg text-[14px] text-left
                         ${
                           selected === app.name
                             ? "bg-indigo-500/15 text-indigo-400 font-semibold shadow-lg shadow-indigo-500/5"
@@ -419,7 +419,7 @@ export function Sidebar({
                             {app.tags.slice(0, 3).map((tag) => (
                               <span
                                 key={tag}
-                                className="inline-flex px-1.5 py-0 rounded text-[9px] font-medium bg-gray-800/80 text-gray-500"
+                                className="inline-flex px-1.5 py-0 rounded text-[10px] font-medium bg-gray-800/80 text-gray-500"
                               >
                                 {tag}
                               </span>
@@ -453,13 +453,13 @@ export function Sidebar({
                 </div>
 
                 {/* Datasets */}
-                <p className="px-3 mt-6 mb-2 text-[10px] font-semibold uppercase tracking-[0.15em] text-gray-600 whitespace-nowrap">
+                <p className="px-3 mt-6 mb-2 text-[11px] font-semibold uppercase tracking-[0.15em] text-gray-600 whitespace-nowrap">
                   Datasets
                 </p>
                 <button
                   type="button"
                   className={`
-                    w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-[13px] whitespace-nowrap
+                    w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-[14px] whitespace-nowrap
                     ${
                       viewMode === "datasets"
                         ? "bg-amber-500/15 text-amber-400 font-semibold shadow-lg shadow-amber-500/5"
@@ -488,7 +488,7 @@ export function Sidebar({
 
               {/* Footer */}
               <div className="px-5 py-4 border-t border-gray-800/50">
-                <p className="text-[10px] text-gray-700 whitespace-nowrap">requirements_creator</p>
+                <p className="text-[11px] text-gray-700 whitespace-nowrap">requirements_creator</p>
               </div>
             </motion.aside>
           </>
@@ -598,7 +598,7 @@ export function Sidebar({
               <h1 className="text-sm font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent whitespace-nowrap">
                 Requirements
               </h1>
-              <p className="text-[10px] text-gray-500 font-medium">Viewer</p>
+              <p className="text-[11px] text-gray-500 font-medium">Viewer</p>
             </motion.div>
           </div>
           <motion.button
@@ -650,7 +650,7 @@ export function Sidebar({
         {/* Navigation */}
         <nav className="flex-1 overflow-y-auto dark-scrollbar px-3 pb-4">
           <motion.p
-            className="px-3 mb-2 text-[10px] font-semibold uppercase tracking-[0.15em] text-gray-600 whitespace-nowrap"
+            className="px-3 mb-2 text-[11px] font-semibold uppercase tracking-[0.15em] text-gray-600 whitespace-nowrap"
             animate={{ opacity: expanded ? 1 : 0 }}
             transition={{ duration: 0.2 }}
           >
@@ -670,7 +670,7 @@ export function Sidebar({
                 variants={itemVariants}
                 whileHover={{ x: 2 }}
                 className={`
-                  group w-full flex items-start gap-3 px-3 py-2.5 rounded-lg text-[13px] text-left
+                  group w-full flex items-start gap-3 px-3 py-2.5 rounded-lg text-[14px] text-left
                   ${
                     selected === app.name
                       ? "bg-indigo-500/15 text-indigo-400 font-semibold shadow-lg shadow-indigo-500/5"
@@ -698,7 +698,7 @@ export function Sidebar({
                       {app.tags.slice(0, 3).map((tag) => (
                         <span
                           key={tag}
-                          className="inline-flex px-1.5 py-0 rounded text-[9px] font-medium bg-gray-800/80 text-gray-500"
+                          className="inline-flex px-1.5 py-0 rounded text-[10px] font-medium bg-gray-800/80 text-gray-500"
                         >
                           {tag}
                         </span>
@@ -733,7 +733,7 @@ export function Sidebar({
 
           {/* Datasets */}
           <motion.p
-            className="px-3 mt-6 mb-2 text-[10px] font-semibold uppercase tracking-[0.15em] text-gray-600 whitespace-nowrap"
+            className="px-3 mt-6 mb-2 text-[11px] font-semibold uppercase tracking-[0.15em] text-gray-600 whitespace-nowrap"
             animate={{ opacity: expanded ? 1 : 0 }}
             transition={{ duration: 0.2 }}
           >
@@ -743,7 +743,7 @@ export function Sidebar({
             type="button"
             whileHover={{ x: 2 }}
             className={`
-              group w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-[13px] whitespace-nowrap
+              group w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-[14px] whitespace-nowrap
               ${
                 viewMode === "datasets"
                   ? "bg-amber-500/15 text-amber-400 font-semibold shadow-lg shadow-amber-500/5"
@@ -772,7 +772,7 @@ export function Sidebar({
 
         {/* Footer */}
         <div className="px-5 py-4 border-t border-gray-800/50">
-          <p className="text-[10px] text-gray-700 whitespace-nowrap">requirements_creator</p>
+          <p className="text-[11px] text-gray-700 whitespace-nowrap">requirements_creator</p>
         </div>
       </div>
     </motion.aside>

--- a/viewer/src/index.css
+++ b/viewer/src/index.css
@@ -1,6 +1,20 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+/* === Font size +1px global adjustment === */
+@theme {
+  --font-size-xs: 0.8125rem; /* 13px (default 12px) */
+  --font-size-xs--line-height: 1.125rem; /* 18px */
+  --font-size-sm: 0.9375rem; /* 15px (default 14px) */
+  --font-size-sm--line-height: 1.375rem; /* 22px */
+  --font-size-base: 1.0625rem; /* 17px (default 16px) */
+  --font-size-base--line-height: 1.625rem; /* 26px */
+  --font-size-lg: 1.1875rem; /* 19px (default 18px) */
+  --font-size-lg--line-height: 1.75rem; /* 28px */
+  --font-size-xl: 1.3125rem; /* 21px (default 20px) */
+  --font-size-xl--line-height: 1.875rem; /* 30px */
+}
+
 /* === Overscroll === */
 html,
 body {


### PR DESCRIPTION
## Summary

Issue #78 のスマホ版バグ6項目をまとめて対応。

Closes #78

## Changes

- **画面下部の切れ対策**: 全画面のbottom paddingを増加（スマホ: `pb-20`、デスクトップ: `pb-10`）
- **DatasetAddButton Portal化**: `createPortal`で`document.body`に直接レンダリングし、親要素のoverflow clippingを回避。透明オーバーレイ（`z-[60]`）で外部タップ時のドロップダウン閉じ＆リンク遷移防止を実装
- **Commit & Push ボタン移動**: AppViewからCommandRunnerのログヘッダーエリアに移動（PC/SP共通）
- **フォントサイズ+1px**: Tailwind CSS v4の`@theme`ディレクティブでグローバル設定（xs〜xl）、カスタムpx値は個別に+1px調整
- **CommandRunnerコマンドセレクタ固定**: 左ペインをセレクタ（固定）とオプション（スクロール可能）に分離し、実行中にセレクタが隠れる問題を解消

## Test plan

- [ ] スマホ表示で画面下部が切れないことを確認
- [ ] DatasetAddButtonのドロップダウンが画面上に正しく表示されることを確認
- [ ] ドロップダウン外タップでドロップダウンが閉じ、背後のリンクに遷移しないことを確認
- [ ] Commit & PushボタンがCommandRunner画面に表示されることを確認
- [ ] フォントサイズが全体的に1px大きくなっていることを確認
- [ ] CommandRunner実行中にコマンドセレクタが隠れないことを確認
- [ ] デスクトップ表示でも各機能が正常動作することを確認