### PR TITLE
feat: パイプラインキュー機能を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 │   │       └── keyword.json
 │   ├── datasets/             # データセット定義（JSON、Viewer経由で管理）
 │   │   └── {dataset_name}.json
+│   ├── pipeline_queue/       # パイプラインキュー（アイデアをJSON保存、スケジューラで自動処理）
+│   │   └── {id}.json
 │   └── requirements/         # 生成されたアプリ要件（アプリ単位のサブディレクトリ）
 │       └── {app_name}/
 │           ├── _source_info.json
@@ -59,8 +61,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 │   ├── collect.ts            # データ収集
 │   ├── extract.sh / extract.ts  # キーワード抽出
 │   ├── generate.sh / generate.ts  # 要件生成
+│   ├── regenerate.sh         # 既存アプリの再生成
 │   ├── validate-requirements.ts  # バリデーション
 │   ├── pipeline.ts           # パイプライン一括実行
+│   ├── process-queue.ts      # パイプラインキュー処理（キュー内アイテムを順次pipeline実行）
+│   ├── scheduler-run.sh      # systemdタイマー用ラッパー（キュー優先で分岐実行）
+│   ├── scheduler-ctl.sh      # systemdスケジューラの有効/無効/状態確認
 │   └── lib/                  # 共通ライブラリ
 │       ├── cli.ts            # CLIオプションパーサー
 │       ├── config.ts         # app.config.yaml読み込み
@@ -84,8 +90,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 │           ├── FavoritePage.tsx   # お気に入り一覧ページ（解除・データセット追加機能付き）
 │           ├── MarkdownPane.tsx   # Markdownレンダリング
 │           ├── MemoTab.tsx        # メモ編集タブ
+│           ├── QueueManager.tsx   # パイプラインキュー管理画面（CRUD操作）
 │           ├── SearchView.tsx     # 検索結果表示
 │           ├── Sidebar.tsx        # アプリ選択サイドバー（タグフィルタ・検索機能付き）
+│           ├── CommandRunner.tsx  # コマンド実行UI（パイプライン操作等）
+│           ├── ConfigEditor.tsx   # app.config.yaml編集UI
 │           └── Toast.tsx          # トースト通知
 ├── todo/                     # 開発タスク管理（フェーズ別）
 ├── app.config.yaml           # アプリケーション設定（フェーズ別の設定を階層管理）
@@ -134,6 +143,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | `pnpm generate` | キーワードから要件生成 |
 | `pnpm generate:validate` | 要件構造のバリデーション |
 | `pnpm pipeline` | 上記を一括実行（`--skip-collect`, `--skip-extract`, `--source <dir>` オプション対応） |
+| `pnpm regenerate` | 既存アプリの要件を再生成 |
+| `pnpm queue:process` | パイプラインキュー内のアイテムを順次処理 |
+
+### スケジューラ
+
+| コマンド | 説明 |
+| --------- | ------ |
+| `pnpm scheduler:enable` | systemdスケジューラを有効化 |
+| `pnpm scheduler:disable` | systemdスケジューラを無効化 |
+| `pnpm scheduler:status` | スケジューラの状態・今後の実行予定を表示 |
 
 ### Webビューワー
 
@@ -271,11 +290,42 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | `GET /api/apps-with-tags` | 全アプリのタグ情報（全タグ取得、名前順） |
 | `GET /api/search?q=&tags=` | 全文検索 + タグAND検索（複合検索対応） |
 
+### パイプラインキュー
+
+| エンドポイント | 説明 |
+| -------------- | ------ |
+| `GET /api/queue` | キューアイテム一覧取得 |
+| `GET /api/queue/:id` | キューアイテム詳細取得 |
+| `POST /api/queue` | キューアイテム作成（dev modeのみ、body: `{title, content}`） |
+| `PUT /api/queue/:id` | キューアイテム更新（dev modeのみ、body: `{title?, content?}`） |
+| `DELETE /api/queue/:id` | キューアイテム削除（dev modeのみ） |
+
+### 設定
+
+| エンドポイント | 説明 |
+| -------------- | ------ |
+| `GET /api/config` | app.config.yamlの内容取得 |
+| `PUT /api/config` | app.config.yamlの更新（dev modeのみ） |
+| `GET /api/apps/:name/config` | アプリ固有の設定取得 |
+
+### コマンド実行
+
+| エンドポイント | 説明 |
+| -------------- | ------ |
+| `GET /api/commands/data-sources` | データソース一覧 |
+| `GET /api/commands/apps` | アプリ名一覧 |
+| `GET /api/commands/collect-sources` | 収集ソース一覧（config由来） |
+| `GET /api/commands/dataset-names` | データセット名一覧 |
+| `POST /api/commands/execute` | コマンド実行（dev modeのみ、body: `{command, args}`） |
+| `POST /api/commands/abort` | 実行中コマンドの中止 |
+
 ### Git操作
 
 | エンドポイント | 説明 |
 | -------------- | ------ |
 | `POST /api/git/commit-push` | genディレクトリのgit add + commit + push（dev modeのみ） |
+| `GET /api/git/branch` | 現在のブランチ名取得 |
+| `POST /api/git/switch-branch` | main/develop間のブランチ切り替え（dev modeのみ） |
 
 ## pnpmワークスペース構成
 

--- a/USECASE_QUEUE.md
+++ b/USECASE_QUEUE.md
@@ -1,0 +1,290 @@
+# USECASE_QUEUE.md - パイプラインキュー機能
+
+ユーザーのジャストアイデアを保存しておき、定期実行（systemdスケジューラ）で自動的に要件生成するキュー機能のドキュメント。
+
+---
+
+## 目次
+
+- [概要](#概要)
+- [使い方](#使い方)
+  - [Viewer からキューを管理する](#viewer-からキューを管理する)
+  - [CLI からキューを処理する](#cli-からキューを処理する)
+  - [systemd スケジューラとの連携](#systemd-スケジューラとの連携)
+- [内部実装](#内部実装)
+  - [データ構造](#データ構造)
+  - [処理フロー](#処理フロー)
+  - [API エンドポイント](#api-エンドポイント)
+  - [ファイル構成](#ファイル構成)
+- [よくあるシナリオ](#よくあるシナリオ)
+
+---
+
+## 概要
+
+### 何ができるか
+
+- アプリのアイデアを `gen/pipeline_queue/` に保存しておく
+- 定期実行時（systemd タイマー）にキューが自動で処理され、要件が生成される
+- Viewer のキュー管理画面から新規作成・編集・削除ができる
+
+### なぜ必要か
+
+- 思いついたアイデアをすぐに保存しておきたい（でも今すぐ generate したくない）
+- ユーザーの活動時間外（例: AM 5:00）に実行することで、Claude サブスクリプションの利用を効率化
+- 既存のパイプライン（collect → extract → generate）には手を加えず、外付けで実現
+
+### 動作原理
+
+```
+[ユーザー]
+   │ アイデアを書く
+   ▼
+gen/pipeline_queue/{id}.json    ← Viewer or 手動で配置
+   │
+   │ (systemd タイマー or 手動実行)
+   ▼
+process-queue.ts
+   │ キュー1件ごとに:
+   ├─ gen/data_source/{timestamp}/user_proposal.md を作成
+   ├─ pnpm pipeline --skip-collect --source {timestamp} を実行
+   └─ 成功 → キューファイルを削除（data_source 側は残る）
+```
+
+---
+
+## 使い方
+
+### Viewer からキューを管理する
+
+Viewer のサイドバーにあるオレンジ色のキューアイコン（横線が並んだアイコン）をクリック。
+
+#### 新規作成
+
+1. キュー画面右上の `+` ボタンをクリック
+2. **タイトル**: アプリのアイデア名を入力（例: `ペットの健康管理アプリ`）
+3. **内容**: アイデアの詳細を自由に記述
+   - 箇条書きでも文章でもOK
+   - 後で AI が user_proposal.md として読むので、やりたいことを素直に書く
+4. 「追加」ボタンで保存
+
+#### 編集
+
+1. キュー一覧からアイテムを選択
+2. 右上の鉛筆アイコンをクリック
+3. タイトル・内容を修正して「更新」
+
+#### 削除
+
+- 一覧のアイテムにホバーしてゴミ箱アイコンをクリック
+- または詳細画面の右上のゴミ箱アイコンをクリック
+
+### CLI からキューを処理する
+
+```bash
+# キューに溜まったアイテムを全て処理（即時実行したい場合）
+pnpm queue:process
+```
+
+キューが空なら何もせず終了する。1件ずつ順番に処理し、成功したアイテムはキューから削除される。失敗したアイテムはキューに残り、次回の実行で再試行される。
+
+### systemd スケジューラとの連携
+
+`scheduler-run.sh` の分岐ロジック:
+
+```
+スケジューラ実行開始
+   │
+   ├─ gen/pipeline_queue/ に .json ファイルがある？
+   │     YES → pnpm queue:process（キューを処理）
+   │     NO  → pnpm pipeline（新規データを collect して生成）
+   │
+   ▼
+スケジューラ実行終了
+```
+
+つまり:
+
+- **キューにアイデアがある日** → キューの要件生成が優先される
+- **キューが空の日** → 通常通り外部 API からデータ収集して新しいアプリを生成
+
+スケジューラの有効化:
+
+```bash
+pnpm scheduler:enable    # systemd タイマー有効化
+pnpm scheduler:status    # 状態確認
+```
+
+---
+
+## 内部実装
+
+### データ構造
+
+キューアイテムは `gen/pipeline_queue/{id}.json` に1ファイル1アイテムで保存される。
+
+```json
+{
+  "id": "1739520000000-a1b2c3",
+  "title": "ペットの健康管理アプリ",
+  "content": "毎日の食事・運動・体重を記録し、獣医との共有もできるアプリ\n\n- 写真で食事記録\n- 散歩のGPSトラッキング\n- 体重グラフ",
+  "createdAt": "2026-02-14T12:00:00.000Z",
+  "updatedAt": "2026-02-14T12:00:00.000Z"
+}
+```
+
+| フィールド | 説明 |
+|-----------|------|
+| `id` | `{timestamp_ms}-{random_6chars}` 形式のユニーク ID。ファイル名にもなる |
+| `title` | アイデアのタイトル。`user_proposal.md` の `# 見出し` になる |
+| `content` | アイデアの本文。Markdown 可。そのまま `user_proposal.md` の本文になる |
+| `createdAt` | 作成日時（ISO 8601） |
+| `updatedAt` | 最終更新日時（ISO 8601） |
+
+### 処理フロー
+
+`scripts/process-queue.ts` の処理:
+
+```
+1. gen/pipeline_queue/*.json を読み込み、createdAt 昇順でソート
+2. アイテムごとにループ:
+   a. タイムスタンプ付きディレクトリを作成: gen/data_source/{yyyy_mm_dd_hh_mm_ss}/
+   b. user_proposal.md を書き出し:
+      ---
+      # {item.title}
+
+      {item.content}
+      ---
+   c. execSync で実行:
+      pnpm pipeline --skip-collect --source {timestamp_dir}
+      → extract（キーワード抽出）→ generate（要件生成）→ validate
+   d. 成功 → gen/pipeline_queue/{id}.json を削除
+      失敗 → キューに残す（次回再試行）
+```
+
+ポイント:
+
+- `--skip-collect` を指定するので外部 API は呼ばない
+- `user_proposal.md` は `scripts/lib/data-source.ts` の `loadAllTexts()` で自動認識される
+- 処理は逐次実行（1件ずつ）。並列ではない
+- `data_source` 側のファイルは処理後も残る（キューファイルのみ削除）
+
+### API エンドポイント
+
+全て `viewer/server.ts` に実装。dev mode のみ書き込み可能。
+
+| メソッド | パス | 説明 | dev mode |
+|---------|------|------|----------|
+| `GET` | `/api/queue` | キュー一覧（createdAt 昇順） | 不要 |
+| `GET` | `/api/queue/:id` | キュー詳細 | 不要 |
+| `POST` | `/api/queue` | キュー追加（body: `{title, content}`） | 必要 |
+| `PUT` | `/api/queue/:id` | キュー編集（body: `{title?, content?}`） | 必要 |
+| `DELETE` | `/api/queue/:id` | キュー削除 | 必要 |
+
+レスポンス例:
+
+```bash
+# 一覧取得
+curl http://localhost:3001/api/queue
+# → [{"id":"...","title":"...","content":"...","createdAt":"...","updatedAt":"..."}]
+
+# 新規作成
+curl -X POST http://localhost:3001/api/queue \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"テストアプリ","content":"テスト内容"}'
+# → {"success":true,"item":{...}}
+```
+
+### ファイル構成
+
+```
+scripts/
+├── process-queue.ts        # キュー処理スクリプト（pnpm queue:process）
+├── scheduler-run.sh        # スケジューララッパー（キュー分岐ロジック）
+└── lib/
+    └── paths.ts            # PIPELINE_QUEUE_DIR 定数
+
+viewer/
+├── server.ts               # Queue API エンドポイント
+└── src/
+    ├── api.ts              # Queue API クライアント関数
+    ├── App.tsx             # キュービューモード追加
+    └── components/
+        ├── Sidebar.tsx     # キューボタン追加
+        └── QueueManager.tsx # キュー管理 UI
+
+gen/
+└── pipeline_queue/         # キューデータ保存先（.gitignore 対象）
+    ├── 1739520000000-a1b2c3.json
+    └── 1739520060000-d4e5f6.json
+```
+
+---
+
+## よくあるシナリオ
+
+### 1. 思いついたアイデアを後で自動生成
+
+```bash
+# Viewer を開いてキュー画面でアイデアを追加
+pnpm viewer
+# → サイドバーのキューアイコン → + ボタン → タイトルと内容を入力
+
+# あとは放置。次のスケジューラ実行（AM 5:00）で自動処理される
+```
+
+### 2. キューを今すぐ処理したい
+
+```bash
+# スケジューラを待たずに手動実行
+pnpm queue:process
+```
+
+### 3. JSON ファイルを直接配置
+
+Viewer を使わずに、手動でキューファイルを作ることもできる。
+
+```bash
+mkdir -p gen/pipeline_queue
+
+cat > gen/pipeline_queue/my-idea.json << 'EOF'
+{
+  "id": "my-idea",
+  "title": "家計簿×AI分析アプリ",
+  "content": "レシート写真から自動で家計簿をつけ、AIが節約ポイントを提案するアプリ\n\n- OCRでレシート読み取り\n- カテゴリ自動分類\n- 月次レポート生成",
+  "createdAt": "2026-02-14T00:00:00.000Z",
+  "updatedAt": "2026-02-14T00:00:00.000Z"
+}
+EOF
+
+# 手動実行
+pnpm queue:process
+```
+
+### 4. 複数アイデアをまとめてキューに入れる
+
+Viewer で複数のアイデアを連続して追加しておく。処理は createdAt 順に1件ずつ実行される。
+
+```
+キュー:
+  1. ペット健康管理アプリ    (02/14 10:00)
+  2. 家計簿AI分析アプリ     (02/14 10:05)
+  3. 読書ログSNSアプリ      (02/14 10:10)
+
+→ スケジューラ実行時、1 → 2 → 3 の順で処理
+→ 2 が失敗した場合: 1, 3 は成功してキューから消え、2 だけ残る
+→ 次回実行で 2 が再試行される
+```
+
+### 5. 失敗したアイテムの確認
+
+キュー処理で失敗したアイテムはキューに残る。Viewer で内容を確認・編集して再試行できる。
+
+```bash
+# ログで失敗原因を確認
+ls logs/scheduler/
+cat logs/scheduler/2026_02_14_05_00_00.log
+
+# Viewer でキューを確認・編集
+pnpm viewer
+```

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -156,5 +156,7 @@ generate:
       enabled: true
       model: gemini-2.5-pro
       roles:
-        - researcher
         - designer
+        - researcher
+  perspectives:
+    mode: random

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "viewer:start": "pnpm --filter viewer start",
     "setup": "bash setup.sh",
     "pipeline": "tsx scripts/pipeline.ts",
+    "queue:process": "tsx scripts/process-queue.ts",
     "scheduler:enable": "bash scripts/scheduler-ctl.sh enable",
     "scheduler:disable": "bash scripts/scheduler-ctl.sh disable",
     "scheduler:status": "bash scripts/scheduler-ctl.sh status",

--- a/scripts/lib/paths.ts
+++ b/scripts/lib/paths.ts
@@ -30,3 +30,6 @@ export const DATASETS_DIR = resolve(OUTPUT_BASE_DIR, "datasets");
 
 /** pipeline_queue ディレクトリのフルパス */
 export const PIPELINE_QUEUE_DIR = resolve(OUTPUT_BASE_DIR, "pipeline_queue");
+
+/** pipeline_queue_rejected ディレクトリのフルパス（論理削除先） */
+export const PIPELINE_QUEUE_REJECTED_DIR = resolve(OUTPUT_BASE_DIR, "pipeline_queue_rejected");

--- a/scripts/lib/paths.ts
+++ b/scripts/lib/paths.ts
@@ -27,3 +27,6 @@ export const REQUIREMENTS_DIR = resolve(OUTPUT_BASE_DIR, "requirements");
 
 /** datasets ディレクトリのフルパス */
 export const DATASETS_DIR = resolve(OUTPUT_BASE_DIR, "datasets");
+
+/** pipeline_queue ディレクトリのフルパス */
+export const PIPELINE_QUEUE_DIR = resolve(OUTPUT_BASE_DIR, "pipeline_queue");

--- a/scripts/process-queue.ts
+++ b/scripts/process-queue.ts
@@ -4,11 +4,11 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
-  unlinkSync,
+  renameSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
-import { DATA_SOURCE_DIR, PIPELINE_QUEUE_DIR } from "./lib/paths.js";
+import { DATA_SOURCE_DIR, PIPELINE_QUEUE_DIR, PIPELINE_QUEUE_REJECTED_DIR } from "./lib/paths.js";
 
 interface QueueItem {
   id: string;
@@ -70,11 +70,14 @@ function main() {
       });
       console.log("パイプライン完了（成功）");
 
-      // 成功したらキューアイテムを削除
+      // 成功したらキューアイテムを処理済みディレクトリに移動
       const queueFilePath = join(PIPELINE_QUEUE_DIR, `${item.id}.json`);
       if (existsSync(queueFilePath)) {
-        unlinkSync(queueFilePath);
-        console.log(`キューアイテムを削除しました: ${item.id}`);
+        if (!existsSync(PIPELINE_QUEUE_REJECTED_DIR)) {
+          mkdirSync(PIPELINE_QUEUE_REJECTED_DIR, { recursive: true });
+        }
+        renameSync(queueFilePath, join(PIPELINE_QUEUE_REJECTED_DIR, `${item.id}.json`));
+        console.log(`キューアイテムを処理済みに移動しました: ${item.id}`);
       }
     } catch (err) {
       console.error(`パイプライン失敗: ${item.title} (${item.id})`);

--- a/scripts/process-queue.ts
+++ b/scripts/process-queue.ts
@@ -1,0 +1,89 @@
+import { execSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { DATA_SOURCE_DIR, PIPELINE_QUEUE_DIR } from "./lib/paths.js";
+
+interface QueueItem {
+  id: string;
+  title: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function timestamp(): string {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${now.getFullYear()}_${pad(now.getMonth() + 1)}_${pad(now.getDate())}_${pad(now.getHours())}_${pad(now.getMinutes())}_${pad(now.getSeconds())}`;
+}
+
+function loadQueueItems(): QueueItem[] {
+  if (!existsSync(PIPELINE_QUEUE_DIR)) return [];
+  return readdirSync(PIPELINE_QUEUE_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => {
+      try {
+        return JSON.parse(readFileSync(join(PIPELINE_QUEUE_DIR, f), "utf-8")) as QueueItem;
+      } catch {
+        return null;
+      }
+    })
+    .filter((item): item is QueueItem => item !== null)
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+}
+
+function main() {
+  const items = loadQueueItems();
+
+  if (items.length === 0) {
+    console.log("キューにアイテムがありません。");
+    process.exit(0);
+  }
+
+  console.log(`キューに ${items.length} 件のアイテムがあります。`);
+
+  for (const item of items) {
+    console.log(`\n--- 処理中: ${item.title} (${item.id}) ---`);
+
+    // data_source にディレクトリを作成し user_proposal.md を配置
+    const ts = timestamp();
+    const sourceDir = join(DATA_SOURCE_DIR, ts);
+    mkdirSync(sourceDir, { recursive: true });
+
+    const proposalContent = `# ${item.title}\n\n${item.content}`;
+    writeFileSync(join(sourceDir, "user_proposal.md"), proposalContent, "utf-8");
+    console.log(`data_source/${ts}/user_proposal.md を作成しました。`);
+
+    // パイプライン実行（skip-collect）
+    try {
+      console.log(`pnpm pipeline --skip-collect --source ${ts} を実行中...`);
+      execSync(`pnpm pipeline --skip-collect --source ${ts}`, {
+        stdio: "inherit",
+        cwd: join(import.meta.dirname, ".."),
+      });
+      console.log("パイプライン完了（成功）");
+
+      // 成功したらキューアイテムを削除
+      const queueFilePath = join(PIPELINE_QUEUE_DIR, `${item.id}.json`);
+      if (existsSync(queueFilePath)) {
+        unlinkSync(queueFilePath);
+        console.log(`キューアイテムを削除しました: ${item.id}`);
+      }
+    } catch (err) {
+      console.error(`パイプライン失敗: ${item.title} (${item.id})`);
+      console.error(err);
+      // 失敗してもキューには残す（次回再実行される）
+    }
+  }
+
+  console.log("\nキュー処理完了。");
+}
+
+main();

--- a/scripts/scheduler-run.sh
+++ b/scripts/scheduler-run.sh
@@ -32,12 +32,29 @@ fi
 log "Node: $(node --version 2>/dev/null || echo 'not found')"
 log "pnpm: $(pnpm --version 2>/dev/null || echo 'not found')"
 
-# パイプライン実行
-log "pnpm pipeline を実行中..."
-if pnpm pipeline >> "$LOG_FILE" 2>&1; then
-  log "=== パイプライン完了（成功） ==="
+# キューがあればキュー処理、なければ通常パイプライン
+QUEUE_DIR="$PROJECT_ROOT/gen/pipeline_queue"
+
+has_queue_items() {
+  [[ -d "$QUEUE_DIR" ]] && [[ -n "$(find "$QUEUE_DIR" -maxdepth 1 -name '*.json' -print -quit 2>/dev/null)" ]]
+}
+
+if has_queue_items; then
+  log "キューにアイテムがあります。キュー処理を実行..."
+  if pnpm queue:process >> "$LOG_FILE" 2>&1; then
+    log "=== キュー処理完了（成功） ==="
+  else
+    EXIT_CODE=$?
+    log "=== キュー処理完了（失敗: exit $EXIT_CODE） ==="
+    exit $EXIT_CODE
+  fi
 else
-  EXIT_CODE=$?
-  log "=== パイプライン完了（失敗: exit $EXIT_CODE） ==="
-  exit $EXIT_CODE
+  log "キューは空です。通常パイプラインを実行..."
+  if pnpm pipeline >> "$LOG_FILE" 2>&1; then
+    log "=== パイプライン完了（成功） ==="
+  else
+    EXIT_CODE=$?
+    log "=== パイプライン完了（失敗: exit $EXIT_CODE） ==="
+    exit $EXIT_CODE
+  fi
 fi

--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -63,6 +63,28 @@ function loadDataSourceDir(): string {
 
 const DATA_SOURCE_DIR = loadDataSourceDir();
 
+function loadPipelineQueueDir(): string {
+  try {
+    const configPath = resolve(projectRoot, "app.config.yaml");
+    const raw = readFileSync(configPath, "utf-8");
+    const config = parse(raw) as { output_base_dir?: string };
+    const base = config.output_base_dir ?? "gen";
+    return resolve(projectRoot, base, "pipeline_queue");
+  } catch {
+    return resolve(projectRoot, "gen", "pipeline_queue");
+  }
+}
+
+const PIPELINE_QUEUE_DIR = loadPipelineQueueDir();
+
+interface QueueItem {
+  id: string;
+  title: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 interface DatasetItem {
   appName: string;
   type: "overview" | "feature";
@@ -563,6 +585,80 @@ app.delete("/api/favorites", async (c) => {
       ),
   );
   writeFavorites(filtered);
+  return c.json({ success: true });
+});
+
+// --- Pipeline Queue API ---
+
+function readQueueItems(): QueueItem[] {
+  if (!existsSync(PIPELINE_QUEUE_DIR)) return [];
+  return readdirSync(PIPELINE_QUEUE_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => {
+      try {
+        return JSON.parse(readFileSync(join(PIPELINE_QUEUE_DIR, f), "utf-8")) as QueueItem;
+      } catch {
+        return null;
+      }
+    })
+    .filter((item): item is QueueItem => item !== null)
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+}
+
+app.get("/api/queue", (c) => {
+  return c.json(readQueueItems());
+});
+
+app.get("/api/queue/:id", (c) => {
+  const id = c.req.param("id");
+  const filePath = join(PIPELINE_QUEUE_DIR, `${id}.json`);
+  if (!existsSync(filePath)) return c.json({ error: "Not found" }, 404);
+  return c.json(JSON.parse(readFileSync(filePath, "utf-8")) as QueueItem);
+});
+
+app.post("/api/queue", async (c) => {
+  if (!isDev) return c.json({ error: "Dev mode only" }, 403);
+  const body = await c.req.json<{ title: string; content: string }>();
+  if (!body.title?.trim()) return c.json({ error: "タイトルは必須です" }, 400);
+  if (!body.content?.trim()) return c.json({ error: "内容は必須です" }, 400);
+
+  if (!existsSync(PIPELINE_QUEUE_DIR)) mkdirSync(PIPELINE_QUEUE_DIR, { recursive: true });
+  const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const now = new Date().toISOString();
+  const item: QueueItem = {
+    id,
+    title: body.title.trim(),
+    content: body.content.trim(),
+    createdAt: now,
+    updatedAt: now,
+  };
+  writeFileSync(join(PIPELINE_QUEUE_DIR, `${id}.json`), JSON.stringify(item, null, 2), "utf-8");
+  return c.json({ success: true, item });
+});
+
+app.put("/api/queue/:id", async (c) => {
+  if (!isDev) return c.json({ error: "Dev mode only" }, 403);
+  const id = c.req.param("id");
+  const filePath = join(PIPELINE_QUEUE_DIR, `${id}.json`);
+  if (!existsSync(filePath)) return c.json({ error: "Not found" }, 404);
+
+  const existing = JSON.parse(readFileSync(filePath, "utf-8")) as QueueItem;
+  const body = await c.req.json<{ title?: string; content?: string }>();
+
+  if (body.title !== undefined) existing.title = body.title.trim();
+  if (body.content !== undefined) existing.content = body.content.trim();
+  existing.updatedAt = new Date().toISOString();
+
+  writeFileSync(filePath, JSON.stringify(existing, null, 2), "utf-8");
+  return c.json({ success: true, item: existing });
+});
+
+app.delete("/api/queue/:id", (c) => {
+  if (!isDev) return c.json({ error: "Dev mode only" }, 403);
+  const id = c.req.param("id");
+  const filePath = join(PIPELINE_QUEUE_DIR, `${id}.json`);
+  if (!existsSync(filePath)) return c.json({ error: "Not found" }, 404);
+  unlinkSync(filePath);
   return c.json({ success: true });
 });
 

--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -5,6 +5,7 @@ import {
   readdirSync,
   readFileSync,
   statSync,
+  renameSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -658,7 +659,9 @@ app.delete("/api/queue/:id", (c) => {
   const id = c.req.param("id");
   const filePath = join(PIPELINE_QUEUE_DIR, `${id}.json`);
   if (!existsSync(filePath)) return c.json({ error: "Not found" }, 404);
-  unlinkSync(filePath);
+  const rejectedDir = join(PIPELINE_QUEUE_DIR, "..", "pipeline_queue_rejected");
+  if (!existsSync(rejectedDir)) mkdirSync(rejectedDir, { recursive: true });
+  renameSync(filePath, join(rejectedDir, `${id}.json`));
   return c.json({ success: true });
 });
 

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -16,12 +16,13 @@ import { CommandRunner } from "./components/CommandRunner";
 import { ConfigEditor } from "./components/ConfigEditor";
 import { DatasetManager } from "./components/DatasetManager";
 import { FavoritePage } from "./components/FavoritePage";
+import { QueueManager } from "./components/QueueManager";
 import { SearchView } from "./components/SearchView";
 import { Sidebar } from "./components/Sidebar";
 import { ToastProvider } from "./components/Toast";
 import { useIsMobile } from "./hooks/useIsMobile";
 
-type ViewMode = "apps" | "datasets" | "favorites" | "commands" | "config";
+type ViewMode = "apps" | "datasets" | "favorites" | "commands" | "config" | "queue";
 
 function buildUrl(state: {
   viewMode: ViewMode;
@@ -45,6 +46,8 @@ function buildUrl(state: {
     url.searchParams.set("view", "commands");
   } else if (state.viewMode === "config") {
     url.searchParams.set("view", "config");
+  } else if (state.viewMode === "queue") {
+    url.searchParams.set("view", "queue");
   } else {
     if (state.app) url.searchParams.set("app", state.app);
     if (state.feature) url.searchParams.set("feature", state.feature);
@@ -109,8 +112,11 @@ export function App() {
     const isFavoritesView = viewParam === "favorites";
     const isCommandsView = viewParam === "commands";
     const isConfigView = viewParam === "config";
-    // URL から datasets/favorites/commands/config ビュー復元
-    if (isConfigView) {
+    const isQueueView = viewParam === "queue";
+    // URL から datasets/favorites/commands/config/queue ビュー復元
+    if (isQueueView) {
+      setViewMode("queue");
+    } else if (isConfigView) {
       setViewMode("config");
     } else if (isCommandsView) {
       setViewMode("commands");
@@ -148,15 +154,17 @@ export function App() {
         tabParam && ["overview", "source-info", "diagrams", "features", "memo"].includes(tabParam)
           ? tabParam
           : undefined;
-      const currentViewMode = isConfigView
-        ? "config"
-        : isCommandsView
-          ? "commands"
-          : isFavoritesView
-            ? "favorites"
-            : isDatasetView
-              ? "datasets"
-              : "apps";
+      const currentViewMode = isQueueView
+        ? "queue"
+        : isConfigView
+          ? "config"
+          : isCommandsView
+            ? "commands"
+            : isFavoritesView
+              ? "favorites"
+              : isDatasetView
+                ? "datasets"
+                : "apps";
       window.history.replaceState(
         {},
         "",
@@ -176,7 +184,11 @@ export function App() {
     const handlePopState = () => {
       const params = new URLSearchParams(window.location.search);
       const viewParam = params.get("view");
-      if (viewParam === "config") {
+      if (viewParam === "queue") {
+        setViewMode("queue");
+        setSelectedFeature(null);
+        setSelectedTab("overview");
+      } else if (viewParam === "config") {
         setViewMode("config");
         setSelectedFeature(null);
         setSelectedTab("overview");
@@ -257,6 +269,14 @@ export function App() {
     setSearchActive(false);
     if (isMobile) setMobileSidebarOpen(false);
     window.history.pushState({}, "", buildUrl({ viewMode: "favorites" }));
+  };
+
+  const handleSelectQueue = () => {
+    setViewMode("queue");
+    setSelectedFeature(null);
+    setSearchActive(false);
+    if (isMobile) setMobileSidebarOpen(false);
+    window.history.pushState({}, "", buildUrl({ viewMode: "queue" }));
   };
 
   const handleNavigateToDataset = (datasetName: string) => {
@@ -462,7 +482,9 @@ export function App() {
                     ? "お気に入り"
                     : viewMode === "datasets"
                       ? "データセット"
-                      : (selectedApp ?? "Requirements Viewer")}
+                      : viewMode === "queue"
+                        ? "パイプラインキュー"
+                        : (selectedApp ?? "Requirements Viewer")}
             </span>
           </div>
         )}
@@ -481,6 +503,7 @@ export function App() {
           onSelectFavorites={handleSelectFavorites}
           onSelectCommands={handleSelectCommands}
           onSelectConfig={handleSelectConfig}
+          onSelectQueue={handleSelectQueue}
           onSearch={handleSearch}
           onClearSearch={handleClearSearch}
           isSearchActive={searchActive}
@@ -506,6 +529,8 @@ export function App() {
               onSelectFeature={handleNavigateToFeature}
               onSelectDiagram={handleNavigateToDiagram}
             />
+          ) : viewMode === "queue" ? (
+            <QueueManager isMobile={isMobile} isDev={isDev} />
           ) : viewMode === "datasets" ? (
             <DatasetManager
               isMobile={isMobile}

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -390,6 +390,55 @@ export async function abortCommand(): Promise<{ success: boolean }> {
   return res.json();
 }
 
+// --- Pipeline Queue API ---
+
+export interface QueueItem {
+  id: string;
+  title: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function fetchQueueItems(): Promise<QueueItem[]> {
+  const res = await fetch(`${BASE}/queue`);
+  return res.json();
+}
+
+export async function fetchQueueItem(id: string): Promise<QueueItem> {
+  const res = await fetch(`${BASE}/queue/${id}`);
+  return res.json();
+}
+
+export async function createQueueItem(
+  title: string,
+  content: string,
+): Promise<{ success: boolean; item?: QueueItem; error?: string }> {
+  const res = await fetch(`${BASE}/queue`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ title, content }),
+  });
+  return res.json();
+}
+
+export async function updateQueueItem(
+  id: string,
+  data: { title?: string; content?: string },
+): Promise<{ success: boolean; item?: QueueItem; error?: string }> {
+  const res = await fetch(`${BASE}/queue/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  return res.json();
+}
+
+export async function deleteQueueItem(id: string): Promise<{ success: boolean }> {
+  const res = await fetch(`${BASE}/queue/${id}`, { method: "DELETE" });
+  return res.json();
+}
+
 // --- Git API ---
 
 export interface GitResult {

--- a/viewer/src/components/QueueManager.tsx
+++ b/viewer/src/components/QueueManager.tsx
@@ -12,7 +12,6 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
   const [items, setItems] = useState<QueueItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [selected, setSelected] = useState<string | null>(null);
-  const [editing, setEditing] = useState(false);
   const [creating, setCreating] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
@@ -52,7 +51,6 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
     async (id: string, title: string, content: string) => {
       const result = await updateQueueItem(id, { title, content });
       if (result.success) {
-        setEditing(false);
         reload();
         showMessage("更新しました");
       } else {
@@ -69,7 +67,6 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
       if (!window.confirm(`${label}を削除しますか？`)) return;
       await deleteQueueItem(id);
       if (selected === id) setSelected(null);
-      setEditing(false);
       reload();
       showMessage("削除しました");
     },
@@ -111,7 +108,7 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
         </motion.div>
       );
     }
-    if (selectedItem && editing) {
+    if (selectedItem) {
       return (
         <motion.div
           className="flex flex-col h-full"
@@ -122,30 +119,9 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
           <QueueForm
             item={selectedItem}
             onSubmit={(title, content) => handleUpdate(selectedItem.id, title, content)}
-            onCancel={() => setEditing(false)}
+            onCancel={() => setSelected(null)}
             isMobile
           />
-          <MessageToast message={message} />
-        </motion.div>
-      );
-    }
-    if (selectedItem) {
-      return (
-        <motion.div
-          className="flex flex-col h-full"
-          initial={{ opacity: 0, x: 20 }}
-          animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 0.25 }}
-        >
-          <QueueDetailHeader
-            item={selectedItem}
-            onBack={() => setSelected(null)}
-            onEdit={() => setEditing(true)}
-            onDelete={() => handleDelete(selectedItem.id)}
-            isDev={isDev}
-            isMobile
-          />
-          <QueueDetailContent item={selectedItem} />
           <MessageToast message={message} />
         </motion.div>
       );
@@ -169,6 +145,7 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
             onSelect={setSelected}
             onDelete={handleDelete}
             isDev={isDev}
+            isMobile
           />
         </div>
         <MessageToast message={message} />
@@ -199,7 +176,6 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
             selected={selected}
             onSelect={(id) => {
               setSelected(id);
-              setEditing(false);
               setCreating(false);
             }}
             onDelete={handleDelete}
@@ -208,26 +184,16 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
         </div>
       </div>
 
-      {/* Right: detail / form */}
+      {/* Right: edit form */}
       <div className="flex-1 flex flex-col min-w-0">
         {creating ? (
           <QueueForm onSubmit={handleCreate} onCancel={() => setCreating(false)} />
-        ) : selectedItem && editing ? (
+        ) : selectedItem ? (
           <QueueForm
             item={selectedItem}
             onSubmit={(title, content) => handleUpdate(selectedItem.id, title, content)}
-            onCancel={() => setEditing(false)}
+            onCancel={() => setSelected(null)}
           />
-        ) : selectedItem ? (
-          <>
-            <QueueDetailHeader
-              item={selectedItem}
-              onEdit={() => setEditing(true)}
-              onDelete={() => handleDelete(selectedItem.id)}
-              isDev={isDev}
-            />
-            <QueueDetailContent item={selectedItem} />
-          </>
         ) : (
           <div className="flex h-full items-center justify-center text-gray-500 text-sm">
             {items.length === 0
@@ -268,12 +234,14 @@ function QueueList({
   onSelect,
   onDelete,
   isDev,
+  isMobile,
 }: {
   items: QueueItem[];
   selected: string | null;
   onSelect: (id: string) => void;
   onDelete: (id: string) => void;
   isDev: boolean;
+  isMobile?: boolean;
 }) {
   if (items.length === 0) {
     return (
@@ -337,7 +305,7 @@ function QueueList({
           {isDev && (
             <button
               type="button"
-              className="p-1 rounded-md text-gray-700 hover:text-red-400 hover:bg-red-400/10 opacity-0 group-hover:opacity-100 transition-all shrink-0"
+              className={`p-1.5 rounded-lg text-gray-700 hover:text-red-400 hover:bg-red-400/10 transition-all shrink-0 ${isMobile ? "opacity-100" : "opacity-0 group-hover:opacity-100"}`}
               onClick={(e) => {
                 e.stopPropagation();
                 onDelete(item.id);
@@ -346,7 +314,7 @@ function QueueList({
             >
               <svg
                 aria-hidden="true"
-                className="size-3.5"
+                className="size-4"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
@@ -362,124 +330,6 @@ function QueueList({
           )}
         </button>
       ))}
-    </div>
-  );
-}
-
-function QueueDetailHeader({
-  item,
-  onBack,
-  onEdit,
-  onDelete,
-  isDev,
-  isMobile,
-}: {
-  item: QueueItem;
-  onBack?: () => void;
-  onEdit: () => void;
-  onDelete: () => void;
-  isDev: boolean;
-  isMobile?: boolean;
-}) {
-  return (
-    <div className="flex items-center gap-2 px-4 bg-gray-800/50 border-b border-gray-700/50 shrink-0">
-      {isMobile && onBack && (
-        <button
-          type="button"
-          className="p-1.5 rounded-lg text-gray-400 hover:text-gray-200 hover:bg-gray-700/50 transition-colors"
-          onClick={onBack}
-        >
-          <svg
-            aria-hidden="true"
-            className="size-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M15 19l-7-7 7-7"
-            />
-          </svg>
-        </button>
-      )}
-      <span className="px-3 py-2.5 text-xs font-medium text-orange-400 truncate">{item.title}</span>
-      <span className="text-[11px] text-gray-600 shrink-0">
-        {new Date(item.createdAt).toLocaleDateString("ja-JP")}
-      </span>
-      <div className="flex-1" />
-      {isDev && (
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            className="p-1.5 rounded-lg text-gray-400 hover:text-indigo-400 hover:bg-indigo-500/10 transition-colors"
-            onClick={onEdit}
-            title="編集"
-          >
-            <svg
-              aria-hidden="true"
-              className="size-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"
-              />
-            </svg>
-          </button>
-          <button
-            type="button"
-            className="p-1.5 rounded-lg text-gray-400 hover:text-red-400 hover:bg-red-400/10 transition-colors"
-            onClick={onDelete}
-            title="削除"
-          >
-            <svg
-              aria-hidden="true"
-              className="size-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-              />
-            </svg>
-          </button>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function QueueDetailContent({ item }: { item: QueueItem }) {
-  return (
-    <div className="flex-1 overflow-y-auto dark-scrollbar p-6 bg-gray-900">
-      <motion.div
-        initial={{ opacity: 0, y: 8 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.3 }}
-      >
-        <div className="prose prose-invert prose-sm max-w-none">
-          <pre className="whitespace-pre-wrap text-sm text-gray-300 bg-gray-800/50 rounded-xl p-4 border border-gray-700/50">
-            {item.content}
-          </pre>
-        </div>
-        <div className="mt-6 flex gap-4 text-[11px] text-gray-600">
-          <span>作成: {new Date(item.createdAt).toLocaleString("ja-JP")}</span>
-          {item.updatedAt !== item.createdAt && (
-            <span>更新: {new Date(item.updatedAt).toLocaleString("ja-JP")}</span>
-          )}
-        </div>
-      </motion.div>
     </div>
   );
 }
@@ -533,13 +383,6 @@ function QueueForm({
           {isEdit ? "キューアイテム編集" : "新規キューアイテム"}
         </span>
         <div className="flex-1" />
-        <button
-          type="button"
-          className="px-3 py-1.5 my-1 text-xs text-gray-400 hover:text-gray-200 transition-colors"
-          onClick={onCancel}
-        >
-          キャンセル
-        </button>
         <button
           type="button"
           className={`px-3 py-1.5 my-1 text-xs font-medium rounded-lg transition-colors ${

--- a/viewer/src/components/QueueManager.tsx
+++ b/viewer/src/components/QueueManager.tsx
@@ -64,13 +64,16 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
 
   const handleDelete = useCallback(
     async (id: string) => {
+      const target = items.find((i) => i.id === id);
+      const label = target ? `「${target.title}」` : "このアイテム";
+      if (!window.confirm(`${label}を削除しますか？`)) return;
       await deleteQueueItem(id);
       if (selected === id) setSelected(null);
       setEditing(false);
       reload();
       showMessage("削除しました");
     },
-    [selected, reload, showMessage],
+    [items, selected, reload, showMessage],
   );
 
   if (loading) {

--- a/viewer/src/components/QueueManager.tsx
+++ b/viewer/src/components/QueueManager.tsx
@@ -1,0 +1,600 @@
+import { AnimatePresence, motion } from "motion/react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  createQueueItem,
+  deleteQueueItem,
+  fetchQueueItems,
+  type QueueItem,
+  updateQueueItem,
+} from "../api";
+
+export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: boolean }) {
+  const [items, setItems] = useState<QueueItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const reload = useCallback(() => {
+    fetchQueueItems()
+      .then(setItems)
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const selectedItem = items.find((i) => i.id === selected);
+
+  const showMessage = useCallback((msg: string) => {
+    setMessage(msg);
+    setTimeout(() => setMessage(null), 3000);
+  }, []);
+
+  const handleCreate = useCallback(
+    async (title: string, content: string) => {
+      const result = await createQueueItem(title, content);
+      if (result.success && result.item) {
+        setCreating(false);
+        reload();
+        setSelected(result.item.id);
+        showMessage("キューに追加しました");
+      } else {
+        showMessage(result.error ?? "作成エラー");
+      }
+    },
+    [reload, showMessage],
+  );
+
+  const handleUpdate = useCallback(
+    async (id: string, title: string, content: string) => {
+      const result = await updateQueueItem(id, { title, content });
+      if (result.success) {
+        setEditing(false);
+        reload();
+        showMessage("更新しました");
+      } else {
+        showMessage(result.error ?? "更新エラー");
+      }
+    },
+    [reload, showMessage],
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      await deleteQueueItem(id);
+      if (selected === id) setSelected(null);
+      setEditing(false);
+      reload();
+      showMessage("削除しました");
+    },
+    [selected, reload, showMessage],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <motion.div
+          className="flex flex-col items-center gap-3"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.3 }}
+        >
+          <motion.div
+            className="size-8 rounded-full border-2 border-indigo-800 border-t-indigo-400"
+            animate={{ rotate: 360 }}
+            transition={{ duration: 1, repeat: Number.POSITIVE_INFINITY, ease: "linear" }}
+          />
+          <p className="text-xs text-gray-500">読み込み中...</p>
+        </motion.div>
+      </div>
+    );
+  }
+
+  /* Mobile layout */
+  if (isMobile) {
+    if (creating) {
+      return (
+        <motion.div
+          className="flex flex-col h-full"
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.25 }}
+        >
+          <QueueForm onSubmit={handleCreate} onCancel={() => setCreating(false)} isMobile />
+          <MessageToast message={message} />
+        </motion.div>
+      );
+    }
+    if (selectedItem && editing) {
+      return (
+        <motion.div
+          className="flex flex-col h-full"
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.25 }}
+        >
+          <QueueForm
+            item={selectedItem}
+            onSubmit={(title, content) => handleUpdate(selectedItem.id, title, content)}
+            onCancel={() => setEditing(false)}
+            isMobile
+          />
+          <MessageToast message={message} />
+        </motion.div>
+      );
+    }
+    if (selectedItem) {
+      return (
+        <motion.div
+          className="flex flex-col h-full"
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.25 }}
+        >
+          <QueueDetailHeader
+            item={selectedItem}
+            onBack={() => setSelected(null)}
+            onEdit={() => setEditing(true)}
+            onDelete={() => handleDelete(selectedItem.id)}
+            isDev={isDev}
+            isMobile
+          />
+          <QueueDetailContent item={selectedItem} />
+          <MessageToast message={message} />
+        </motion.div>
+      );
+    }
+    return (
+      <motion.div
+        className="flex flex-col h-full"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.4 }}
+      >
+        <div className="flex items-center gap-2 px-4 py-3 bg-gray-900 border-b border-gray-800 shrink-0">
+          <h2 className="text-sm font-semibold text-gray-200">パイプラインキュー</h2>
+          <div className="flex-1" />
+          {isDev && <CreateButton onClick={() => setCreating(true)} />}
+        </div>
+        <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-32 bg-gray-900">
+          <QueueList
+            items={items}
+            selected={selected}
+            onSelect={setSelected}
+            onDelete={handleDelete}
+            isDev={isDev}
+          />
+        </div>
+        <MessageToast message={message} />
+      </motion.div>
+    );
+  }
+
+  /* Desktop layout */
+  return (
+    <motion.div
+      className="flex h-full"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+    >
+      {/* Left: queue list */}
+      <div className="w-72 flex flex-col border-r border-gray-700/50 shrink-0">
+        <div className="flex items-center gap-2 px-4 bg-gray-800/50 border-b border-gray-700/50 shrink-0">
+          <span className="px-3 py-2.5 text-xs font-medium text-orange-400">
+            パイプラインキュー
+          </span>
+          <div className="flex-1" />
+          {isDev && <CreateButton onClick={() => setCreating(true)} />}
+        </div>
+        <div className="flex-1 overflow-y-auto dark-scrollbar p-3 bg-gray-900">
+          <QueueList
+            items={items}
+            selected={selected}
+            onSelect={(id) => {
+              setSelected(id);
+              setEditing(false);
+              setCreating(false);
+            }}
+            onDelete={handleDelete}
+            isDev={isDev}
+          />
+        </div>
+      </div>
+
+      {/* Right: detail / form */}
+      <div className="flex-1 flex flex-col min-w-0">
+        {creating ? (
+          <QueueForm onSubmit={handleCreate} onCancel={() => setCreating(false)} />
+        ) : selectedItem && editing ? (
+          <QueueForm
+            item={selectedItem}
+            onSubmit={(title, content) => handleUpdate(selectedItem.id, title, content)}
+            onCancel={() => setEditing(false)}
+          />
+        ) : selectedItem ? (
+          <>
+            <QueueDetailHeader
+              item={selectedItem}
+              onEdit={() => setEditing(true)}
+              onDelete={() => handleDelete(selectedItem.id)}
+              isDev={isDev}
+            />
+            <QueueDetailContent item={selectedItem} />
+          </>
+        ) : (
+          <div className="flex h-full items-center justify-center text-gray-500 text-sm">
+            {items.length === 0
+              ? "キューにアイデアを追加して、定期実行で要件を自動生成しましょう"
+              : "キューアイテムを選択してください"}
+          </div>
+        )}
+      </div>
+      <MessageToast message={message} />
+    </motion.div>
+  );
+}
+
+function CreateButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className="p-1.5 rounded-lg text-gray-400 hover:text-orange-400 hover:bg-orange-500/10 transition-colors"
+      onClick={onClick}
+      title="新規キューアイテム作成"
+    >
+      <svg
+        aria-hidden="true"
+        className="size-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+      </svg>
+    </button>
+  );
+}
+
+function QueueList({
+  items,
+  selected,
+  onSelect,
+  onDelete,
+  isDev,
+}: {
+  items: QueueItem[];
+  selected: string | null;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+  isDev: boolean;
+}) {
+  if (items.length === 0) {
+    return (
+      <div className="py-12 text-center">
+        <div className="size-12 mx-auto mb-3 rounded-full bg-gray-800 flex items-center justify-center">
+          <svg
+            aria-hidden="true"
+            className="size-6 text-gray-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z"
+            />
+          </svg>
+        </div>
+        <p className="text-gray-600 text-xs">キューは空です</p>
+        <p className="text-gray-700 text-[11px] mt-1">
+          アプリのアイデアを追加して定期実行に備えましょう
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {items.map((item) => (
+        <button
+          type="button"
+          key={item.id}
+          className={`
+            group w-full flex items-center gap-2 px-3 py-2.5 rounded-xl cursor-pointer transition-colors
+            ${selected === item.id ? "bg-orange-500/15 text-orange-400" : "text-gray-400 hover:bg-white/[0.04] hover:text-gray-200"}
+          `}
+          onClick={() => onSelect(item.id)}
+        >
+          <svg
+            aria-hidden="true"
+            className={`size-4 shrink-0 ${selected === item.id ? "text-orange-400" : "text-gray-600"}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z"
+            />
+          </svg>
+          <div className="flex-1 min-w-0">
+            <p className="text-[14px] font-medium truncate">{item.title}</p>
+            <p className="text-[11px] text-gray-600 truncate">
+              {new Date(item.createdAt).toLocaleDateString("ja-JP")}
+            </p>
+          </div>
+          {isDev && (
+            <button
+              type="button"
+              className="p-1 rounded-md text-gray-700 hover:text-red-400 hover:bg-red-400/10 opacity-0 group-hover:opacity-100 transition-all shrink-0"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(item.id);
+              }}
+              title="削除"
+            >
+              <svg
+                aria-hidden="true"
+                className="size-3.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                />
+              </svg>
+            </button>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function QueueDetailHeader({
+  item,
+  onBack,
+  onEdit,
+  onDelete,
+  isDev,
+  isMobile,
+}: {
+  item: QueueItem;
+  onBack?: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  isDev: boolean;
+  isMobile?: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2 px-4 bg-gray-800/50 border-b border-gray-700/50 shrink-0">
+      {isMobile && onBack && (
+        <button
+          type="button"
+          className="p-1.5 rounded-lg text-gray-400 hover:text-gray-200 hover:bg-gray-700/50 transition-colors"
+          onClick={onBack}
+        >
+          <svg
+            aria-hidden="true"
+            className="size-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+        </button>
+      )}
+      <span className="px-3 py-2.5 text-xs font-medium text-orange-400 truncate">{item.title}</span>
+      <span className="text-[11px] text-gray-600 shrink-0">
+        {new Date(item.createdAt).toLocaleDateString("ja-JP")}
+      </span>
+      <div className="flex-1" />
+      {isDev && (
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className="p-1.5 rounded-lg text-gray-400 hover:text-indigo-400 hover:bg-indigo-500/10 transition-colors"
+            onClick={onEdit}
+            title="編集"
+          >
+            <svg
+              aria-hidden="true"
+              className="size-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"
+              />
+            </svg>
+          </button>
+          <button
+            type="button"
+            className="p-1.5 rounded-lg text-gray-400 hover:text-red-400 hover:bg-red-400/10 transition-colors"
+            onClick={onDelete}
+            title="削除"
+          >
+            <svg
+              aria-hidden="true"
+              className="size-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function QueueDetailContent({ item }: { item: QueueItem }) {
+  return (
+    <div className="flex-1 overflow-y-auto dark-scrollbar p-6 bg-gray-900">
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+      >
+        <div className="prose prose-invert prose-sm max-w-none">
+          <pre className="whitespace-pre-wrap text-sm text-gray-300 bg-gray-800/50 rounded-xl p-4 border border-gray-700/50">
+            {item.content}
+          </pre>
+        </div>
+        <div className="mt-6 flex gap-4 text-[11px] text-gray-600">
+          <span>作成: {new Date(item.createdAt).toLocaleString("ja-JP")}</span>
+          {item.updatedAt !== item.createdAt && (
+            <span>更新: {new Date(item.updatedAt).toLocaleString("ja-JP")}</span>
+          )}
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+function QueueForm({
+  item,
+  onSubmit,
+  onCancel,
+  isMobile,
+}: {
+  item?: QueueItem;
+  onSubmit: (title: string, content: string) => void;
+  onCancel: () => void;
+  isMobile?: boolean;
+}) {
+  const [title, setTitle] = useState(item?.title ?? "");
+  const [content, setContent] = useState(item?.content ?? "");
+  const isEdit = !!item;
+
+  return (
+    <motion.div
+      className="flex flex-col h-full"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2 }}
+    >
+      <div className="flex items-center gap-2 px-4 bg-gray-800/50 border-b border-gray-700/50 shrink-0">
+        {isMobile && (
+          <button
+            type="button"
+            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-200 hover:bg-gray-700/50 transition-colors"
+            onClick={onCancel}
+          >
+            <svg
+              aria-hidden="true"
+              className="size-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+        )}
+        <span className="px-3 py-2.5 text-xs font-medium text-orange-400">
+          {isEdit ? "キューアイテム編集" : "新規キューアイテム"}
+        </span>
+        <div className="flex-1" />
+        <button
+          type="button"
+          className="px-3 py-1.5 my-1 text-xs text-gray-400 hover:text-gray-200 transition-colors"
+          onClick={onCancel}
+        >
+          キャンセル
+        </button>
+        <button
+          type="button"
+          className={`px-3 py-1.5 my-1 text-xs font-medium rounded-lg transition-colors ${
+            title.trim() && content.trim()
+              ? "bg-orange-600 text-white hover:bg-orange-500"
+              : "bg-gray-800 text-gray-600 cursor-not-allowed"
+          }`}
+          disabled={!title.trim() || !content.trim()}
+          onClick={() => onSubmit(title, content)}
+        >
+          {isEdit ? "更新" : "追加"}
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto dark-scrollbar p-6 bg-gray-900 space-y-4">
+        <div>
+          <label className="block text-[11px] font-medium text-gray-500 mb-1.5" htmlFor="q-title">
+            タイトル
+          </label>
+          <input
+            id="q-title"
+            type="text"
+            className="w-full px-3 py-2 text-sm bg-gray-800 border border-gray-700/50 rounded-lg text-gray-200 placeholder-gray-600 outline-none focus:border-orange-500/50 focus:ring-1 focus:ring-orange-500/20"
+            placeholder="アプリのアイデア名"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+        <div className="flex-1 flex flex-col">
+          <label className="block text-[11px] font-medium text-gray-500 mb-1.5" htmlFor="q-content">
+            内容
+          </label>
+          <textarea
+            id="q-content"
+            className="w-full flex-1 min-h-[200px] px-3 py-2 text-sm bg-gray-800 border border-gray-700/50 rounded-lg text-gray-200 placeholder-gray-600 outline-none focus:border-orange-500/50 focus:ring-1 focus:ring-orange-500/20 resize-y"
+            placeholder="アプリのアイデアを自由に記述してください。箇条書きでも文章でもOKです。"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+          />
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+function MessageToast({ message }: { message: string | null }) {
+  return (
+    <AnimatePresence>
+      {message && (
+        <motion.div
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-xl bg-gray-700 text-sm text-gray-200 shadow-xl border border-gray-600"
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 10 }}
+          transition={{ duration: 0.2 }}
+        >
+          {message}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -11,11 +11,12 @@ interface SidebarProps {
   isMobile: boolean;
   mobileOpen: boolean;
   onMobileClose: () => void;
-  viewMode: "apps" | "datasets" | "favorites" | "commands" | "config";
+  viewMode: "apps" | "datasets" | "favorites" | "commands" | "config" | "queue";
   onSelectDatasets: () => void;
   onSelectFavorites: () => void;
   onSelectCommands: () => void;
   onSelectConfig: () => void;
+  onSelectQueue: () => void;
   onSearch: (query: string, tags: string[]) => void;
   onClearSearch: () => void;
   isSearchActive: boolean;
@@ -232,6 +233,7 @@ export function Sidebar({
   onSelectFavorites,
   onSelectCommands,
   onSelectConfig,
+  onSelectQueue,
   onSearch,
   onClearSearch,
   isSearchActive,
@@ -341,6 +343,31 @@ export function Sidebar({
                         strokeLinejoin="round"
                         strokeWidth={2}
                         d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                      viewMode === "queue"
+                        ? "text-orange-400 bg-orange-400/10"
+                        : "text-gray-500 hover:text-orange-400 hover:bg-orange-400/10"
+                    }`}
+                    onClick={onSelectQueue}
+                    title="パイプラインキュー"
+                  >
+                    <svg
+                      className="size-5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z"
                       />
                     </svg>
                   </button>
@@ -577,6 +604,33 @@ export function Sidebar({
                   strokeLinejoin="round"
                   strokeWidth={2}
                   d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                />
+              </svg>
+            </motion.button>
+            <motion.button
+              type="button"
+              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                viewMode === "queue"
+                  ? "text-orange-400 bg-orange-400/10"
+                  : "text-gray-500 hover:text-orange-400 hover:bg-orange-400/10"
+              }`}
+              onClick={onSelectQueue}
+              title="パイプラインキュー"
+              animate={{ opacity: expanded ? 1 : 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              <svg
+                className="size-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z"
                 />
               </svg>
             </motion.button>

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -266,34 +266,8 @@ export function Sidebar({
               transition={{ duration: 0.25, ease: "easeOut" }}
             >
               {/* Header */}
-              <div className="px-5 pt-5 pb-3 space-y-2">
-                <div className="flex items-center justify-between">
-                  <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
-                    R
-                  </span>
-                  <button
-                    type="button"
-                    className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-white/[0.06] transition-colors shrink-0"
-                    onClick={onMobileClose}
-                    title="閉じる"
-                  >
-                    <svg
-                      className="size-4"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      aria-hidden="true"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M6 18L18 6M6 6l12 12"
-                      />
-                    </svg>
-                  </button>
-                </div>
-                <div className="flex items-center gap-1.5 pl-1">
+              <div className="px-4 pt-4 pb-3">
+                <div className="flex items-center gap-1">
                   <button
                     type="button"
                     className={`p-1.5 rounded-lg transition-colors shrink-0 ${
@@ -305,7 +279,7 @@ export function Sidebar({
                     title="お気に入り"
                   >
                     <svg
-                      className="size-4.5"
+                      className="size-5"
                       viewBox="0 0 24 24"
                       fill={viewMode === "favorites" ? "currentColor" : "none"}
                       stroke="currentColor"
@@ -330,7 +304,7 @@ export function Sidebar({
                     title="コマンド実行"
                   >
                     <svg
-                      className="size-4.5"
+                      className="size-5"
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
@@ -355,7 +329,7 @@ export function Sidebar({
                     title="データセット"
                   >
                     <svg
-                      className="size-4.5"
+                      className="size-5"
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
@@ -380,7 +354,7 @@ export function Sidebar({
                     title="パイプラインキュー"
                   >
                     <svg
-                      className="size-4.5"
+                      className="size-5"
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
@@ -405,7 +379,7 @@ export function Sidebar({
                     title="設定"
                   >
                     <svg
-                      className="size-4.5"
+                      className="size-5"
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
@@ -416,6 +390,28 @@ export function Sidebar({
                         strokeLinejoin="round"
                         strokeWidth={2}
                         d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28ZM15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+                      />
+                    </svg>
+                  </button>
+                  <div className="flex-1" />
+                  <button
+                    type="button"
+                    className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-white/[0.06] transition-colors shrink-0"
+                    onClick={onMobileClose}
+                    title="閉じる"
+                  >
+                    <svg
+                      className="size-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
                       />
                     </svg>
                   </button>
@@ -523,18 +519,143 @@ export function Sidebar({
     >
       <div className="h-full flex flex-col" style={{ width: SIDEBAR_WIDTH }}>
         {/* Header */}
-        <div className="px-5 pt-5 pb-3 space-y-2">
-          <div className="flex items-center justify-between">
-            <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
-              R
-            </span>
+        <div className="px-4 pt-4 pb-3">
+          <motion.div
+            className="flex items-center gap-1"
+            animate={{ opacity: expanded ? 1 : 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            <button
+              type="button"
+              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                viewMode === "favorites"
+                  ? "text-pink-400 bg-pink-400/10"
+                  : "text-gray-500 hover:text-pink-400 hover:bg-pink-400/10"
+              }`}
+              onClick={onSelectFavorites}
+              title="お気に入り"
+            >
+              <svg
+                className="size-5"
+                viewBox="0 0 24 24"
+                fill={viewMode === "favorites" ? "currentColor" : "none"}
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
+                />
+              </svg>
+            </button>
+            <button
+              type="button"
+              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                viewMode === "commands"
+                  ? "text-cyan-400 bg-cyan-400/10"
+                  : "text-gray-500 hover:text-cyan-400 hover:bg-cyan-400/10"
+              }`}
+              onClick={onSelectCommands}
+              title="コマンド実行"
+            >
+              <svg
+                className="size-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"
+                />
+              </svg>
+            </button>
+            <button
+              type="button"
+              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                viewMode === "datasets"
+                  ? "text-amber-400 bg-amber-400/10"
+                  : "text-gray-500 hover:text-amber-400 hover:bg-amber-400/10"
+              }`}
+              onClick={onSelectDatasets}
+              title="データセット"
+            >
+              <svg
+                className="size-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                />
+              </svg>
+            </button>
+            <button
+              type="button"
+              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                viewMode === "queue"
+                  ? "text-orange-400 bg-orange-400/10"
+                  : "text-gray-500 hover:text-orange-400 hover:bg-orange-400/10"
+              }`}
+              onClick={onSelectQueue}
+              title="パイプラインキュー"
+            >
+              <svg
+                className="size-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z"
+                />
+              </svg>
+            </button>
+            <button
+              type="button"
+              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                viewMode === "config"
+                  ? "text-gray-300 bg-gray-700/50"
+                  : "text-gray-500 hover:text-gray-300 hover:bg-gray-700/30"
+              }`}
+              onClick={onSelectConfig}
+              title="設定"
+            >
+              <svg
+                className="size-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28ZM15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+                />
+              </svg>
+            </button>
+            <div className="flex-1" />
             <motion.button
               type="button"
               className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-white/[0.06] transition-colors shrink-0"
               onClick={onToggleCollapse}
               title={collapsed ? "サイドバーを開く" : "サイドバーを閉じる"}
-              animate={{ opacity: expanded ? 1 : 0 }}
-              transition={{ duration: 0.2 }}
             >
               <svg
                 aria-hidden="true"
@@ -560,137 +681,6 @@ export function Sidebar({
                 )}
               </svg>
             </motion.button>
-          </div>
-          <motion.div
-            className="flex items-center gap-1.5 pl-1"
-            animate={{ opacity: expanded ? 1 : 0 }}
-            transition={{ duration: 0.2 }}
-          >
-            <button
-              type="button"
-              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
-                viewMode === "favorites"
-                  ? "text-pink-400 bg-pink-400/10"
-                  : "text-gray-500 hover:text-pink-400 hover:bg-pink-400/10"
-              }`}
-              onClick={onSelectFavorites}
-              title="お気に入り"
-            >
-              <svg
-                className="size-4.5"
-                viewBox="0 0 24 24"
-                fill={viewMode === "favorites" ? "currentColor" : "none"}
-                stroke="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
-                />
-              </svg>
-            </button>
-            <button
-              type="button"
-              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
-                viewMode === "commands"
-                  ? "text-cyan-400 bg-cyan-400/10"
-                  : "text-gray-500 hover:text-cyan-400 hover:bg-cyan-400/10"
-              }`}
-              onClick={onSelectCommands}
-              title="コマンド実行"
-            >
-              <svg
-                className="size-4.5"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"
-                />
-              </svg>
-            </button>
-            <button
-              type="button"
-              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
-                viewMode === "datasets"
-                  ? "text-amber-400 bg-amber-400/10"
-                  : "text-gray-500 hover:text-amber-400 hover:bg-amber-400/10"
-              }`}
-              onClick={onSelectDatasets}
-              title="データセット"
-            >
-              <svg
-                className="size-4.5"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
-                />
-              </svg>
-            </button>
-            <button
-              type="button"
-              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
-                viewMode === "queue"
-                  ? "text-orange-400 bg-orange-400/10"
-                  : "text-gray-500 hover:text-orange-400 hover:bg-orange-400/10"
-              }`}
-              onClick={onSelectQueue}
-              title="パイプラインキュー"
-            >
-              <svg
-                className="size-4.5"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z"
-                />
-              </svg>
-            </button>
-            <button
-              type="button"
-              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
-                viewMode === "config"
-                  ? "text-gray-300 bg-gray-700/50"
-                  : "text-gray-500 hover:text-gray-300 hover:bg-gray-700/30"
-              }`}
-              onClick={onSelectConfig}
-              title="設定"
-            >
-              <svg
-                className="size-4.5"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28ZM15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-                />
-              </svg>
-            </button>
           </motion.div>
         </div>
 

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -266,11 +266,34 @@ export function Sidebar({
               transition={{ duration: 0.25, ease: "easeOut" }}
             >
               {/* Header */}
-              <div className="px-5 py-6 flex items-center justify-between">
-                <div className="flex items-center gap-3">
+              <div className="px-5 pt-5 pb-3 space-y-2">
+                <div className="flex items-center justify-between">
                   <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
                     R
                   </span>
+                  <button
+                    type="button"
+                    className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-white/[0.06] transition-colors shrink-0"
+                    onClick={onMobileClose}
+                    title="閉じる"
+                  >
+                    <svg
+                      className="size-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div className="flex items-center gap-1.5 pl-1">
                   <button
                     type="button"
                     className={`p-1.5 rounded-lg transition-colors shrink-0 ${
@@ -282,7 +305,7 @@ export function Sidebar({
                     title="お気に入り"
                   >
                     <svg
-                      className="size-5"
+                      className="size-4.5"
                       viewBox="0 0 24 24"
                       fill={viewMode === "favorites" ? "currentColor" : "none"}
                       stroke="currentColor"
@@ -307,7 +330,7 @@ export function Sidebar({
                     title="コマンド実行"
                   >
                     <svg
-                      className="size-5"
+                      className="size-4.5"
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
@@ -332,7 +355,7 @@ export function Sidebar({
                     title="データセット"
                   >
                     <svg
-                      className="size-5"
+                      className="size-4.5"
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
@@ -357,7 +380,7 @@ export function Sidebar({
                     title="パイプラインキュー"
                   >
                     <svg
-                      className="size-5"
+                      className="size-4.5"
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
@@ -382,7 +405,7 @@ export function Sidebar({
                     title="設定"
                   >
                     <svg
-                      className="size-5"
+                      className="size-4.5"
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
@@ -397,27 +420,6 @@ export function Sidebar({
                     </svg>
                   </button>
                 </div>
-                <button
-                  type="button"
-                  className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-white/[0.06] transition-colors shrink-0"
-                  onClick={onMobileClose}
-                  title="閉じる"
-                >
-                  <svg
-                    className="size-4"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
               </div>
 
               {/* Search */}
@@ -521,12 +523,50 @@ export function Sidebar({
     >
       <div className="h-full flex flex-col" style={{ width: SIDEBAR_WIDTH }}>
         {/* Header */}
-        <div className="px-5 py-6 flex items-center justify-between">
-          <div className="flex items-center gap-3">
+        <div className="px-5 pt-5 pb-3 space-y-2">
+          <div className="flex items-center justify-between">
             <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-sm font-bold shadow-lg shadow-indigo-500/25">
               R
             </span>
             <motion.button
+              type="button"
+              className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-white/[0.06] transition-colors shrink-0"
+              onClick={onToggleCollapse}
+              title={collapsed ? "サイドバーを開く" : "サイドバーを閉じる"}
+              animate={{ opacity: expanded ? 1 : 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              <svg
+                aria-hidden="true"
+                className="size-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                {collapsed ? (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                ) : (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 19l-7-7 7-7"
+                  />
+                )}
+              </svg>
+            </motion.button>
+          </div>
+          <motion.div
+            className="flex items-center gap-1.5 pl-1"
+            animate={{ opacity: expanded ? 1 : 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            <button
               type="button"
               className={`p-1.5 rounded-lg transition-colors shrink-0 ${
                 viewMode === "favorites"
@@ -535,11 +575,9 @@ export function Sidebar({
               }`}
               onClick={onSelectFavorites}
               title="お気に入り"
-              animate={{ opacity: expanded ? 1 : 0 }}
-              transition={{ duration: 0.2 }}
             >
               <svg
-                className="size-5"
+                className="size-4.5"
                 viewBox="0 0 24 24"
                 fill={viewMode === "favorites" ? "currentColor" : "none"}
                 stroke="currentColor"
@@ -552,8 +590,8 @@ export function Sidebar({
                   d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
                 />
               </svg>
-            </motion.button>
-            <motion.button
+            </button>
+            <button
               type="button"
               className={`p-1.5 rounded-lg transition-colors shrink-0 ${
                 viewMode === "commands"
@@ -562,11 +600,9 @@ export function Sidebar({
               }`}
               onClick={onSelectCommands}
               title="コマンド実行"
-              animate={{ opacity: expanded ? 1 : 0 }}
-              transition={{ duration: 0.2 }}
             >
               <svg
-                className="size-5"
+                className="size-4.5"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
@@ -579,8 +615,8 @@ export function Sidebar({
                   d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"
                 />
               </svg>
-            </motion.button>
-            <motion.button
+            </button>
+            <button
               type="button"
               className={`p-1.5 rounded-lg transition-colors shrink-0 ${
                 viewMode === "datasets"
@@ -589,11 +625,9 @@ export function Sidebar({
               }`}
               onClick={onSelectDatasets}
               title="データセット"
-              animate={{ opacity: expanded ? 1 : 0 }}
-              transition={{ duration: 0.2 }}
             >
               <svg
-                className="size-5"
+                className="size-4.5"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
@@ -606,8 +640,8 @@ export function Sidebar({
                   d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
                 />
               </svg>
-            </motion.button>
-            <motion.button
+            </button>
+            <button
               type="button"
               className={`p-1.5 rounded-lg transition-colors shrink-0 ${
                 viewMode === "queue"
@@ -616,11 +650,9 @@ export function Sidebar({
               }`}
               onClick={onSelectQueue}
               title="パイプラインキュー"
-              animate={{ opacity: expanded ? 1 : 0 }}
-              transition={{ duration: 0.2 }}
             >
               <svg
-                className="size-5"
+                className="size-4.5"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
@@ -633,8 +665,8 @@ export function Sidebar({
                   d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z"
                 />
               </svg>
-            </motion.button>
-            <motion.button
+            </button>
+            <button
               type="button"
               className={`p-1.5 rounded-lg transition-colors shrink-0 ${
                 viewMode === "config"
@@ -643,11 +675,9 @@ export function Sidebar({
               }`}
               onClick={onSelectConfig}
               title="設定"
-              animate={{ opacity: expanded ? 1 : 0 }}
-              transition={{ duration: 0.2 }}
             >
               <svg
-                className="size-5"
+                className="size-4.5"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
@@ -660,40 +690,8 @@ export function Sidebar({
                   d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28ZM15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
                 />
               </svg>
-            </motion.button>
-          </div>
-          <motion.button
-            type="button"
-            className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-white/[0.06] transition-colors shrink-0"
-            onClick={onToggleCollapse}
-            title={collapsed ? "サイドバーを開く" : "サイドバーを閉じる"}
-            animate={{ opacity: expanded ? 1 : 0 }}
-            transition={{ duration: 0.2 }}
-          >
-            <svg
-              aria-hidden="true"
-              className="size-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              {collapsed ? (
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 5l7 7-7 7"
-                />
-              ) : (
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 19l-7-7 7-7"
-                />
-              )}
-            </svg>
-          </motion.button>
+            </button>
+          </motion.div>
         </div>
 
         {/* Search */}


### PR DESCRIPTION
## Summary

- `gen/pipeline_queue/` にユーザーのアイデアをJSON形式で保存するキュー機構を実装
- キュー処理スクリプト: キューアイテムを `data_source/{timestamp}/user_proposal.md` に変換し `pnpm pipeline --skip-collect` で実行
- `scheduler-run.sh`: キューがあればキュー処理、なければ通常パイプラインの分岐ロジック
- Viewer にキュー管理画面（新規作成・編集・削除）とサイドバーボタンを追加
- Queue API エンドポイント（CRUD: GET/POST/PUT/DELETE `/api/queue`）

Closes #87

## Changes

- `scripts/lib/paths.ts` - `PIPELINE_QUEUE_DIR` 定数追加
- `scripts/process-queue.ts` - キュー処理スクリプト（新規）
- `scripts/scheduler-run.sh` - キュー有無による分岐ロジック
- `package.json` - `queue:process` コマンド追加
- `viewer/server.ts` - Queue API エンドポイント追加
- `viewer/src/api.ts` - Queue API クライアント関数追加
- `viewer/src/components/QueueManager.tsx` - キュー管理UI（新規）
- `viewer/src/App.tsx` - キュービューモード追加
- `viewer/src/components/Sidebar.tsx` - キューボタン追加

## Test plan

- [ ] Viewer でキュー画面を開き、アイデアの新規作成・編集・削除が動作すること
- [ ] `gen/pipeline_queue/` にJSONファイルが正しく作成されること
- [ ] `pnpm queue:process` でキューアイテムがパイプライン処理されること
- [ ] 処理成功後にキューファイルが削除されること
- [ ] `scheduler-run.sh` でキュー有無の分岐が正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)