### PR TITLE
fix: スケジューラの断続的失敗を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "description": "各種データから連想方式でアプリケーション設計を行うためのツール",
   "scripts": {
     "collect": "tsx scripts/collect.ts",

--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -406,19 +406,34 @@ async function main() {
     results.push({ name: "extract", status: "skipped" });
   } else {
     console.log("[Step 2] extract: キーワード抽出を開始...\n");
-    try {
-      await runStep("bash", ["scripts/extract.sh", "--target", targetDir]);
-      console.log("");
-      const keywordPath = resolve(DATA_SOURCE_DIR, targetDir, "keyword.json");
-      if (!existsSync(keywordPath)) {
-        throw new Error("keyword.json が生成されませんでした");
+    const maxRetries = 2;
+    let extractSuccess = false;
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        if (attempt > 1) {
+          console.log(`\n[extract] リトライ ${attempt}/${maxRetries}...\n`);
+        }
+        await runStep("bash", ["scripts/extract.sh", "--target", targetDir]);
+        console.log("");
+        const keywordPath = resolve(DATA_SOURCE_DIR, targetDir, "keyword.json");
+        if (!existsSync(keywordPath)) {
+          throw new Error("keyword.json が生成されませんでした");
+        }
+        extractSuccess = true;
+        break;
+      } catch (err) {
+        console.error(
+          `\nextract 試行 ${attempt} 失敗: ${err instanceof Error ? err.message : err}`,
+        );
+        if (attempt === maxRetries) {
+          results.push({ name: "extract", status: "failed" });
+          await printSummary(results);
+          process.exit(1);
+        }
       }
+    }
+    if (extractSuccess) {
       results.push({ name: "extract", status: "success" });
-    } catch (err) {
-      console.error(`\nextract 失敗: ${err instanceof Error ? err.message : err}`);
-      results.push({ name: "extract", status: "failed" });
-      await printSummary(results);
-      process.exit(1);
     }
   }
 

--- a/scripts/validate-requirements.ts
+++ b/scripts/validate-requirements.ts
@@ -1,7 +1,25 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { REQUIREMENTS_DIR } from "./lib/paths.js";
 import { validateTags } from "./lib/tags.js";
+
+// --- JSON修復 ---
+function repairJson(raw: string): string | null {
+  let s = raw;
+  // コメント除去（// ... と /* ... */）
+  s = s.replace(/\/\/.*$/gm, "");
+  s = s.replace(/\/\*[\s\S]*?\*\//g, "");
+  // 末尾カンマ除去（}, ] の直前のカンマ）
+  s = s.replace(/,\s*([}\]])/g, "$1");
+  // シングルクォートをダブルクォートに（値の中のアポストロフィは対象外にするため、キー・値囲みのみ）
+  s = s.replace(/(?<=[\[{,:\s])'/g, '"').replace(/'(?=\s*[,\]}:])/g, '"');
+  try {
+    const parsed = JSON.parse(s);
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return null;
+  }
+}
 
 // --- 必須セクション定義 ---
 const OVERVIEW_REQUIRED_SECTIONS = [
@@ -144,11 +162,19 @@ function validate(appName: string): ValidationError[] {
     try {
       data = JSON.parse(raw) as SourceInfoJson;
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      errors.push({
-        file: "_source_info.json",
-        message: `JSON構文エラー: ${msg}（未エスケープのダブルクォートや末尾カンマ等がないか確認してください）`,
-      });
+      // 自動修復を試みる
+      const repaired = repairJson(raw);
+      if (repaired) {
+        writeFileSync(sourceInfoPath, repaired, "utf-8");
+        data = JSON.parse(repaired) as SourceInfoJson;
+        console.log("  ℹ _source_info.json のJSON構文を自動修復しました");
+      } else {
+        const msg = e instanceof Error ? e.message : String(e);
+        errors.push({
+          file: "_source_info.json",
+          message: `JSON構文エラー: ${msg}（自動修復にも失敗しました）`,
+        });
+      }
     }
 
     // 5b. スキーマバリデーション（JSON構文が正常な場合のみ）


### PR DESCRIPTION
## Summary
- `package.json` に `engines.node >= 22` を明記
- `pipeline.ts` の extract ステップにリトライ機構を追加（最大2回試行）。Claude CLIが keyword.json を生成しない断続的失敗に対処
- `validate-requirements.ts` に `_source_info.json` のJSON自動修復を追加（末尾カンマ・コメント・シングルクォート等を修復）

## Test plan
- [ ] `pnpm pipeline` で extract が1回失敗してもリトライで成功することを確認
- [ ] 不正なJSON（末尾カンマ等）の `_source_info.json` が自動修復されることを確認
- [ ] Node 22+ で `pnpm queue:process` が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)