### PR TITLE
feat: genリポジトリのブランチ切替機能を追加

### DIFF
--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -626,6 +626,57 @@ app.post("/api/git/commit-push", async (c) => {
   return c.json({ success: true, output: logs.join("\n") });
 });
 
+app.get("/api/git/branch", async (c) => {
+  const genDir = resolve(REQUIREMENTS_DIR, "..");
+  try {
+    const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD", { cwd: genDir });
+    return c.json({ branch: stdout.trim() });
+  } catch {
+    return c.json({ branch: null });
+  }
+});
+
+app.post("/api/git/switch-branch", async (c) => {
+  if (!isDev) return c.json({ error: "Only available in dev mode" }, 403);
+
+  const genDir = resolve(REQUIREMENTS_DIR, "..");
+
+  // 現在のブランチを取得
+  let currentBranch: string;
+  try {
+    const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD", { cwd: genDir });
+    currentBranch = stdout.trim();
+  } catch {
+    return c.json({
+      success: false,
+      branch: null,
+      output: "Error: gen ディレクトリに git リポジトリが見つかりません",
+    });
+  }
+
+  const targetBranch = currentBranch === "main" ? "develop" : "main";
+
+  try {
+    const { stdout, stderr } = await execAsync(`git checkout ${targetBranch}`, { cwd: genDir });
+    const output = [stdout, stderr].filter((s) => s.trim()).join("\n");
+    return c.json({
+      success: true,
+      branch: targetBranch,
+      output: output || `${targetBranch} に切り替えました`,
+    });
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; message: string };
+    const output = `${e.stdout || ""}${e.stderr || ""}`.trim() || e.message;
+    // 失敗時も現在ブランチを再取得
+    let branch = currentBranch;
+    try {
+      const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD", { cwd: genDir });
+      branch = stdout.trim();
+    } catch {}
+    return c.json({ success: false, branch, output });
+  }
+});
+
 // --- Commands API (dev mode only) ---
 
 const ALLOWED_COMMANDS: Record<string, { bin: string; baseArgs: string[] }> = {

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -400,3 +400,19 @@ export async function commitAndPush(): Promise<GitResult> {
   const res = await fetch(`${BASE}/git/commit-push`, { method: "POST" });
   return res.json();
 }
+
+export async function getGenBranch(): Promise<{ branch: string | null }> {
+  const res = await fetch(`${BASE}/git/branch`);
+  return res.json();
+}
+
+export interface SwitchBranchResult {
+  success: boolean;
+  branch: string | null;
+  output: string;
+}
+
+export async function switchGenBranch(): Promise<SwitchBranchResult> {
+  const res = await fetch(`${BASE}/git/switch-branch`, { method: "POST" });
+  return res.json();
+}

--- a/viewer/src/components/CommandRunner.tsx
+++ b/viewer/src/components/CommandRunner.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { abortCommand, type CommandEvent, commitAndPush, executeCommand } from "../api";
+import {
+  abortCommand,
+  type CommandEvent,
+  commitAndPush,
+  executeCommand,
+  getGenBranch,
+  switchGenBranch,
+} from "../api";
 import { useToast } from "./Toast";
 
 // --- Types ---
@@ -244,6 +251,8 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [running, setRunning] = useState(false);
   const [pushing, setPushing] = useState(false);
+  const [genBranch, setGenBranch] = useState<string | null>(null);
+  const [switching, setSwitching] = useState(false);
   const { showToast } = useToast();
   const logContainerRef = useRef<HTMLDivElement>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -282,6 +291,7 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
   // Initial fetch
   useEffect(() => {
     fetchDynamicChoices();
+    getGenBranch().then((r) => setGenBranch(r.branch));
   }, [fetchDynamicChoices]);
 
   // Auto-scroll logs (container直接スクロールで親要素への波及を防止)
@@ -471,6 +481,31 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
     }
   }, [pushing, showToast]);
 
+  const handleSwitchBranch = useCallback(async () => {
+    if (switching) return;
+    setSwitching(true);
+    try {
+      const result = await switchGenBranch();
+      setGenBranch(result.branch);
+      showToast({
+        title: result.success ? "ブランチ切替完了" : "ブランチ切替失敗",
+        output: result.output,
+        success: result.success,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      showToast({
+        title: "ブランチ切替エラー",
+        output: message,
+        success: false,
+      });
+      // エラー時もブランチ名を再取得
+      getGenBranch().then((r) => setGenBranch(r.branch));
+    } finally {
+      setSwitching(false);
+    }
+  }, [switching, showToast]);
+
   if (!isDev) {
     return (
       <div className="flex h-full items-center justify-center text-gray-500 text-sm">
@@ -515,6 +550,18 @@ export function CommandRunner({ isMobile, isDev }: CommandRunnerProps) {
               disabled={pushing}
             >
               {pushing ? "Push中..." : "Commit & Push"}
+            </button>
+            <button
+              type="button"
+              className={`px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                switching
+                  ? "bg-gray-700 text-gray-400 cursor-not-allowed"
+                  : "bg-emerald-600/20 text-emerald-300 ring-1 ring-emerald-500/40 hover:bg-emerald-600/30"
+              }`}
+              onClick={handleSwitchBranch}
+              disabled={switching}
+            >
+              {switching ? "切替中..." : `Branch: ${genBranch ?? "---"}`}
             </button>
           </div>
 


### PR DESCRIPTION
## Summary

Viewerのコマンド画面からgenリポジトリのブランチ（main⇔develop）を切り替えられるボタンを追加。

Closes #80

## Changes

- `GET /api/git/branch` — genリポジトリの現在ブランチ名を返すエンドポイント
- `POST /api/git/switch-branch` — main⇔developをトグルするエンドポイント（差分がある場合は失敗+現在ブランチ名返却）
- `getGenBranch()` / `switchGenBranch()` フロントエンドAPI関数
- CommandRunnerのコマンドボタン列にブランチ切替ボタン追加（Commit & Pushと同じemerald色、`Branch: develop` 等のラベル表示）

## Test plan

- [ ] コマンド画面で「Branch: develop」ボタンが表示されることを確認
- [ ] ボタン押下でmainに切り替わり、ラベルが「Branch: main」に更新されることを確認
- [ ] 再度押下でdevelopに戻ることを確認
- [ ] gen側に未コミットの差分がある状態で切替が失敗し、現在ブランチ名が正しく表示されることを確認
- [ ] SP版でもボタンが正しく表示・動作することを確認