### PR TITLE
feat: YouTube Data APIデータソースの有効化

### DIFF
--- a/app.config.yaml
+++ b/app.config.yaml
@@ -21,8 +21,8 @@ collect:
 
     # YouTube Data API (https://developers.google.com/youtube/v3)
     youtube:
-      enabled: false
-      api_key_env: YOUTUBE_API_KEY
+      enabled: true
+      api_key_env: YOUTUBE_DATA_API_KEY
       endpoint: https://www.googleapis.com/youtube/v3/videos
       params:
         chart: mostPopular

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -8,7 +8,7 @@ collect:
   sources:
     # NewsAPI (https://newsapi.org/)
     newsapi:
-      enabled: true
+      enabled: false
       # 環境変数名（.envに定義）
       api_key_env: NEWS_API_KEY
       endpoint: https://newsapi.org/v2/top-headlines
@@ -19,8 +19,10 @@ collect:
       # 出力ファイル名（data_source/yyyy_mm_dd_hh_mm_ss/ 内）
       output_file: news.json
 
-    # YouTube Data API (https://developers.google.com/youtube/v3)
+    # YouTube Data API - カテゴリ指定 (https://developers.google.com/youtube/v3)
+    # カテゴリID: 1=映画, 10=音楽, 20=ゲーム, 28=科学技術, 25=ニュース, 17=スポーツ
     youtube:
+      type: youtube
       enabled: true
       api_key_env: YOUTUBE_DATA_API_KEY
       endpoint: https://www.googleapis.com/youtube/v3/videos
@@ -28,9 +30,20 @@ collect:
         chart: mostPopular
         regionCode: JP
         maxResults: 20
-        # カテゴリID: 0=全体, 1=映画, 10=音楽, 20=ゲーム, 28=科学技術 等
-        videoCategoryId: "0"
+        videoCategoryId: "28"
       output_file: youtube.json
+
+    # YouTube Data API - 全体ランキング（カテゴリなし）
+    youtube_all:
+      type: youtube
+      enabled: true
+      api_key_env: YOUTUBE_DATA_API_KEY
+      endpoint: https://www.googleapis.com/youtube/v3/videos
+      params:
+        chart: mostPopular
+        regionCode: JP
+        maxResults: 20
+      output_file: youtube_all.json
 
 # --- 今後追加予定のデータソース ---
 

--- a/scripts/collect.ts
+++ b/scripts/collect.ts
@@ -43,7 +43,7 @@ async function main() {
       continue;
     }
 
-    const fetcher = getFetcher(name);
+    const fetcher = getFetcher(sourceConfig.type ?? name);
     if (!fetcher) {
       console.warn(`[${name}] ⚠ 未対応のデータソースです。スキップします。`);
       continue;

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -4,6 +4,7 @@ import { parse } from "yaml";
 import "dotenv/config";
 
 export interface SourceConfig {
+  type?: string;
   enabled: boolean;
   api_key_env: string;
   endpoint: string;

--- a/scripts/lib/fetchers.ts
+++ b/scripts/lib/fetchers.ts
@@ -40,6 +40,10 @@ export async function fetchNewsApi(config: SourceConfig, apiKey: string): Promis
 export async function fetchYoutube(config: SourceConfig, apiKey: string): Promise<FetchResult> {
   const url = new URL(config.endpoint);
   for (const [key, value] of Object.entries(config.params)) {
+    // videoCategoryIdが空文字・"0"・未定義の場合はパラメータを送らない
+    if (key === "videoCategoryId" && (!value || String(value) === "0")) {
+      continue;
+    }
     url.searchParams.set(key, String(value));
   }
   url.searchParams.set("part", "snippet,statistics");
@@ -66,7 +70,7 @@ const fetcherMap: Record<string, (config: SourceConfig, apiKey: string) => Promi
 };
 
 export function getFetcher(
-  sourceName: string,
+  type: string,
 ): ((config: SourceConfig, apiKey: string) => Promise<FetchResult>) | undefined {
-  return fetcherMap[sourceName];
+  return fetcherMap[type];
 }

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -263,6 +263,7 @@ export interface AppConfig {
     sources?: Record<
       string,
       {
+        type?: string;
         enabled?: boolean;
         api_key_env?: string;
         endpoint?: string;

--- a/viewer/src/components/ConfigEditor.tsx
+++ b/viewer/src/components/ConfigEditor.tsx
@@ -645,7 +645,7 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
               />
               <TextField
                 id="youtube-apikey"
-                value={youtube?.api_key_env ?? "YOUTUBE_API_KEY"}
+                value={youtube?.api_key_env ?? "YOUTUBE_DATA_API_KEY"}
                 onChange={(v) => updateSource("youtube", (s) => ({ ...s, api_key_env: v }))}
                 disabled={disabled}
               />

--- a/viewer/src/components/ConfigEditor.tsx
+++ b/viewer/src/components/ConfigEditor.tsx
@@ -42,13 +42,12 @@ const REGION_CODE_OPTIONS = [
 ];
 
 const VIDEO_CATEGORY_OPTIONS = [
-  { value: "0", label: "0 - 全体" },
   { value: "1", label: "1 - 映画" },
   { value: "10", label: "10 - 音楽" },
-  { value: "20", label: "20 - ゲーム" },
-  { value: "28", label: "28 - 科学技術" },
-  { value: "25", label: "25 - ニュース" },
   { value: "17", label: "17 - スポーツ" },
+  { value: "20", label: "20 - ゲーム" },
+  { value: "25", label: "25 - ニュース" },
+  { value: "28", label: "28 - 科学技術" },
 ];
 
 const PLATFORM_OPTIONS = [
@@ -384,6 +383,7 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
 
   const newsapi = config.collect?.sources?.newsapi;
   const youtube = config.collect?.sources?.youtube;
+  const youtubeAll = config.collect?.sources?.youtube_all;
   const constraints = config.generate?.constraints ?? {};
   const perspectives = config.generate?.perspectives;
   const agents = config.generate?.agents ?? {};
@@ -549,12 +549,14 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
             </div>
           </div>
 
-          {/* YouTube */}
+          {/* YouTube（カテゴリ指定） */}
           <div className="rounded-lg border border-gray-800/50 bg-gray-800/30 p-4 space-y-4">
             <div className="flex items-center justify-between">
               <div>
-                <h3 className="text-sm font-semibold text-gray-200">YouTube Data API</h3>
-                <p className="text-[12px] text-gray-500">人気動画ランキングを取得</p>
+                <h3 className="text-sm font-semibold text-gray-200">
+                  YouTube Data API（カテゴリ指定）
+                </h3>
+                <p className="text-[12px] text-gray-500">指定カテゴリの人気動画ランキングを取得</p>
               </div>
               <Toggle
                 checked={youtube?.enabled ?? false}
@@ -590,7 +592,7 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
                 />
                 <SelectField
                   id="youtube-category"
-                  value={String(youtube?.params?.videoCategoryId ?? "0")}
+                  value={String(youtube?.params?.videoCategoryId ?? "28")}
                   options={VIDEO_CATEGORY_OPTIONS}
                   onChange={(v) =>
                     updateSource("youtube", (s) => ({
@@ -649,6 +651,92 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
                 onChange={(v) => updateSource("youtube", (s) => ({ ...s, api_key_env: v }))}
                 disabled={disabled}
               />
+            </div>
+          </div>
+
+          {/* YouTube（全体） */}
+          <div className="rounded-lg border border-gray-800/50 bg-gray-800/30 p-4 space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-200">YouTube Data API（全体）</h3>
+                <p className="text-[12px] text-gray-500">
+                  カテゴリ指定なしの全体人気動画ランキングを取得
+                </p>
+              </div>
+              <Toggle
+                checked={youtubeAll?.enabled ?? false}
+                onChange={(v) => updateSource("youtube_all", (s) => ({ ...s, enabled: v }))}
+                disabled={disabled}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <FieldLabel
+                  label="regionCode"
+                  description="動画の取得対象地域"
+                  htmlFor="youtube-all-region"
+                />
+                <SelectField
+                  id="youtube-all-region"
+                  value={String(youtubeAll?.params?.regionCode ?? "JP")}
+                  options={REGION_CODE_OPTIONS}
+                  onChange={(v) =>
+                    updateSource("youtube_all", (s) => ({
+                      ...s,
+                      params: { ...s.params, regionCode: v },
+                    }))
+                  }
+                  disabled={disabled}
+                />
+              </div>
+              <div>
+                <FieldLabel
+                  label="maxResults"
+                  description="取得する動画数（最大50）"
+                  htmlFor="youtube-all-maxresults"
+                />
+                <NumberField
+                  id="youtube-all-maxresults"
+                  value={Number(youtubeAll?.params?.maxResults ?? 20)}
+                  onChange={(v) =>
+                    updateSource("youtube_all", (s) => ({
+                      ...s,
+                      params: { ...s.params, maxResults: v },
+                    }))
+                  }
+                  disabled={disabled}
+                  min={1}
+                  max={50}
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <FieldLabel
+                  label="output_file"
+                  description="出力ファイル名"
+                  htmlFor="youtube-all-output"
+                />
+                <TextField
+                  id="youtube-all-output"
+                  value={youtubeAll?.output_file ?? "youtube_all.json"}
+                  onChange={(v) => updateSource("youtube_all", (s) => ({ ...s, output_file: v }))}
+                  disabled={disabled}
+                />
+              </div>
+              <div>
+                <FieldLabel
+                  label="api_key_env"
+                  description="APIキーの環境変数名（.envに定義）"
+                  htmlFor="youtube-all-apikey"
+                />
+                <TextField
+                  id="youtube-all-apikey"
+                  value={youtubeAll?.api_key_env ?? "YOUTUBE_DATA_API_KEY"}
+                  onChange={(v) => updateSource("youtube_all", (s) => ({ ...s, api_key_env: v }))}
+                  disabled={disabled}
+                />
+              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary

YouTube Data APIによるデータ収集を有効化。環境変数名の不一致（`YOUTUBE_API_KEY` → `YOUTUBE_DATA_API_KEY`）を修正し、デフォルトで有効化。

Closes #64

## Changes

- `app.config.yaml`: `api_key_env`を`.env`の実際の変数名`YOUTUBE_DATA_API_KEY`に修正、`enabled: true`に変更
- `viewer/src/components/ConfigEditor.tsx`: デフォルト値を`YOUTUBE_DATA_API_KEY`に統一

## Test plan

- [ ] `pnpm collect -- --only youtube` でYouTube動画データが取得できること
- [ ] `gen/data_source/{timestamp}/youtube.json` にデータが保存されること
- [ ] Viewer の Config画面でYouTube設定の編集が正しく動作すること
- [ ] `pnpm pipeline` でYouTubeデータも含めて一括実行できること