### PR TITLE
fix: Mermaid全画面表示中の横スワイプによるタブ移動を防止

### DIFF
--- a/viewer/src/components/MarkdownPane.tsx
+++ b/viewer/src/components/MarkdownPane.tsx
@@ -99,8 +99,17 @@ function MermaidFullscreenDialog({ svgHtml, onClose }: { svgHtml: string; onClos
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
 
+  const stopSwipePropagation = useCallback((e: React.PointerEvent) => {
+    e.stopPropagation();
+  }, []);
+
   return createPortal(
-    <div className="fixed inset-0 z-50 flex flex-col bg-gray-950/95">
+    <div
+      className="fixed inset-0 z-50 flex flex-col bg-gray-950/95"
+      onPointerDown={stopSwipePropagation}
+      onPointerMove={stopSwipePropagation}
+      onPointerUp={stopSwipePropagation}
+    >
       <div className="flex items-center justify-between px-4 py-3">
         <span className="text-xs text-gray-500">ESC で閉じる</span>
         <button


### PR DESCRIPTION
## Summary

SP版ViewerでMermaid図の全画面表示中に横スワイプするとタブ移動が発火する問題を修正。

`MermaidFullscreenDialog`は`createPortal`で`document.body`に描画されるが、Reactの合成イベントはReactコンポーネントツリーを通じてバブリングするため、PointerEventが親の`useSwipeTab`ハンドラまで伝播していた。全画面ダイアログの最外層divで`stopPropagation()`を呼ぶことで解決。

Closes #81

## Changes

- `MermaidFullscreenDialog`の最外層divに`onPointerDown`/`onPointerMove`/`onPointerUp`で`stopPropagation()`を追加

## Test plan

- [ ] SP版Viewerで図解タブを表示し、Mermaid図を全画面表示する
- [ ] 全画面表示中に横スワイプしてもタブが切り替わらないことを確認
- [ ] 全画面表示中のピンチズーム・パン操作が正常に動作することを確認
- [ ] 全画面表示を閉じた後、通常の横スワイプによるタブ移動が正常に動作することを確認