### PR TITLE
feat: X (Twitter) Trends APIをデータソースとして追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `NEWS_API_KEY` - NewsAPI用
 - `YOUTUBE_API_KEY` - YouTube Data API用（`app.config.yaml`で`enabled: false`がデフォルト）
+- `X_BEARER_TOKEN` - X (Twitter) API用（`app.config.yaml`で`enabled: false`がデフォルト）
 
 ## アプリケーション設定（`app.config.yaml`）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `NEWS_API_KEY` - NewsAPI用
 - `YOUTUBE_API_KEY` - YouTube Data API用（`app.config.yaml`で`enabled: false`がデフォルト）
-- `X_BEARER_TOKEN` - X (Twitter) API用（`app.config.yaml`で`enabled: false`がデフォルト）
+- `X_API_BEARER_TOKEN` - X (Twitter) API用（`app.config.yaml`で`enabled: false`がデフォルト）
 
 ## アプリケーション設定（`app.config.yaml`）
 

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -50,11 +50,27 @@ collect:
     x:
       type: x
       enabled: false
-      api_key_env: X_BEARER_TOKEN
+      api_key_env: X_API_BEARER_TOKEN
       endpoint: https://api.x.com/2/trends/by/woeid
       params:
         woeid: 23424856
       output_file: x_trends.json
+
+    # X (Twitter) Popular Posts - バズったツイートを取得
+    # sort_order=relevancy でエンゲージメントの高い投稿を優先取得
+    # query: lang/is/has等のオペレーターだけでは使用不可。キーワードが最低1つ必要
+    # query例: "(話題 OR トレンド OR 注目) lang:ja -is:retweet -is:reply"
+    #          "#AI lang:ja -is:retweet"
+    x_popular_posts:
+      type: x_popular_posts
+      enabled: false
+      api_key_env: X_API_BEARER_TOKEN
+      endpoint: https://api.x.com/2/tweets/search/recent
+      params:
+        query: "(話題 OR トレンド OR 注目 OR ニュース OR 最新) lang:ja -is:retweet -is:reply"
+        maxResults: 20
+        sort_order: relevancy
+      output_file: x_popular_posts.json
 
 # --- 今後追加予定のデータソース ---
 

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -45,6 +45,17 @@ collect:
         maxResults: 20
       output_file: youtube_all.json
 
+    # X (Twitter) Trends API (https://docs.x.com/x-api/trends/introduction)
+    # WOEID: 1=世界, 23424856=日本, 1118370=東京
+    x:
+      type: x
+      enabled: false
+      api_key_env: X_BEARER_TOKEN
+      endpoint: https://api.x.com/2/trends/by/woeid
+      params:
+        woeid: 23424856
+      output_file: x_trends.json
+
 # --- 今後追加予定のデータソース ---
 
 # TikTok

--- a/scripts/lib/fetchers.ts
+++ b/scripts/lib/fetchers.ts
@@ -64,9 +64,31 @@ export async function fetchYoutube(config: SourceConfig, apiKey: string): Promis
   };
 }
 
+export async function fetchXTrends(config: SourceConfig, apiKey: string): Promise<FetchResult> {
+  const woeid = config.params.woeid ?? 23424856;
+  const url = `${config.endpoint}/${woeid}`;
+
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`X API error (${res.status}): ${body}`);
+  }
+
+  const data = await res.json();
+  return {
+    fetched_at: new Date().toISOString(),
+    source: "x",
+    params: config.params,
+    data,
+  };
+}
+
 const fetcherMap: Record<string, (config: SourceConfig, apiKey: string) => Promise<FetchResult>> = {
   newsapi: fetchNewsApi,
   youtube: fetchYoutube,
+  x: fetchXTrends,
 };
 
 export function getFetcher(

--- a/scripts/lib/fetchers.ts
+++ b/scripts/lib/fetchers.ts
@@ -85,10 +85,50 @@ export async function fetchXTrends(config: SourceConfig, apiKey: string): Promis
   };
 }
 
+export async function fetchXPopularPosts(
+  config: SourceConfig,
+  apiKey: string,
+): Promise<FetchResult> {
+  const query = String(
+    config.params.query ??
+      "(話題 OR トレンド OR 注目 OR ニュース OR 最新) lang:ja -is:retweet -is:reply",
+  );
+  const maxResults = Number(config.params.maxResults ?? 20);
+  const sortOrder = String(config.params.sort_order ?? "relevancy");
+
+  const url = new URL(config.endpoint);
+  url.searchParams.set("query", query);
+  url.searchParams.set("max_results", String(maxResults));
+  url.searchParams.set("sort_order", sortOrder);
+  url.searchParams.set(
+    "tweet.fields",
+    "text,public_metrics,created_at,author_id,conversation_id,lang,note_tweet",
+  );
+  url.searchParams.set("expansions", "author_id");
+  url.searchParams.set("user.fields", "name,username");
+
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`X API error (${res.status}): ${body}`);
+  }
+
+  const data = await res.json();
+  return {
+    fetched_at: new Date().toISOString(),
+    source: "x_popular_posts",
+    params: { query, maxResults, sort_order: sortOrder },
+    data,
+  };
+}
+
 const fetcherMap: Record<string, (config: SourceConfig, apiKey: string) => Promise<FetchResult>> = {
   newsapi: fetchNewsApi,
   youtube: fetchYoutube,
   x: fetchXTrends,
+  x_popular_posts: fetchXPopularPosts,
 };
 
 export function getFetcher(

--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -4,8 +4,8 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
-  statSync,
   renameSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";

--- a/viewer/src/components/ConfigEditor.tsx
+++ b/viewer/src/components/ConfigEditor.tsx
@@ -50,6 +50,15 @@ const VIDEO_CATEGORY_OPTIONS = [
   { value: "28", label: "28 - 科学技術" },
 ];
 
+const WOEID_OPTIONS = [
+  { value: "1", label: "1 - 世界" },
+  { value: "23424856", label: "23424856 - 日本" },
+  { value: "1118370", label: "1118370 - 東京" },
+  { value: "23424977", label: "23424977 - アメリカ" },
+  { value: "23424975", label: "23424975 - イギリス" },
+  { value: "23424868", label: "23424868 - 韓国" },
+];
+
 const PLATFORM_OPTIONS = [
   { value: "frontend-only", label: "frontend-only (フロントエンドのみ)" },
   { value: "fullstack", label: "fullstack (フルスタック)" },
@@ -384,6 +393,8 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
   const newsapi = config.collect?.sources?.newsapi;
   const youtube = config.collect?.sources?.youtube;
   const youtubeAll = config.collect?.sources?.youtube_all;
+  const xTrends = config.collect?.sources?.x;
+  const xPopularPosts = config.collect?.sources?.x_popular_posts;
   const constraints = config.generate?.constraints ?? {};
   const perspectives = config.generate?.perspectives;
   const agents = config.generate?.agents ?? {};
@@ -737,6 +748,143 @@ export function ConfigEditor({ isMobile, isDev }: ConfigEditorProps) {
                   disabled={disabled}
                 />
               </div>
+            </div>
+          </div>
+
+          {/* X (Twitter) Trends */}
+          <div className="rounded-lg border border-gray-800/50 bg-gray-800/30 p-4 space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-200">X (Twitter) Trends API</h3>
+                <p className="text-[12px] text-gray-500">地域別のトレンドトピックを取得</p>
+              </div>
+              <Toggle
+                checked={xTrends?.enabled ?? false}
+                onChange={(v) => updateSource("x", (s) => ({ ...s, enabled: v }))}
+                disabled={disabled}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <FieldLabel label="woeid" description="地域コード (WOEID)" htmlFor="x-woeid" />
+                <SelectField
+                  id="x-woeid"
+                  value={String(xTrends?.params?.woeid ?? "23424856")}
+                  options={WOEID_OPTIONS}
+                  onChange={(v) =>
+                    updateSource("x", (s) => ({
+                      ...s,
+                      params: { ...s.params, woeid: Number(v) },
+                    }))
+                  }
+                  disabled={disabled}
+                />
+              </div>
+              <div>
+                <FieldLabel label="output_file" description="出力ファイル名" htmlFor="x-output" />
+                <TextField
+                  id="x-output"
+                  value={xTrends?.output_file ?? "x_trends.json"}
+                  onChange={(v) => updateSource("x", (s) => ({ ...s, output_file: v }))}
+                  disabled={disabled}
+                />
+              </div>
+            </div>
+            <div>
+              <FieldLabel
+                label="api_key_env"
+                description="Bearer Tokenの環境変数名（.envに定義）"
+                htmlFor="x-apikey"
+              />
+              <TextField
+                id="x-apikey"
+                value={xTrends?.api_key_env ?? "X_API_BEARER_TOKEN"}
+                onChange={(v) => updateSource("x", (s) => ({ ...s, api_key_env: v }))}
+                disabled={disabled}
+              />
+            </div>
+          </div>
+
+          {/* X (Twitter) Popular Posts */}
+          <div className="rounded-lg border border-gray-800/50 bg-gray-800/30 p-4 space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-200">X (Twitter) Popular Posts</h3>
+                <p className="text-[12px] text-gray-500">バズったツイートをrelevancy順で取得</p>
+              </div>
+              <Toggle
+                checked={xPopularPosts?.enabled ?? false}
+                onChange={(v) => updateSource("x_popular_posts", (s) => ({ ...s, enabled: v }))}
+                disabled={disabled}
+              />
+            </div>
+            <div>
+              <FieldLabel
+                label="query"
+                description="検索クエリ（キーワードが最低1つ必要。例: #AI lang:ja -is:retweet）"
+                htmlFor="xpp-query"
+              />
+              <TextField
+                id="xpp-query"
+                value={String(
+                  xPopularPosts?.params?.query ??
+                    "(話題 OR トレンド OR 注目 OR ニュース OR 最新) lang:ja -is:retweet -is:reply",
+                )}
+                onChange={(v) =>
+                  updateSource("x_popular_posts", (s) => ({
+                    ...s,
+                    params: { ...s.params, query: v },
+                  }))
+                }
+                disabled={disabled}
+                placeholder="(話題 OR トレンド) lang:ja -is:retweet -is:reply"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <FieldLabel
+                  label="maxResults"
+                  description="取得するツイート数（10〜100）"
+                  htmlFor="xpp-maxresults"
+                />
+                <NumberField
+                  id="xpp-maxresults"
+                  value={Number(xPopularPosts?.params?.maxResults ?? 20)}
+                  onChange={(v) =>
+                    updateSource("x_popular_posts", (s) => ({
+                      ...s,
+                      params: { ...s.params, maxResults: v },
+                    }))
+                  }
+                  disabled={disabled}
+                  min={10}
+                  max={100}
+                />
+              </div>
+              <div>
+                <FieldLabel label="output_file" description="出力ファイル名" htmlFor="xpp-output" />
+                <TextField
+                  id="xpp-output"
+                  value={xPopularPosts?.output_file ?? "x_popular_posts.json"}
+                  onChange={(v) =>
+                    updateSource("x_popular_posts", (s) => ({ ...s, output_file: v }))
+                  }
+                  disabled={disabled}
+                />
+              </div>
+            </div>
+            <div>
+              <FieldLabel
+                label="api_key_env"
+                description="Bearer Tokenの環境変数名（.envに定義）"
+                htmlFor="xpp-apikey"
+              />
+              <TextField
+                id="xpp-apikey"
+                value={xPopularPosts?.api_key_env ?? "X_API_BEARER_TOKEN"}
+                onChange={(v) => updateSource("x_popular_posts", (s) => ({ ...s, api_key_env: v }))}
+                disabled={disabled}
+              />
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary

X (Twitter) Trends API (`/2/trends/by/woeid/:id`) をデータソースとして追加。Bearer Token認証に対応した専用fetcher関数を実装。

Closes #86

## Changes

- `scripts/lib/fetchers.ts`: `fetchXTrends` 関数追加、`fetcherMap` に `x` を登録
- `app.config.yaml`: `x` ソース設定追加（`enabled: false` デフォルト、WOEID: 23424856=日本）
- `CLAUDE.md`: 環境変数セクションに `X_BEARER_TOKEN` を追記

## Test plan

- [ ] `.env` に `X_BEARER_TOKEN` を設定し、`app.config.yaml` で `x.enabled: true` にして `pnpm collect` を実行
- [ ] `gen/data_source/` 配下に `x_trends.json` が生成されることを確認
- [ ] Bearer Token未設定時にスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)