### PR TITLE
feat: Slack通知にメンション追加とviewer_hostのUI編集対応

### DIFF
--- a/app.config.yaml
+++ b/app.config.yaml
@@ -74,7 +74,12 @@ notifications:
     # 詳細は SLACK_NOTIFICATION.md を参照
     token_env: SLACK_BOT_USER_OAUTH_TOKEN
     # Viewerへのリンク生成用ホスト（通知メッセージにアプリへのリンクを含める）
-    viewer_host: http://localhost:3001
+    viewer_host: http://100.113.125.78:3001
+    # メンション設定（通知メッセージにメンションを付与）
+    # - Slack User ID（例: U01ABCDEF）を指定すると <@U01ABCDEF> 形式で個人メンション
+    # - "channel" を指定すると <!channel> でチャンネル全員にメンション
+    # - 未設定の場合はメンションなし
+    mention: channel
 
 # --- パイプライン共通設定 ---
 pipeline:

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -62,6 +62,7 @@ export interface SlackConfig {
   enabled: boolean;
   token_env?: string;
   viewer_host?: string;
+  mention?: string;
 }
 
 export interface NotificationsConfig {

--- a/scripts/lib/slack.ts
+++ b/scripts/lib/slack.ts
@@ -12,6 +12,7 @@ export interface SlackNotificationResult {
 interface SlackContext {
   token: string;
   viewerHost?: string;
+  mention?: string;
 }
 
 function getSlackContext(): SlackContext | undefined {
@@ -21,7 +22,13 @@ function getSlackContext(): SlackContext | undefined {
   const envKey = slackConfig.token_env ?? "SLACK_BOT_USER_OAUTH_TOKEN";
   const token = process.env[envKey];
   if (!token) return undefined;
-  return { token, viewerHost: slackConfig.viewer_host };
+  return { token, viewerHost: slackConfig.viewer_host, mention: slackConfig.mention };
+}
+
+function formatMention(mention: string | undefined): string {
+  if (!mention) return "";
+  if (mention === "channel") return "<!channel> ";
+  return `<@${mention}> `;
 }
 
 function appLink(viewerHost: string | undefined, appName: string): string {
@@ -85,7 +92,12 @@ export async function notifyPipelineResult(
     })
     .join("\n");
 
-  const lines: string[] = [`${emoji} *パイプライン${statusText}${modeLabel}*`, "", stepLines];
+  const mentionPrefix = formatMention(ctx.mention);
+  const lines: string[] = [
+    `${mentionPrefix}${emoji} *パイプライン${statusText}${modeLabel}*`,
+    "",
+    stepLines,
+  ];
 
   if (opts?.articleCount !== undefined) {
     lines.push("", `記事数: ${opts.articleCount}`);
@@ -105,13 +117,14 @@ export async function notifyGenerateResult(newApps?: string[]): Promise<SlackNot
   const ctx = getSlackContext();
   if (!ctx) return { success: false, error: "Slack通知が無効または未設定です" };
 
+  const mentionPrefix = formatMention(ctx.mention);
   if (newApps && newApps.length > 0) {
     const appLinks = newApps.map((a) => appLink(ctx.viewerHost, a)).join(", ");
-    const text = `:white_check_mark: *要件生成完了*\n生成アプリ: ${appLinks}`;
+    const text = `${mentionPrefix}:white_check_mark: *要件生成完了*\n生成アプリ: ${appLinks}`;
     return postToSlack(ctx.token, text);
   }
 
-  const text = `:white_check_mark: *要件生成完了*\n生成アプリ: （新規アプリなし）`;
+  const text = `${mentionPrefix}:white_check_mark: *要件生成完了*\n生成アプリ: （新規アプリなし）`;
   return postToSlack(ctx.token, text);
 }
 

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -297,6 +297,14 @@ export interface AppConfig {
       }
     >;
   };
+  notifications?: {
+    slack?: {
+      enabled?: boolean;
+      token_env?: string;
+      viewer_host?: string;
+      mention?: string;
+    };
+  };
 }
 
 export async function fetchConfig(): Promise<AppConfig> {

--- a/viewer/src/components/ConfigEditor.tsx
+++ b/viewer/src/components/ConfigEditor.tsx
@@ -1002,6 +1002,80 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
           </div>
         </section>
 
+        {/* --- Notifications --- */}
+        <section className="rounded-xl border border-gray-800 bg-gray-900/50 p-5 space-y-4">
+          <SectionHeader title="Notifications" description="パイプライン完了時の通知設定" />
+
+          {/* Slack */}
+          <div className="rounded-lg border border-gray-800/50 bg-gray-800/30 p-4 space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-200">Slack</h3>
+                <p className="text-[12px] text-gray-500">
+                  パイプライン完了時にSlackチャンネルへ通知
+                </p>
+              </div>
+              <Toggle
+                checked={config.notifications?.slack?.enabled ?? false}
+                onChange={(v) =>
+                  persistConfig({
+                    ...config,
+                    notifications: {
+                      ...config.notifications,
+                      slack: { ...config.notifications?.slack, enabled: v },
+                    },
+                  })
+                }
+                disabled={disabled}
+              />
+            </div>
+            <div>
+              <FieldLabel
+                label="viewer_host"
+                description="通知メッセージ内のアプリリンクに使用するViewerホストURL"
+                htmlFor="slack-viewer-host"
+              />
+              <TextField
+                id="slack-viewer-host"
+                value={config.notifications?.slack?.viewer_host ?? ""}
+                onChange={(v) =>
+                  persistConfig({
+                    ...config,
+                    notifications: {
+                      ...config.notifications,
+                      slack: { ...config.notifications?.slack, viewer_host: v || undefined },
+                    },
+                  })
+                }
+                disabled={disabled}
+                placeholder="例: http://100.113.125.78:3001"
+              />
+            </div>
+            <div>
+              <FieldLabel
+                label="mention"
+                description="通知時のメンション（Slack User ID または 'channel'。空欄でメンションなし）"
+                htmlFor="slack-mention"
+              />
+              <TextField
+                id="slack-mention"
+                value={config.notifications?.slack?.mention ?? ""}
+                onChange={(v) =>
+                  persistConfig({
+                    ...config,
+                    notifications: {
+                      ...config.notifications,
+                      slack: { ...config.notifications?.slack, mention: v || undefined },
+                    },
+                  })
+                }
+                disabled={disabled}
+                placeholder="例: U01ABCDEF または channel"
+              />
+            </div>
+          </div>
+        </section>
+
         {/* --- Pipeline --- */}
         <section className="rounded-xl border border-gray-800 bg-gray-900/50 p-5">
           <SectionHeader title="Pipeline" description="パイプライン共通の設定" />


### PR DESCRIPTION
## Summary

- Slack通知に個人メンション（`<@USER_ID>`）またはチャンネルメンション（`<!channel>`）を付与する機能を追加
- 通知内アプリURLのviewer_hostをtailnet向けURLに変更し、Viewer ConfigEditorから編集可能にした

Closes #88

## Changes

- `scripts/lib/config.ts`: `SlackConfig`に`mention`フィールドを追加
- `scripts/lib/slack.ts`: `formatMention`ヘルパー追加、`notifyPipelineResult`/`notifyGenerateResult`でメンション付与
- `app.config.yaml`: `viewer_host`をtailnet URL(`http://100.113.125.78:3001`)に変更、`mention: channel`設定追加
- `viewer/src/api.ts`: `AppConfig`型に`notifications`セクション追加
- `viewer/src/components/ConfigEditor.tsx`: Notificationsセクション（Slack enabled/viewer_host/mention）のUI追加

## Test plan

- [ ] `pnpm viewer`でConfigEditorにNotificationsセクションが表示されることを確認
- [ ] viewer_host・mentionフィールドの編集・保存が動作すること
- [ ] Slack通知送信時にメンションが付与されることを確認（`mention: channel`で`<!channel>`、User IDで`<@USER_ID>`）
- [ ] メンション未設定時は従来通りメンションなしで通知されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)