### PR TITLE
feat: スケジューラ設定画面を追加

### DIFF
--- a/scripts/scheduler-ctl.sh
+++ b/scripts/scheduler-ctl.sh
@@ -31,6 +31,36 @@ case "${1:-}" in
     echo "無効化完了。"
     ;;
   status)
+    # サマリー表示
+    TIMER_STATE=$(systemctl --user is-active pipeline.timer 2>/dev/null || true)
+    if [[ "$TIMER_STATE" == "active" ]]; then
+      echo "スケジューラ: 有効"
+    else
+      echo "スケジューラ: 無効"
+    fi
+
+    # 次回実行
+    NEXT=$(systemctl --user list-timers pipeline.timer --no-pager 2>/dev/null | grep pipeline || true)
+    if [[ -n "$NEXT" ]]; then
+      NEXT_TIME=$(echo "$NEXT" | awk '{print $1, $2, $3}')
+      echo "次回実行:     $NEXT_TIME"
+    fi
+
+    # スケジュール（OnCalendar）
+    TIMER_FILE="$UNIT_DIR/pipeline.timer"
+    if [[ -f "$TIMER_FILE" ]]; then
+      FIRST=true
+      while IFS= read -r cal; do
+        if $FIRST; then
+          echo "スケジュール: $cal"
+          FIRST=false
+        else
+          echo "              $cal"
+        fi
+      done < <(grep -E '^OnCalendar=' "$TIMER_FILE" | sed 's/^OnCalendar=//')
+    fi
+
+    echo ""
     echo "=== タイマー状態 ==="
     systemctl --user status pipeline.timer --no-pager 2>/dev/null || echo "タイマー未インストール"
     echo ""
@@ -38,17 +68,15 @@ case "${1:-}" in
     systemctl --user status pipeline.service --no-pager 2>/dev/null || echo "サービス未インストール"
     echo ""
     echo "=== 今後の実行予定 ==="
-    # タイマーファイルから有効なOnCalendar行を抽出し、systemd-analyzeで今後の予定を表示
-    TIMER_FILE="$UNIT_DIR/pipeline.timer"
     if [[ -f "$TIMER_FILE" ]]; then
-      CALENDARS=()
+      CALENDAR_ARGS=()
       while IFS= read -r line; do
-        CALENDARS+=("$line")
+        CALENDAR_ARGS+=("$line")
       done < <(grep -E '^OnCalendar=' "$TIMER_FILE" | sed 's/^OnCalendar=//')
       TIMER_TZ=$(grep -E '^TimezoneOfTimer=' "$TIMER_FILE" | sed 's/^TimezoneOfTimer=//' || true)
-      if [[ ${#CALENDARS[@]} -gt 0 ]]; then
+      if [[ ${#CALENDAR_ARGS[@]} -gt 0 ]]; then
         export TZ="${TIMER_TZ:-}"
-        systemd-analyze calendar --iterations=10 "${CALENDARS[@]}" 2>/dev/null || echo "解析できませんでした"
+        systemd-analyze calendar --iterations=10 "${CALENDAR_ARGS[@]}" 2>/dev/null || echo "解析できませんでした"
       fi
     else
       echo "タイマーファイルが見つかりません"

--- a/scripts/validate-requirements.ts
+++ b/scripts/validate-requirements.ts
@@ -12,7 +12,7 @@ function repairJson(raw: string): string | null {
   // 末尾カンマ除去（}, ] の直前のカンマ）
   s = s.replace(/,\s*([}\]])/g, "$1");
   // シングルクォートをダブルクォートに（値の中のアポストロフィは対象外にするため、キー・値囲みのみ）
-  s = s.replace(/(?<=[\[{,:\s])'/g, '"').replace(/'(?=\s*[,\]}:])/g, '"');
+  s = s.replace(/(?<=[[{,:\s])'/g, '"').replace(/'(?=\s*[,\]}:])/g, '"');
   try {
     const parsed = JSON.parse(s);
     return JSON.stringify(parsed, null, 2);

--- a/systemd/pipeline.service
+++ b/systemd/pipeline.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 Type=oneshot
 WorkingDirectory=%h/develop/requirements_creator
 ExecStart=%h/develop/requirements_creator/scripts/scheduler-run.sh
-Environment=PATH=%h/.local/share/pnpm:%h/.nvm/versions/node/v20.9.0/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=%h/.local/share/pnpm:%h/.nvm/versions/node/v22.17.0/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 
 [Install]
 WantedBy=default.target

--- a/systemd/pipeline.timer
+++ b/systemd/pipeline.timer
@@ -2,12 +2,12 @@
 Description=Requirements Creator パイプライン 毎日JST実行
 
 [Timer]
-OnCalendar=Mon,Thu,Fri,Sat,Sun *-*-* 02:00:00
-OnCalendar=Mon,Thu,Fri,Sat,Sun *-*-* 02:30:00
-OnCalendar=Mon,Thu,Fri,Sat,Sun *-*-* 03:00:00
-OnCalendar=Mon,Thu,Fri,Sat,Sun *-*-* 03:30:00
-OnCalendar=Mon,Thu,Fri,Sat,Sun *-*-* 04:00:00
-OnCalendar=Mon,Thu,Fri,Sat,Sun *-*-* 05:00:00
+OnCalendar=*-*-* 02:00:00
+OnCalendar=*-*-* 02:30:00
+OnCalendar=*-*-* 03:00:00
+OnCalendar=*-*-* 03:30:00
+OnCalendar=*-*-* 04:00:00
+OnCalendar=*-*-* 05:00:00
 TimezoneOfTimer=Asia/Tokyo
 Persistent=true
 

--- a/systemd/pipeline.timer
+++ b/systemd/pipeline.timer
@@ -2,17 +2,12 @@
 Description=Requirements Creator パイプライン 毎日JST実行
 
 [Timer]
-OnCalendar=*-*-* 02:00:00
-OnCalendar=*-*-* 02:30:00
-OnCalendar=*-*-* 03:00:00
-OnCalendar=*-*-* 03:30:00
-OnCalendar=*-*-* 04:00:00
-OnCalendar=*-*-* 05:00:00
-# OnCalendar=*-*-* 18:00:00
-# 毎時実行:
-# OnCalendar=*-*-* *:00:00
-# 平日のみ:
-# OnCalendar=Mon..Fri *-*-* 05:00:00
+OnCalendar=Mon,Thu,Fri,Sat,Sun *-*-* 02:00:00
+OnCalendar=Mon,Thu,Fri,Sat,Sun *-*-* 02:30:00
+OnCalendar=Mon,Thu,Fri,Sat,Sun *-*-* 03:00:00
+OnCalendar=Mon,Thu,Fri,Sat,Sun *-*-* 03:30:00
+OnCalendar=Mon,Thu,Fri,Sat,Sun *-*-* 04:00:00
+OnCalendar=Mon,Thu,Fri,Sat,Sun *-*-* 05:00:00
 TimezoneOfTimer=Asia/Tokyo
 Persistent=true
 

--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -806,6 +806,70 @@ app.post("/api/git/switch-branch", async (c) => {
   }
 });
 
+// --- Scheduler API ---
+app.get("/api/scheduler/status", async (c) => {
+  try {
+    const { stdout } = await execAsync("bash scripts/scheduler-ctl.sh status 2>&1", {
+      cwd: projectRoot,
+      timeout: 10000,
+    });
+    // タイマーが active かどうか判定
+    const timerActive = /Active:\s+active/.test(stdout.split("=== サービス状態 ===")[0] ?? "");
+    // 次回実行時刻を抽出（systemd-analyze calendar の出力から）
+    const nextMatch = stdout.match(/Next elapse:\s+(.+)/);
+    const nextRun = nextMatch?.[1]?.trim() ?? null;
+    return c.json({ timerActive, nextRun, output: stdout });
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; message: string };
+    const output = `${e.stdout ?? ""}${e.stderr ?? ""}`.trim() || e.message;
+    return c.json({ timerActive: false, nextRun: null, output });
+  }
+});
+
+app.post("/api/scheduler/enable", async (c) => {
+  if (!isDev) return c.json({ error: "Dev mode only" }, 403);
+  try {
+    const { stdout, stderr } = await execAsync("bash scripts/scheduler-ctl.sh enable 2>&1", {
+      cwd: projectRoot,
+      timeout: 15000,
+    });
+    const output = [stdout, stderr].filter((s) => s?.trim()).join("\n");
+    return c.json({ success: true, output });
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; message: string };
+    const output = `${e.stdout ?? ""}${e.stderr ?? ""}`.trim() || e.message;
+    return c.json({ success: false, output });
+  }
+});
+
+app.post("/api/scheduler/disable", async (c) => {
+  if (!isDev) return c.json({ error: "Dev mode only" }, 403);
+  try {
+    const { stdout, stderr } = await execAsync("bash scripts/scheduler-ctl.sh disable 2>&1", {
+      cwd: projectRoot,
+      timeout: 15000,
+    });
+    const output = [stdout, stderr].filter((s) => s?.trim()).join("\n");
+    return c.json({ success: true, output });
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; message: string };
+    const output = `${e.stdout ?? ""}${e.stderr ?? ""}`.trim() || e.message;
+    return c.json({ success: false, output });
+  }
+});
+
+app.get("/api/scheduler/timer-config", (c) => {
+  const timerPath = resolve(projectRoot, "systemd", "pipeline.timer");
+  if (!existsSync(timerPath)) return c.json({ error: "Timer file not found" }, 404);
+  return c.json({ content: readFileSync(timerPath, "utf-8") });
+});
+
+app.get("/api/scheduler/service-config", (c) => {
+  const servicePath = resolve(projectRoot, "systemd", "pipeline.service");
+  if (!existsSync(servicePath)) return c.json({ error: "Service file not found" }, 404);
+  return c.json({ content: readFileSync(servicePath, "utf-8") });
+});
+
 // --- Commands API (dev mode only) ---
 
 const ALLOWED_COMMANDS: Record<string, { bin: string; baseArgs: string[] }> = {

--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -807,22 +807,55 @@ app.post("/api/git/switch-branch", async (c) => {
 });
 
 // --- Scheduler API ---
+
+const ALL_DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function parseTimerSchedule(): { days: string[]; times: string[] } {
+  const timerPath = resolve(projectRoot, "systemd", "pipeline.timer");
+  if (!existsSync(timerPath)) return { days: [...ALL_DAYS], times: [] };
+  const content = readFileSync(timerPath, "utf-8");
+  const lines = content.split("\n");
+  const times: string[] = [];
+  let days: string[] | null = null;
+
+  for (const line of lines) {
+    const m = line.match(/^OnCalendar=(.+)$/);
+    if (!m) continue;
+    const spec = m[1].trim();
+    // "Mon,Tue *-*-* HH:MM:SS" or "*-*-* HH:MM:SS"
+    const parts = spec.split(/\s+/);
+    if (parts.length === 2) {
+      // No day spec: *-*-* HH:MM:SS
+      const time = parts[1].slice(0, 5); // HH:MM
+      if (!times.includes(time)) times.push(time);
+      if (days === null) days = [...ALL_DAYS];
+    } else if (parts.length === 3) {
+      // Day spec: Mon,Tue *-*-* HH:MM:SS
+      const daySpec = parts[0].replace(/,/g, ",");
+      if (days === null) days = daySpec.split(",").filter((d) => ALL_DAYS.includes(d));
+      const time = parts[2].slice(0, 5);
+      if (!times.includes(time)) times.push(time);
+    }
+  }
+
+  times.sort();
+  return { days: days ?? [...ALL_DAYS], times };
+}
+
 app.get("/api/scheduler/status", async (c) => {
   try {
     const { stdout } = await execAsync("bash scripts/scheduler-ctl.sh status 2>&1", {
       cwd: projectRoot,
       timeout: 10000,
     });
-    // タイマーが active かどうか判定
     const timerActive = /Active:\s+active/.test(stdout.split("=== サービス状態 ===")[0] ?? "");
-    // 次回実行時刻を抽出（systemd-analyze calendar の出力から）
     const nextMatch = stdout.match(/Next elapse:\s+(.+)/);
     const nextRun = nextMatch?.[1]?.trim() ?? null;
-    return c.json({ timerActive, nextRun, output: stdout });
-  } catch (err: unknown) {
-    const e = err as { stdout?: string; stderr?: string; message: string };
-    const output = `${e.stdout ?? ""}${e.stderr ?? ""}`.trim() || e.message;
-    return c.json({ timerActive: false, nextRun: null, output });
+    const schedule = parseTimerSchedule();
+    return c.json({ timerActive, nextRun, schedule });
+  } catch {
+    const schedule = parseTimerSchedule();
+    return c.json({ timerActive: false, nextRun: null, schedule });
   }
 });
 
@@ -858,16 +891,77 @@ app.post("/api/scheduler/disable", async (c) => {
   }
 });
 
-app.get("/api/scheduler/timer-config", (c) => {
+app.post("/api/scheduler/schedule", async (c) => {
+  if (!isDev) return c.json({ error: "Dev mode only" }, 403);
+  const body = await c.req.json<{ days: string[]; times: string[] }>();
+  const { days, times } = body;
+
+  if (!Array.isArray(days) || !Array.isArray(times)) {
+    return c.json({ error: "days and times must be arrays" }, 400);
+  }
+  if (times.length === 0) {
+    return c.json({ error: "少なくとも1つの実行時刻が必要です" }, 400);
+  }
+  if (days.length === 0) {
+    return c.json({ error: "少なくとも1つの曜日を選択してください" }, 400);
+  }
+
   const timerPath = resolve(projectRoot, "systemd", "pipeline.timer");
   if (!existsSync(timerPath)) return c.json({ error: "Timer file not found" }, 404);
-  return c.json({ content: readFileSync(timerPath, "utf-8") });
-});
 
-app.get("/api/scheduler/service-config", (c) => {
-  const servicePath = resolve(projectRoot, "systemd", "pipeline.service");
-  if (!existsSync(servicePath)) return c.json({ error: "Service file not found" }, 404);
-  return c.json({ content: readFileSync(servicePath, "utf-8") });
+  const content = readFileSync(timerPath, "utf-8");
+  const lines = content.split("\n");
+
+  // [Timer]セクションのOnCalendar行を除去し、新しいものに置換
+  const newLines: string[] = [];
+  let inTimer = false;
+  let calendarInserted = false;
+
+  for (const line of lines) {
+    if (line.trim() === "[Timer]") {
+      inTimer = true;
+      newLines.push(line);
+      continue;
+    }
+    if (line.trim().startsWith("[") && line.trim() !== "[Timer]") {
+      inTimer = false;
+    }
+    if (inTimer && /^OnCalendar=/.test(line)) {
+      if (!calendarInserted) {
+        // 新しいOnCalendar行を挿入
+        const isAllDays = ALL_DAYS.every((d) => days.includes(d)) && days.length === 7;
+        const sortedTimes = [...times].sort();
+        for (const time of sortedTimes) {
+          if (isAllDays) {
+            newLines.push(`OnCalendar=*-*-* ${time}:00`);
+          } else {
+            newLines.push(`OnCalendar=${days.join(",")} *-*-* ${time}:00`);
+          }
+        }
+        calendarInserted = true;
+      }
+      // 既存のOnCalendar行はスキップ
+      continue;
+    }
+    newLines.push(line);
+  }
+
+  writeFileSync(timerPath, newLines.join("\n"), "utf-8");
+
+  // タイマーが有効な場合のみ daemon-reload
+  try {
+    const { stdout } = await execAsync(
+      "systemctl --user is-active pipeline.timer 2>/dev/null || true",
+      { cwd: projectRoot, timeout: 5000 },
+    );
+    if (stdout.trim() === "active") {
+      await execAsync("systemctl --user daemon-reload", { cwd: projectRoot, timeout: 10000 });
+    }
+  } catch {
+    // daemon-reload failure is non-fatal
+  }
+
+  return c.json({ success: true });
 });
 
 // --- Commands API (dev mode only) ---

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -17,12 +17,13 @@ import { ConfigEditor } from "./components/ConfigEditor";
 import { DatasetManager } from "./components/DatasetManager";
 import { FavoritePage } from "./components/FavoritePage";
 import { QueueManager } from "./components/QueueManager";
+import { SchedulerSettings } from "./components/SchedulerSettings";
 import { SearchView } from "./components/SearchView";
 import { Sidebar } from "./components/Sidebar";
 import { ToastProvider } from "./components/Toast";
 import { useIsMobile } from "./hooks/useIsMobile";
 
-type ViewMode = "apps" | "datasets" | "favorites" | "commands" | "config" | "queue";
+type ViewMode = "apps" | "datasets" | "favorites" | "commands" | "config" | "queue" | "scheduler";
 
 function buildUrl(state: {
   viewMode: ViewMode;
@@ -51,6 +52,8 @@ function buildUrl(state: {
   } else if (state.viewMode === "queue") {
     url.searchParams.set("view", "queue");
     if (state.queueItem) url.searchParams.set("queueItem", state.queueItem);
+  } else if (state.viewMode === "scheduler") {
+    url.searchParams.set("view", "scheduler");
   } else {
     if (state.app) url.searchParams.set("app", state.app);
     if (state.feature) url.searchParams.set("feature", state.feature);
@@ -116,8 +119,11 @@ export function App() {
     const isCommandsView = viewParam === "commands";
     const isConfigView = viewParam === "config";
     const isQueueView = viewParam === "queue";
-    // URL から datasets/favorites/commands/config/queue ビュー復元
-    if (isQueueView) {
+    const isSchedulerView = viewParam === "scheduler";
+    // URL から datasets/favorites/commands/config/queue/scheduler ビュー復元
+    if (isSchedulerView) {
+      setViewMode("scheduler");
+    } else if (isQueueView) {
       setViewMode("queue");
     } else if (isConfigView) {
       setViewMode("config");
@@ -157,17 +163,19 @@ export function App() {
         tabParam && ["overview", "source-info", "diagrams", "features", "memo"].includes(tabParam)
           ? tabParam
           : undefined;
-      const currentViewMode = isQueueView
-        ? "queue"
-        : isConfigView
-          ? "config"
-          : isCommandsView
-            ? "commands"
-            : isFavoritesView
-              ? "favorites"
-              : isDatasetView
-                ? "datasets"
-                : "apps";
+      const currentViewMode = isSchedulerView
+        ? "scheduler"
+        : isQueueView
+          ? "queue"
+          : isConfigView
+            ? "config"
+            : isCommandsView
+              ? "commands"
+              : isFavoritesView
+                ? "favorites"
+                : isDatasetView
+                  ? "datasets"
+                  : "apps";
       window.history.replaceState(
         {},
         "",
@@ -187,7 +195,11 @@ export function App() {
     const handlePopState = () => {
       const params = new URLSearchParams(window.location.search);
       const viewParam = params.get("view");
-      if (viewParam === "queue") {
+      if (viewParam === "scheduler") {
+        setViewMode("scheduler");
+        setSelectedFeature(null);
+        setSelectedTab("overview");
+      } else if (viewParam === "queue") {
         setViewMode("queue");
         setSelectedFeature(null);
         setSelectedTab("overview");
@@ -280,6 +292,14 @@ export function App() {
     setSearchActive(false);
     if (isMobile) setMobileSidebarOpen(false);
     window.history.pushState({}, "", buildUrl({ viewMode: "queue" }));
+  };
+
+  const handleSelectScheduler = () => {
+    setViewMode("scheduler");
+    setSelectedFeature(null);
+    setSearchActive(false);
+    if (isMobile) setMobileSidebarOpen(false);
+    window.history.pushState({}, "", buildUrl({ viewMode: "scheduler" }));
   };
 
   const handleNavigateToDataset = (datasetName: string) => {
@@ -487,7 +507,9 @@ export function App() {
                       ? "データセット"
                       : viewMode === "queue"
                         ? "パイプラインキュー"
-                        : (selectedApp ?? "Requirements Viewer")}
+                        : viewMode === "scheduler"
+                          ? "スケジューラ"
+                          : (selectedApp ?? "Requirements Viewer")}
             </span>
           </div>
         )}
@@ -507,6 +529,7 @@ export function App() {
           onSelectCommands={handleSelectCommands}
           onSelectConfig={handleSelectConfig}
           onSelectQueue={handleSelectQueue}
+          onSelectScheduler={handleSelectScheduler}
           onSearch={handleSearch}
           onClearSearch={handleClearSearch}
           isSearchActive={searchActive}
@@ -520,7 +543,9 @@ export function App() {
               : "mb-3 mr-3 rounded-2xl bg-gray-900 shadow-2xl shadow-black/50 ring-1 ring-gray-800"
           }`}
         >
-          {viewMode === "config" ? (
+          {viewMode === "scheduler" ? (
+            <SchedulerSettings isMobile={isMobile} isDev={isDev} />
+          ) : viewMode === "config" ? (
             <ConfigEditor isMobile={isMobile} isDev={isDev} />
           ) : viewMode === "commands" ? (
             <CommandRunner isMobile={isMobile} isDev={isDev} />

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -257,10 +257,15 @@ export async function removeFavorite(item: FavoriteItem): Promise<{ success: boo
 
 // --- Scheduler API ---
 
+export interface SchedulerSchedule {
+  days: string[];
+  times: string[];
+}
+
 export interface SchedulerStatus {
   timerActive: boolean;
   nextRun: string | null;
-  output: string;
+  schedule: SchedulerSchedule;
 }
 
 export async function fetchSchedulerStatus(): Promise<SchedulerStatus> {
@@ -278,13 +283,14 @@ export async function disableScheduler(): Promise<{ success: boolean; output: st
   return res.json();
 }
 
-export async function fetchTimerConfig(): Promise<{ content: string }> {
-  const res = await fetch(`${BASE}/scheduler/timer-config`);
-  return res.json();
-}
-
-export async function fetchServiceConfig(): Promise<{ content: string }> {
-  const res = await fetch(`${BASE}/scheduler/service-config`);
+export async function saveSchedule(
+  schedule: SchedulerSchedule,
+): Promise<{ success: boolean; error?: string }> {
+  const res = await fetch(`${BASE}/scheduler/schedule`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(schedule),
+  });
   return res.json();
 }
 

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -255,6 +255,39 @@ export async function removeFavorite(item: FavoriteItem): Promise<{ success: boo
   return res.json();
 }
 
+// --- Scheduler API ---
+
+export interface SchedulerStatus {
+  timerActive: boolean;
+  nextRun: string | null;
+  output: string;
+}
+
+export async function fetchSchedulerStatus(): Promise<SchedulerStatus> {
+  const res = await fetch(`${BASE}/scheduler/status`);
+  return res.json();
+}
+
+export async function enableScheduler(): Promise<{ success: boolean; output: string }> {
+  const res = await fetch(`${BASE}/scheduler/enable`, { method: "POST" });
+  return res.json();
+}
+
+export async function disableScheduler(): Promise<{ success: boolean; output: string }> {
+  const res = await fetch(`${BASE}/scheduler/disable`, { method: "POST" });
+  return res.json();
+}
+
+export async function fetchTimerConfig(): Promise<{ content: string }> {
+  const res = await fetch(`${BASE}/scheduler/timer-config`);
+  return res.json();
+}
+
+export async function fetchServiceConfig(): Promise<{ content: string }> {
+  const res = await fetch(`${BASE}/scheduler/service-config`);
+  return res.json();
+}
+
 // --- Config API ---
 
 export interface AppConfig {

--- a/viewer/src/components/SchedulerSettings.tsx
+++ b/viewer/src/components/SchedulerSettings.tsx
@@ -3,8 +3,8 @@ import {
   disableScheduler,
   enableScheduler,
   fetchSchedulerStatus,
-  fetchServiceConfig,
-  fetchTimerConfig,
+  type SchedulerSchedule,
+  saveSchedule,
 } from "../api";
 
 interface SchedulerSettingsProps {
@@ -12,41 +12,59 @@ interface SchedulerSettingsProps {
   isDev: boolean;
 }
 
+const ALL_DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+const DAY_LABELS: Record<string, string> = {
+  Mon: "月",
+  Tue: "火",
+  Wed: "水",
+  Thu: "木",
+  Fri: "金",
+  Sat: "土",
+  Sun: "日",
+};
+
 export function SchedulerSettings({ isMobile, isDev }: SchedulerSettingsProps) {
   const [timerActive, setTimerActive] = useState(false);
   const [nextRun, setNextRun] = useState<string | null>(null);
-  const [statusOutput, setStatusOutput] = useState("");
-  const [timerConfig, setTimerConfig] = useState("");
-  const [serviceConfig, setServiceConfig] = useState("");
   const [loading, setLoading] = useState(true);
   const [toggling, setToggling] = useState(false);
+  const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
-  const [configTab, setConfigTab] = useState<"timer" | "service">("timer");
+
+  // Schedule editing state
+  const [days, setDays] = useState<string[]>([...ALL_DAYS]);
+  const [times, setTimes] = useState<string[]>(["02:00"]);
+  const [newTime, setNewTime] = useState("12:00");
+
+  // Track if schedule has been modified
+  const [originalSchedule, setOriginalSchedule] = useState<SchedulerSchedule | null>(null);
+
+  const showMessage = useCallback((type: "success" | "error", text: string) => {
+    setMessage({ type, text });
+    setTimeout(() => setMessage(null), 5000);
+  }, []);
 
   const loadStatus = useCallback(async () => {
     try {
       const status = await fetchSchedulerStatus();
       setTimerActive(status.timerActive);
       setNextRun(status.nextRun);
-      setStatusOutput(status.output);
+      setDays(status.schedule.days);
+      setTimes(status.schedule.times.length > 0 ? status.schedule.times : ["02:00"]);
+      setOriginalSchedule(status.schedule);
     } catch {
-      setStatusOutput("ステータスの取得に失敗しました");
+      showMessage("error", "ステータスの取得に失敗しました");
     }
-  }, []);
-
-  const loadConfigs = useCallback(async () => {
-    try {
-      const [timer, service] = await Promise.all([fetchTimerConfig(), fetchServiceConfig()]);
-      setTimerConfig(timer.content);
-      setServiceConfig(service.content);
-    } catch {
-      // ignore
-    }
-  }, []);
+  }, [showMessage]);
 
   useEffect(() => {
-    Promise.all([loadStatus(), loadConfigs()]).finally(() => setLoading(false));
-  }, [loadStatus, loadConfigs]);
+    loadStatus().finally(() => setLoading(false));
+  }, [loadStatus]);
+
+  const hasChanges =
+    originalSchedule &&
+    (JSON.stringify([...days].sort()) !== JSON.stringify([...originalSchedule.days].sort()) ||
+      JSON.stringify([...times].sort()) !== JSON.stringify([...originalSchedule.times].sort()));
 
   const handleToggle = async () => {
     setToggling(true);
@@ -54,26 +72,59 @@ export function SchedulerSettings({ isMobile, isDev }: SchedulerSettingsProps) {
     try {
       const result = timerActive ? await disableScheduler() : await enableScheduler();
       if (result.success) {
-        setMessage({
-          type: "success",
-          text: timerActive ? "スケジューラを無効化しました" : "スケジューラを有効化しました",
-        });
+        showMessage(
+          "success",
+          timerActive ? "スケジューラを無効化しました" : "スケジューラを有効化しました",
+        );
       } else {
-        setMessage({ type: "error", text: result.output || "操作に失敗しました" });
+        showMessage("error", result.output || "操作に失敗しました");
       }
       await loadStatus();
     } catch {
-      setMessage({ type: "error", text: "操作に失敗しました" });
+      showMessage("error", "操作に失敗しました");
     } finally {
       setToggling(false);
-      setTimeout(() => setMessage(null), 5000);
     }
   };
 
-  const handleRefresh = async () => {
-    setLoading(true);
-    await loadStatus();
-    setLoading(false);
+  const toggleDay = (day: string) => {
+    setDays((prev) => (prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day]));
+  };
+
+  const removeTime = (time: string) => {
+    setTimes((prev) => prev.filter((t) => t !== time));
+  };
+
+  const addTime = () => {
+    if (newTime && !times.includes(newTime)) {
+      setTimes((prev) => [...prev, newTime].sort());
+    }
+  };
+
+  const handleSave = async () => {
+    if (times.length === 0) {
+      showMessage("error", "少なくとも1つの実行時刻が必要です");
+      return;
+    }
+    if (days.length === 0) {
+      showMessage("error", "少なくとも1つの曜日を選択してください");
+      return;
+    }
+    setSaving(true);
+    setMessage(null);
+    try {
+      const result = await saveSchedule({ days, times });
+      if (result.success) {
+        showMessage("success", "スケジュールを保存しました");
+        await loadStatus();
+      } else {
+        showMessage("error", result.error || "保存に失敗しました");
+      }
+    } catch {
+      showMessage("error", "保存に失敗しました");
+    } finally {
+      setSaving(false);
+    }
   };
 
   if (loading) {
@@ -90,9 +141,7 @@ export function SchedulerSettings({ isMobile, isDev }: SchedulerSettingsProps) {
         {/* Header */}
         <div>
           <h1 className="text-xl font-bold text-gray-100">スケジューラ設定</h1>
-          <p className="text-sm text-gray-500 mt-1">
-            パイプラインスケジューラ（systemdタイマー）の管理
-          </p>
+          <p className="text-sm text-gray-500 mt-1">パイプラインの自動実行スケジュール</p>
         </div>
 
         {/* Message */}
@@ -108,33 +157,8 @@ export function SchedulerSettings({ isMobile, isDev }: SchedulerSettingsProps) {
           </div>
         )}
 
-        {/* Status Card */}
+        {/* Status + Toggle */}
         <section className="rounded-xl border border-gray-800 bg-gray-900/50 p-5 space-y-4">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-semibold text-gray-300">タイマー状態</h2>
-            <button
-              type="button"
-              className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/30 transition-colors"
-              onClick={handleRefresh}
-              title="更新"
-            >
-              <svg
-                className="size-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182"
-                />
-              </svg>
-            </button>
-          </div>
-
           <div className="flex items-center gap-3">
             <span
               className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${
@@ -149,12 +173,11 @@ export function SchedulerSettings({ isMobile, isDev }: SchedulerSettingsProps) {
 
             {nextRun && (
               <span className="text-xs text-gray-500">
-                次回実行: <span className="text-gray-300">{nextRun}</span>
+                次回: <span className="text-gray-300">{nextRun}</span>
               </span>
             )}
           </div>
 
-          {/* Toggle Button */}
           {isDev && (
             <button
               type="button"
@@ -179,53 +202,98 @@ export function SchedulerSettings({ isMobile, isDev }: SchedulerSettingsProps) {
           )}
         </section>
 
-        {/* Config Files */}
-        <section className="rounded-xl border border-gray-800 bg-gray-900/50 p-5 space-y-4">
-          <h2 className="text-sm font-semibold text-gray-300">設定ファイル</h2>
-
-          {/* Tabs */}
-          <div className="flex gap-1 bg-gray-800/50 p-0.5 rounded-lg w-fit">
-            <button
-              type="button"
-              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
-                configTab === "timer"
-                  ? "bg-gray-700 text-gray-200"
-                  : "text-gray-500 hover:text-gray-300"
-              }`}
-              onClick={() => setConfigTab("timer")}
-            >
-              pipeline.timer
-            </button>
-            <button
-              type="button"
-              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
-                configTab === "service"
-                  ? "bg-gray-700 text-gray-200"
-                  : "text-gray-500 hover:text-gray-300"
-              }`}
-              onClick={() => setConfigTab("service")}
-            >
-              pipeline.service
-            </button>
+        {/* Schedule Editor */}
+        <section className="rounded-xl border border-gray-800 bg-gray-900/50 p-5 space-y-5">
+          {/* Days */}
+          <div className="space-y-3">
+            <h2 className="text-sm font-semibold text-gray-300">実行曜日</h2>
+            <div className="flex flex-wrap gap-2">
+              {ALL_DAYS.map((day) => (
+                <button
+                  key={day}
+                  type="button"
+                  className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                    days.includes(day)
+                      ? "bg-blue-500/20 text-blue-400 border border-blue-500/30"
+                      : "bg-gray-800/50 text-gray-600 border border-gray-700/50 hover:text-gray-400"
+                  } ${!isDev ? "cursor-default" : ""}`}
+                  onClick={() => isDev && toggleDay(day)}
+                  disabled={!isDev}
+                >
+                  {DAY_LABELS[day]}
+                </button>
+              ))}
+            </div>
           </div>
 
-          <pre className="p-4 bg-gray-950/50 rounded-lg text-xs text-gray-400 overflow-x-auto font-mono leading-relaxed border border-gray-800/50">
-            {configTab === "timer" ? timerConfig : serviceConfig}
-          </pre>
+          {/* Times */}
+          <div className="space-y-3">
+            <h2 className="text-sm font-semibold text-gray-300">実行時刻</h2>
+            <div className="space-y-2">
+              {times.map((time) => (
+                <div key={time} className="flex items-center gap-2">
+                  <span className="px-3 py-1.5 bg-gray-800/50 border border-gray-700/50 rounded-lg text-sm text-gray-300 font-mono">
+                    {time}
+                  </span>
+                  {isDev && (
+                    <button
+                      type="button"
+                      className="p-1 rounded text-gray-600 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                      onClick={() => removeTime(time)}
+                      title="削除"
+                    >
+                      <svg
+                        className="size-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        role="img"
+                        aria-label="削除"
+                      >
+                        <title>削除</title>
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M6 18L18 6M6 6l12 12"
+                        />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
 
-          <p className="text-[11px] text-gray-600">
-            ファイルパス: systemd/pipeline.{configTab === "timer" ? "timer" : "service"}
-          </p>
-        </section>
-
-        {/* Status Detail */}
-        <section className="rounded-xl border border-gray-800 bg-gray-900/50 p-5 space-y-4">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-semibold text-gray-300">詳細ステータス</h2>
+            {isDev && (
+              <div className="flex items-center gap-2 pt-1">
+                <input
+                  type="time"
+                  value={newTime}
+                  onChange={(e) => setNewTime(e.target.value)}
+                  className="px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-sm text-gray-300 focus:outline-none focus:border-blue-500/50"
+                />
+                <button
+                  type="button"
+                  className="px-3 py-1.5 rounded-lg text-sm font-medium bg-gray-800 text-gray-400 hover:text-gray-200 border border-gray-700 hover:border-gray-600 transition-colors"
+                  onClick={addTime}
+                >
+                  + 時刻を追加
+                </button>
+              </div>
+            )}
           </div>
-          <pre className="p-4 bg-gray-950/50 rounded-lg text-xs text-gray-400 overflow-x-auto font-mono leading-relaxed border border-gray-800/50 max-h-80 overflow-y-auto dark-scrollbar whitespace-pre-wrap">
-            {statusOutput || "ステータスなし"}
-          </pre>
+
+          {/* Save Button */}
+          {isDev && (
+            <button
+              type="button"
+              className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-500/15 text-blue-400 hover:bg-blue-500/25 border border-blue-500/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={handleSave}
+              disabled={saving || !hasChanges}
+            >
+              {saving ? "保存中..." : "保存"}
+            </button>
+          )}
         </section>
       </div>
     </div>

--- a/viewer/src/components/SchedulerSettings.tsx
+++ b/viewer/src/components/SchedulerSettings.tsx
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  disableScheduler,
+  enableScheduler,
+  fetchSchedulerStatus,
+  fetchServiceConfig,
+  fetchTimerConfig,
+} from "../api";
+
+interface SchedulerSettingsProps {
+  isMobile: boolean;
+  isDev: boolean;
+}
+
+export function SchedulerSettings({ isMobile, isDev }: SchedulerSettingsProps) {
+  const [timerActive, setTimerActive] = useState(false);
+  const [nextRun, setNextRun] = useState<string | null>(null);
+  const [statusOutput, setStatusOutput] = useState("");
+  const [timerConfig, setTimerConfig] = useState("");
+  const [serviceConfig, setServiceConfig] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [toggling, setToggling] = useState(false);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+  const [configTab, setConfigTab] = useState<"timer" | "service">("timer");
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const status = await fetchSchedulerStatus();
+      setTimerActive(status.timerActive);
+      setNextRun(status.nextRun);
+      setStatusOutput(status.output);
+    } catch {
+      setStatusOutput("ステータスの取得に失敗しました");
+    }
+  }, []);
+
+  const loadConfigs = useCallback(async () => {
+    try {
+      const [timer, service] = await Promise.all([fetchTimerConfig(), fetchServiceConfig()]);
+      setTimerConfig(timer.content);
+      setServiceConfig(service.content);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    Promise.all([loadStatus(), loadConfigs()]).finally(() => setLoading(false));
+  }, [loadStatus, loadConfigs]);
+
+  const handleToggle = async () => {
+    setToggling(true);
+    setMessage(null);
+    try {
+      const result = timerActive ? await disableScheduler() : await enableScheduler();
+      if (result.success) {
+        setMessage({
+          type: "success",
+          text: timerActive ? "スケジューラを無効化しました" : "スケジューラを有効化しました",
+        });
+      } else {
+        setMessage({ type: "error", text: result.output || "操作に失敗しました" });
+      }
+      await loadStatus();
+    } catch {
+      setMessage({ type: "error", text: "操作に失敗しました" });
+    } finally {
+      setToggling(false);
+      setTimeout(() => setMessage(null), 5000);
+    }
+  };
+
+  const handleRefresh = async () => {
+    setLoading(true);
+    await loadStatus();
+    setLoading(false);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center text-gray-500 text-sm">
+        読み込み中...
+      </div>
+    );
+  }
+
+  return (
+    <div className={`h-full overflow-y-auto dark-scrollbar ${isMobile ? "px-4 py-4" : "p-8"}`}>
+      <div className="max-w-3xl mx-auto space-y-6">
+        {/* Header */}
+        <div>
+          <h1 className="text-xl font-bold text-gray-100">スケジューラ設定</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            パイプラインスケジューラ（systemdタイマー）の管理
+          </p>
+        </div>
+
+        {/* Message */}
+        {message && (
+          <div
+            className={`px-4 py-3 rounded-lg text-sm ${
+              message.type === "success"
+                ? "bg-emerald-500/10 text-emerald-400 border border-emerald-500/20"
+                : "bg-red-500/10 text-red-400 border border-red-500/20"
+            }`}
+          >
+            {message.text}
+          </div>
+        )}
+
+        {/* Status Card */}
+        <section className="rounded-xl border border-gray-800 bg-gray-900/50 p-5 space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-gray-300">タイマー状態</h2>
+            <button
+              type="button"
+              className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/30 transition-colors"
+              onClick={handleRefresh}
+              title="更新"
+            >
+              <svg
+                className="size-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182"
+                />
+              </svg>
+            </button>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <span
+              className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${
+                timerActive ? "bg-emerald-500/15 text-emerald-400" : "bg-gray-700/50 text-gray-500"
+              }`}
+            >
+              <span
+                className={`size-2 rounded-full ${timerActive ? "bg-emerald-400 animate-pulse" : "bg-gray-600"}`}
+              />
+              {timerActive ? "有効" : "無効"}
+            </span>
+
+            {nextRun && (
+              <span className="text-xs text-gray-500">
+                次回実行: <span className="text-gray-300">{nextRun}</span>
+              </span>
+            )}
+          </div>
+
+          {/* Toggle Button */}
+          {isDev && (
+            <button
+              type="button"
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                timerActive
+                  ? "bg-red-500/15 text-red-400 hover:bg-red-500/25 border border-red-500/20"
+                  : "bg-emerald-500/15 text-emerald-400 hover:bg-emerald-500/25 border border-emerald-500/20"
+              }`}
+              onClick={handleToggle}
+              disabled={toggling}
+            >
+              {toggling
+                ? "処理中..."
+                : timerActive
+                  ? "スケジューラを無効化"
+                  : "スケジューラを有効化"}
+            </button>
+          )}
+
+          {!isDev && (
+            <p className="text-xs text-gray-600">有効/無効の切り替えはdev modeでのみ利用可能です</p>
+          )}
+        </section>
+
+        {/* Config Files */}
+        <section className="rounded-xl border border-gray-800 bg-gray-900/50 p-5 space-y-4">
+          <h2 className="text-sm font-semibold text-gray-300">設定ファイル</h2>
+
+          {/* Tabs */}
+          <div className="flex gap-1 bg-gray-800/50 p-0.5 rounded-lg w-fit">
+            <button
+              type="button"
+              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                configTab === "timer"
+                  ? "bg-gray-700 text-gray-200"
+                  : "text-gray-500 hover:text-gray-300"
+              }`}
+              onClick={() => setConfigTab("timer")}
+            >
+              pipeline.timer
+            </button>
+            <button
+              type="button"
+              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                configTab === "service"
+                  ? "bg-gray-700 text-gray-200"
+                  : "text-gray-500 hover:text-gray-300"
+              }`}
+              onClick={() => setConfigTab("service")}
+            >
+              pipeline.service
+            </button>
+          </div>
+
+          <pre className="p-4 bg-gray-950/50 rounded-lg text-xs text-gray-400 overflow-x-auto font-mono leading-relaxed border border-gray-800/50">
+            {configTab === "timer" ? timerConfig : serviceConfig}
+          </pre>
+
+          <p className="text-[11px] text-gray-600">
+            ファイルパス: systemd/pipeline.{configTab === "timer" ? "timer" : "service"}
+          </p>
+        </section>
+
+        {/* Status Detail */}
+        <section className="rounded-xl border border-gray-800 bg-gray-900/50 p-5 space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-gray-300">詳細ステータス</h2>
+          </div>
+          <pre className="p-4 bg-gray-950/50 rounded-lg text-xs text-gray-400 overflow-x-auto font-mono leading-relaxed border border-gray-800/50 max-h-80 overflow-y-auto dark-scrollbar whitespace-pre-wrap">
+            {statusOutput || "ステータスなし"}
+          </pre>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/viewer/src/components/Sidebar.tsx
+++ b/viewer/src/components/Sidebar.tsx
@@ -11,12 +11,13 @@ interface SidebarProps {
   isMobile: boolean;
   mobileOpen: boolean;
   onMobileClose: () => void;
-  viewMode: "apps" | "datasets" | "favorites" | "commands" | "config" | "queue";
+  viewMode: "apps" | "datasets" | "favorites" | "commands" | "config" | "queue" | "scheduler";
   onSelectDatasets: () => void;
   onSelectFavorites: () => void;
   onSelectCommands: () => void;
   onSelectConfig: () => void;
   onSelectQueue: () => void;
+  onSelectScheduler: () => void;
   onSearch: (query: string, tags: string[]) => void;
   onClearSearch: () => void;
   isSearchActive: boolean;
@@ -234,6 +235,7 @@ export function Sidebar({
   onSelectCommands,
   onSelectConfig,
   onSelectQueue,
+  onSelectScheduler,
   onSearch,
   onClearSearch,
   isSearchActive,
@@ -365,6 +367,31 @@ export function Sidebar({
                         strokeLinejoin="round"
                         strokeWidth={2}
                         d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                      viewMode === "scheduler"
+                        ? "text-purple-400 bg-purple-400/10"
+                        : "text-gray-500 hover:text-purple-400 hover:bg-purple-400/10"
+                    }`}
+                    onClick={onSelectScheduler}
+                    title="スケジューラ"
+                  >
+                    <svg
+                      className="size-5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
                       />
                     </svg>
                   </button>
@@ -622,6 +649,31 @@ export function Sidebar({
                   strokeLinejoin="round"
                   strokeWidth={2}
                   d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z"
+                />
+              </svg>
+            </button>
+            <button
+              type="button"
+              className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                viewMode === "scheduler"
+                  ? "text-purple-400 bg-purple-400/10"
+                  : "text-gray-500 hover:text-purple-400 hover:bg-purple-400/10"
+              }`}
+              onClick={onSelectScheduler}
+              title="スケジューラ"
+            >
+              <svg
+                className="size-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
                 />
               </svg>
             </button>


### PR DESCRIPTION
## Summary

スケジューラ（systemdタイマー）の設定・管理画面をViewerに追加。

Closes #104

## Changes

- `viewer/server.ts`: スケジューラAPI追加（`GET /api/scheduler/status`, `POST /api/scheduler/enable`, `POST /api/scheduler/disable`, `GET /api/scheduler/timer-config`, `GET /api/scheduler/service-config`）
- `viewer/src/api.ts`: APIクライアント関数・型定義追加
- `viewer/src/components/SchedulerSettings.tsx`: 新規画面コンポーネント（タイマー状態表示、有効/無効切替、設定ファイル表示、詳細ステータス表示）
- `viewer/src/components/Sidebar.tsx`: サイドバーにスケジューラボタン追加（時計アイコン、紫色テーマ）
- `viewer/src/App.tsx`: `scheduler`ビューモード追加、URL管理・ブラウザバック対応

## Test plan

- [ ] サイドバーのスケジューラアイコンをクリックして画面表示確認
- [ ] タイマー状態（有効/無効）の表示確認
- [ ] dev modeでの有効化/無効化ボタン動作確認
- [ ] 設定ファイル（pipeline.timer / pipeline.service）の表示確認
- [ ] 詳細ステータス出力の表示確認
- [ ] URL直接アクセス（`?view=scheduler`）の動作確認
- [ ] ブラウザバック/フォワードの動作確認
- [ ] モバイル表示の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)