### PR TITLE
feat: devcontainer + compose.yamlによるDocker開発環境を追加

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,104 @@
+FROM node:22
+
+ARG TZ
+ENV TZ="$TZ"
+
+ARG CLAUDE_CODE_VERSION=latest
+
+# Install basic development tools and iptables/ipset
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  less \
+  git \
+  procps \
+  sudo \
+  fzf \
+  zsh \
+  man-db \
+  unzip \
+  gnupg2 \
+  gh \
+  iptables \
+  ipset \
+  iproute2 \
+  dnsutils \
+  aggregate \
+  jq \
+  nano \
+  vim \
+  tmux \
+  supervisor \
+  openssh-client \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Ensure default node user has access to /usr/local/share
+RUN mkdir -p /usr/local/share/npm-global && \
+  chown -R node:node /usr/local/share
+
+ARG USERNAME=node
+
+# Persist bash history.
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  && mkdir /commandhistory \
+  && touch /commandhistory/.bash_history \
+  && chown -R $USERNAME /commandhistory
+
+# Set `DEVCONTAINER` environment variable to help with orientation
+ENV DEVCONTAINER=true
+
+# Create workspace and config directories and set permissions
+RUN mkdir -p /workspace /home/node/.claude && \
+  chown -R node:node /workspace /home/node && \
+  chmod 777 /workspace
+
+WORKDIR /workspace
+
+ARG GIT_DELTA_VERSION=0.18.2
+RUN ARCH=$(dpkg --print-architecture) && \
+  wget "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+  dpkg -i "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+  rm "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb"
+
+# Set up non-root user
+USER node
+
+# Install global packages
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=$PATH:/usr/local/share/npm-global/bin
+
+# Set the default shell to zsh rather than sh
+ENV SHELL=/bin/zsh
+
+# Set the default editor and visual
+ENV EDITOR=nano
+ENV VISUAL=nano
+
+# Default powerline10k theme
+ARG ZSH_IN_DOCKER_VERSION=1.2.0
+RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v${ZSH_IN_DOCKER_VERSION}/zsh-in-docker.sh)" -- \
+  -p git \
+  -p fzf \
+  -p zsh-autosuggestions \
+  -a "source /usr/share/doc/fzf/examples/key-bindings.zsh" \
+  -a "source /usr/share/doc/fzf/examples/completion.zsh" \
+  -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  -x
+
+# Install pnpm and Claude Code
+ARG PNPM_VERSION=10.28.0
+RUN npm install -g pnpm@${PNPM_VERSION} @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+
+# Setup sudo for node user without password (development environment)
+USER root
+RUN echo "node ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/node && \
+  chmod 0440 /etc/sudoers.d/node
+
+# Copy and set up firewall script
+COPY init-firewall.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/init-firewall.sh
+
+# Copy supervisord config
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+RUN mkdir -p /workspace/logs && chown -R node:node /workspace/logs
+
+USER node
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+{
+  "name": "Requirements Creator Dev",
+  "dockerComposeFile": ["../compose.yaml"],
+  "service": "devcontainer",
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "anthropic.claude-code",
+        "eamodio.gitlens"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "bash",
+            "icon": "terminal-bash"
+          },
+          "zsh": {
+            "path": "zsh"
+          }
+        }
+      }
+    }
+  },
+  "remoteUser": "node",
+  "containerEnv": {
+    "NODE_OPTIONS": "--max-old-space-size=4096",
+    "CLAUDE_CONFIG_DIR": "/home/node/.claude",
+    "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
+    "UMASK": "0022"
+  },
+  "forwardPorts": [3001],
+  "portsAttributes": {
+    "3001": {
+      "label": "viewer",
+      "onAutoForward": "notify"
+    }
+  },
+  "postCreateCommand": "pnpm install && zsh .devcontainer/setup-dotfiles.sh",
+  "postStartCommand": "echo 'DevContainer started successfully'",
+  "waitFor": "postCreateCommand"
+}

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
+IFS=$'\n\t'       # Stricter word splitting
+
+# 1. Extract Docker DNS info BEFORE any flushing
+DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
+
+# Flush existing rules and delete existing ipsets
+iptables -F
+iptables -X
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
+ipset destroy allowed-domains 2>/dev/null || true
+
+# 2. Selectively restore ONLY internal Docker DNS resolution
+if [ -n "$DOCKER_DNS_RULES" ]; then
+    echo "Restoring Docker DNS rules..."
+    iptables -t nat -N DOCKER_OUTPUT 2>/dev/null || true
+    iptables -t nat -N DOCKER_POSTROUTING 2>/dev/null || true
+    echo "$DOCKER_DNS_RULES" | xargs -L 1 iptables -t nat
+else
+    echo "No Docker DNS rules to restore"
+fi
+
+# First allow DNS and localhost before any restrictions
+# Allow outbound DNS
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+# Allow inbound DNS responses
+iptables -A INPUT -p udp --sport 53 -j ACCEPT
+# Allow outbound SSH
+iptables -A OUTPUT -p tcp --dport 22 -j ACCEPT
+# Allow inbound SSH responses
+iptables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
+# Allow localhost
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# Create ipset with CIDR support
+ipset create allowed-domains hash:net
+
+# Fetch GitHub meta information and aggregate + add their IP ranges
+echo "Fetching GitHub IP ranges..."
+gh_ranges=$(curl -s https://api.github.com/meta)
+if [ -z "$gh_ranges" ]; then
+    echo "ERROR: Failed to fetch GitHub IP ranges"
+    exit 1
+fi
+
+if ! echo "$gh_ranges" | jq -e '.web and .api and .git' >/dev/null; then
+    echo "ERROR: GitHub API response missing required fields"
+    exit 1
+fi
+
+echo "Processing GitHub IPs..."
+while read -r cidr; do
+    if [[ ! "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
+        echo "ERROR: Invalid CIDR range from GitHub meta: $cidr"
+        exit 1
+    fi
+    echo "Adding GitHub range $cidr"
+    ipset add allowed-domains "$cidr"
+done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
+
+# Resolve and add other allowed domains
+for domain in \
+    "registry.npmjs.org" \
+    "api.anthropic.com" \
+    "sentry.io" \
+    "statsig.anthropic.com" \
+    "statsig.com" \
+    "marketplace.visualstudio.com" \
+    "vscode.blob.core.windows.net" \
+    "update.code.visualstudio.com" \
+    "newsapi.org" \
+    "www.googleapis.com"; do
+    echo "Resolving $domain..."
+    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
+    if [ -z "$ips" ]; then
+        echo "ERROR: Failed to resolve $domain"
+        exit 1
+    fi
+
+    while read -r ip; do
+        if [[ ! "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            echo "ERROR: Invalid IP from DNS for $domain: $ip"
+            exit 1
+        fi
+        echo "Adding $ip for $domain"
+        ipset add allowed-domains "$ip"
+    done < <(echo "$ips")
+done
+
+# Get host IP from default route
+HOST_IP=$(ip route | grep default | cut -d" " -f3)
+if [ -z "$HOST_IP" ]; then
+    echo "ERROR: Failed to detect host IP"
+    exit 1
+fi
+
+HOST_NETWORK=$(echo "$HOST_IP" | sed "s/\.[0-9]*$/.0\/24/")
+echo "Host network detected as: $HOST_NETWORK"
+
+# Set up remaining iptables rules
+iptables -A INPUT -s "$HOST_NETWORK" -j ACCEPT
+iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
+
+# Set default policies to DROP first
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP
+
+# First allow established connections for already approved traffic
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Then allow only specific outbound traffic to allowed domains
+iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+
+# Explicitly REJECT all other outbound traffic for immediate feedback
+iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
+
+echo "Firewall configuration complete"
+echo "Verifying firewall rules..."
+if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed - was able to reach https://example.com"
+    exit 1
+else
+    echo "Firewall verification passed - unable to reach https://example.com as expected"
+fi
+
+# Verify GitHub API access
+if ! curl --connect-timeout 5 https://api.github.com/zen >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed - unable to reach https://api.github.com"
+    exit 1
+else
+    echo "Firewall verification passed - able to reach https://api.github.com as expected"
+fi

--- a/.devcontainer/setup-dotfiles.sh
+++ b/.devcontainer/setup-dotfiles.sh
@@ -1,0 +1,29 @@
+#!/bin/zsh
+set -euo pipefail
+
+DOTFILES_REPO="${DOTFILES_REPO:-git@github.com:monkey999por/dotfiles_zsh.git}"
+DOTFILES_DIR="$HOME/.dotfiles_zsh"
+
+# Idempotency guard
+if [ -f "$DOTFILES_DIR/.installed" ]; then
+  echo "[dotfiles] Already installed, skipping."
+  exit 0
+fi
+
+echo "[dotfiles] Cloning $DOTFILES_REPO ..."
+rm -rf "$DOTFILES_DIR"
+git clone --depth 1 "$DOTFILES_REPO" "$DOTFILES_DIR"
+
+echo "[dotfiles] Running install.sh ..."
+cd "$DOTFILES_DIR"
+zsh install.sh
+
+# Create Homebrew-compatible symlinks for zsh plugins (macOS paths referenced in dotfiles)
+echo "[dotfiles] Creating Homebrew-compatible symlinks ..."
+ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+sudo mkdir -p /opt/homebrew/share/zsh-autosuggestions
+sudo ln -sf "$ZSH_CUSTOM/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh" \
+  /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+
+touch "$DOTFILES_DIR/.installed"
+echo "[dotfiles] Done."

--- a/.devcontainer/supervisord.conf
+++ b/.devcontainer/supervisord.conf
@@ -1,0 +1,12 @@
+[supervisord]
+nodaemon=true
+logfile=/tmp/supervisord.log
+pidfile=/tmp/supervisord.pid
+
+[program:viewer]
+command=pnpm viewer
+directory=/workspace
+autostart=true
+autorestart=true
+stdout_logfile=/workspace/logs/viewer-stdout.log
+stderr_logfile=/workspace/logs/viewer-stderr.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 node_modules/
+.pnpm-store/
 dist/
 *.tsbuildinfo
 gen/

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,19 @@
+services:
+  devcontainer:
+    build:
+      context: .devcontainer
+      dockerfile: Dockerfile
+      args:
+        TZ: ${TZ:-Asia/Tokyo}
+        CLAUDE_CODE_VERSION: latest
+        GIT_DELTA_VERSION: "0.18.2"
+        ZSH_IN_DOCKER_VERSION: "1.2.0"
+        PNPM_VERSION: "10.28.0"
+    volumes:
+      - .:/workspace:cached
+      - ${HOME}/.ssh:/home/node/.ssh:ro
+    ports:
+      - "${VIEWER_HOST_PORT:-3001}:3001"
+    env_file:
+      - .env
+    command: bash -c "mkdir -p /workspace/logs && /usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf"

--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -1240,7 +1240,7 @@ function tryListen(server: ReturnType<typeof createServer>, port: number): Promi
     };
     server.once("error", onError);
     server.once("listening", onListening);
-    server.listen(port);
+    server.listen(port, "0.0.0.0");
   });
 }
 


### PR DESCRIPTION
## Summary

auto-agentの構成を参考に、devcontainerとviewerをcompose.yamlで起動できるDocker開発環境を追加。

Closes #128

## Changes

- `.devcontainer/Dockerfile`: Node 22ベース、pnpm 10.28.0・Claude Code・gh CLI・zsh・supervisor・iptables等インストール
- `.devcontainer/supervisord.conf`: viewerをバックグラウンドサービスとして自動起動（ポート3001）
- `.devcontainer/init-firewall.sh`: allowlistベースのファイアウォール（GitHub・npm・Anthropic API・NewsAPI・YouTube API等）
- `.devcontainer/setup-dotfiles.sh`: dotfilesクローン・セットアップ（冪等性保証）
- `compose.yaml`: devcontainerサービス定義、.envファイル読み込み、SSHキーマウント
- `.devcontainer/devcontainer.json`: VS Code拡張（Claude Code・GitLens）、postCreateCommandでpnpm install実行

## Test plan

- [ ] `docker compose build` でイメージビルドが成功すること
- [ ] `docker compose up` でコンテナが起動しviewerが3001ポートでアクセス可能なこと
- [ ] VS Codeの「Reopen in Container」でdevcontainerとして開発できること
- [ ] supervisordによりviewerが自動起動・自動再起動されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)