### PR TITLE
feat: パイプラインキューにDONE/WAITタブを追加

### DIFF
--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -80,6 +80,7 @@ function loadPipelineQueueDir(): string {
 }
 
 const PIPELINE_QUEUE_DIR = loadPipelineQueueDir();
+const PIPELINE_QUEUE_DONE_DIR = join(PIPELINE_QUEUE_DIR, "..", "pipeline_queue_done");
 
 interface QueueItem {
   id: string;
@@ -705,6 +706,58 @@ app.post("/api/queue/:id/execute", (c) => {
     success: true,
     message: `「${item.title}」のパイプラインをバックグラウンドで開始しました。`,
   });
+});
+
+// --- Done Queue API ---
+
+function readDoneQueueItems(): QueueItem[] {
+  if (!existsSync(PIPELINE_QUEUE_DONE_DIR)) return [];
+  return readdirSync(PIPELINE_QUEUE_DONE_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => {
+      try {
+        return JSON.parse(readFileSync(join(PIPELINE_QUEUE_DONE_DIR, f), "utf-8")) as QueueItem;
+      } catch {
+        return null;
+      }
+    })
+    .filter((item): item is QueueItem => item !== null)
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+app.get("/api/queue/done", (c) => {
+  return c.json(readDoneQueueItems());
+});
+
+app.post("/api/queue/done/:id/restore", (c) => {
+  if (!isDev) return c.json({ error: "Dev mode only" }, 403);
+  const id = c.req.param("id");
+  const doneFilePath = join(PIPELINE_QUEUE_DONE_DIR, `${id}.json`);
+  if (!existsSync(doneFilePath)) return c.json({ error: "Not found" }, 404);
+
+  const existing = JSON.parse(readFileSync(doneFilePath, "utf-8")) as QueueItem;
+
+  // 新IDで pipeline_queue に新規作成
+  if (!existsSync(PIPELINE_QUEUE_DIR)) mkdirSync(PIPELINE_QUEUE_DIR, { recursive: true });
+  const newId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const now = new Date().toISOString();
+  const newItem: QueueItem = {
+    id: newId,
+    title: existing.title,
+    content: existing.content,
+    createdAt: now,
+    updatedAt: now,
+  };
+  writeFileSync(
+    join(PIPELINE_QUEUE_DIR, `${newId}.json`),
+    JSON.stringify(newItem, null, 2),
+    "utf-8",
+  );
+
+  // DONEからファイルを削除
+  unlinkSync(doneFilePath);
+
+  return c.json({ success: true, item: newItem });
 });
 
 app.delete("/api/queue/:id", (c) => {

--- a/viewer/server.ts
+++ b/viewer/server.ts
@@ -630,6 +630,58 @@ app.get("/api/queue", (c) => {
   return c.json(readQueueItems());
 });
 
+// --- Done Queue API （:id より先に定義） ---
+
+function readDoneQueueItems(): QueueItem[] {
+  if (!existsSync(PIPELINE_QUEUE_DONE_DIR)) return [];
+  return readdirSync(PIPELINE_QUEUE_DONE_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => {
+      try {
+        return JSON.parse(readFileSync(join(PIPELINE_QUEUE_DONE_DIR, f), "utf-8")) as QueueItem;
+      } catch {
+        return null;
+      }
+    })
+    .filter((item): item is QueueItem => item !== null)
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+app.get("/api/queue/done", (c) => {
+  return c.json(readDoneQueueItems());
+});
+
+app.post("/api/queue/done/:id/restore", (c) => {
+  if (!isDev) return c.json({ error: "Dev mode only" }, 403);
+  const id = c.req.param("id");
+  const doneFilePath = join(PIPELINE_QUEUE_DONE_DIR, `${id}.json`);
+  if (!existsSync(doneFilePath)) return c.json({ error: "Not found" }, 404);
+
+  const existing = JSON.parse(readFileSync(doneFilePath, "utf-8")) as QueueItem;
+
+  // 新IDで pipeline_queue に新規作成
+  if (!existsSync(PIPELINE_QUEUE_DIR)) mkdirSync(PIPELINE_QUEUE_DIR, { recursive: true });
+  const newId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const now = new Date().toISOString();
+  const newItem: QueueItem = {
+    id: newId,
+    title: existing.title,
+    content: existing.content,
+    createdAt: now,
+    updatedAt: now,
+  };
+  writeFileSync(
+    join(PIPELINE_QUEUE_DIR, `${newId}.json`),
+    JSON.stringify(newItem, null, 2),
+    "utf-8",
+  );
+
+  // DONEからファイルを削除
+  unlinkSync(doneFilePath);
+
+  return c.json({ success: true, item: newItem });
+});
+
 app.get("/api/queue/:id", (c) => {
   const id = c.req.param("id");
   const filePath = join(PIPELINE_QUEUE_DIR, `${id}.json`);
@@ -706,58 +758,6 @@ app.post("/api/queue/:id/execute", (c) => {
     success: true,
     message: `「${item.title}」のパイプラインをバックグラウンドで開始しました。`,
   });
-});
-
-// --- Done Queue API ---
-
-function readDoneQueueItems(): QueueItem[] {
-  if (!existsSync(PIPELINE_QUEUE_DONE_DIR)) return [];
-  return readdirSync(PIPELINE_QUEUE_DONE_DIR)
-    .filter((f) => f.endsWith(".json"))
-    .map((f) => {
-      try {
-        return JSON.parse(readFileSync(join(PIPELINE_QUEUE_DONE_DIR, f), "utf-8")) as QueueItem;
-      } catch {
-        return null;
-      }
-    })
-    .filter((item): item is QueueItem => item !== null)
-    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
-}
-
-app.get("/api/queue/done", (c) => {
-  return c.json(readDoneQueueItems());
-});
-
-app.post("/api/queue/done/:id/restore", (c) => {
-  if (!isDev) return c.json({ error: "Dev mode only" }, 403);
-  const id = c.req.param("id");
-  const doneFilePath = join(PIPELINE_QUEUE_DONE_DIR, `${id}.json`);
-  if (!existsSync(doneFilePath)) return c.json({ error: "Not found" }, 404);
-
-  const existing = JSON.parse(readFileSync(doneFilePath, "utf-8")) as QueueItem;
-
-  // 新IDで pipeline_queue に新規作成
-  if (!existsSync(PIPELINE_QUEUE_DIR)) mkdirSync(PIPELINE_QUEUE_DIR, { recursive: true });
-  const newId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const now = new Date().toISOString();
-  const newItem: QueueItem = {
-    id: newId,
-    title: existing.title,
-    content: existing.content,
-    createdAt: now,
-    updatedAt: now,
-  };
-  writeFileSync(
-    join(PIPELINE_QUEUE_DIR, `${newId}.json`),
-    JSON.stringify(newItem, null, 2),
-    "utf-8",
-  );
-
-  // DONEからファイルを削除
-  unlinkSync(doneFilePath);
-
-  return c.json({ success: true, item: newItem });
 });
 
 app.delete("/api/queue/:id", (c) => {

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -500,6 +500,20 @@ export async function executeQueueItem(
   return res.json();
 }
 
+// --- Done Queue API ---
+
+export async function fetchDoneQueueItems(): Promise<QueueItem[]> {
+  const res = await fetch(`${BASE}/queue/done`);
+  return res.json();
+}
+
+export async function restoreQueueItem(
+  id: string,
+): Promise<{ success: boolean; item?: QueueItem; error?: string }> {
+  const res = await fetch(`${BASE}/queue/done/${id}/restore`, { method: "POST" });
+  return res.json();
+}
+
 // --- Git API ---
 
 export interface GitResult {

--- a/viewer/src/components/QueueManager.tsx
+++ b/viewer/src/components/QueueManager.tsx
@@ -4,17 +4,21 @@ import {
   createQueueItem,
   deleteQueueItem,
   executeQueueItem,
+  fetchDoneQueueItems,
   fetchQueueItems,
   type QueueItem,
+  restoreQueueItem,
   updateQueueItem,
 } from "../api";
 import { useMessageToast } from "../hooks/useMessageToast";
 import { BackButton } from "./shared/BackButton";
 import { CreateButton } from "./shared/CreateButton";
 import { EmptyState } from "./shared/EmptyState";
-import { TrashIcon } from "./shared/Icons";
+import { RestoreIcon, TrashIcon } from "./shared/Icons";
 import { LoadingSpinner } from "./shared/LoadingSpinner";
 import { MessageToast } from "./shared/MessageToast";
+
+type QueueTab = "wait" | "done";
 
 function pushQueueUrl(queueItem?: string | null) {
   const url = new URL(window.location.href);
@@ -33,14 +37,19 @@ function getQueueItemFromUrl(): string | null {
 
 export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: boolean }) {
   const [items, setItems] = useState<QueueItem[]>([]);
+  const [doneItems, setDoneItems] = useState<QueueItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [selected, setSelected] = useState<string | null>(() => getQueueItemFromUrl());
   const [creating, setCreating] = useState(false);
+  const [tab, setTab] = useState<QueueTab>("wait");
   const { message, showMessage } = useMessageToast();
 
   const reload = useCallback(() => {
-    fetchQueueItems()
-      .then(setItems)
+    Promise.all([fetchQueueItems(), fetchDoneQueueItems()])
+      .then(([wait, done]) => {
+        setItems(wait);
+        setDoneItems(done);
+      })
       .finally(() => setLoading(false));
   }, []);
 
@@ -66,7 +75,10 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
     return () => window.removeEventListener("popstate", handlePopState);
   }, []);
 
-  const selectedItem = items.find((i) => i.id === selected);
+  const selectedItem =
+    tab === "wait"
+      ? items.find((i) => i.id === selected)
+      : doneItems.find((i) => i.id === selected);
 
   const handleCreate = useCallback(
     async (title: string, content: string) => {
@@ -117,6 +129,24 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
     [items, showMessage],
   );
 
+  const handleRestore = useCallback(
+    async (id: string) => {
+      const target = doneItems.find((i) => i.id === id);
+      const label = target ? `「${target.title}」` : "このアイテム";
+      if (!window.confirm(`${label}をWAITキューに復元しますか？`)) return;
+      const result = await restoreQueueItem(id);
+      if (result.success) {
+        setSelected(null);
+        pushQueueUrl(null);
+        reload();
+        showMessage("WAITキューに復元しました");
+      } else {
+        showMessage(result.error ?? "復元エラー");
+      }
+    },
+    [doneItems, reload, showMessage],
+  );
+
   const handleDelete = useCallback(
     async (id: string) => {
       const target = items.find((i) => i.id === id);
@@ -133,13 +163,22 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
     [items, selected, reload, showMessage],
   );
 
+  const handleTabChange = useCallback((newTab: QueueTab) => {
+    setTab(newTab);
+    setSelected(null);
+    setCreating(false);
+    pushQueueUrl(null);
+  }, []);
+
   if (loading) {
     return <LoadingSpinner />;
   }
 
+  const currentItems = tab === "wait" ? items : doneItems;
+
   /* Mobile layout */
   if (isMobile) {
-    if (creating) {
+    if (tab === "wait" && creating) {
       return (
         <motion.div
           className="flex flex-col h-full"
@@ -161,6 +200,27 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
       );
     }
     if (selectedItem) {
+      if (tab === "done") {
+        return (
+          <motion.div
+            className="flex flex-col h-full"
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.25 }}
+          >
+            <QueueDetailView
+              item={selectedItem}
+              onBack={() => {
+                setSelected(null);
+                pushQueueUrl(null);
+              }}
+              onRestore={isDev ? () => handleRestore(selectedItem.id) : undefined}
+              isMobile
+            />
+            <MessageToast message={message} />
+          </motion.div>
+        );
+      }
       return (
         <motion.div
           className="flex flex-col h-full"
@@ -191,9 +251,14 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
         transition={{ duration: 0.4 }}
       >
         <div className="flex items-center gap-2 px-4 py-3 bg-gray-900 border-b border-gray-800 shrink-0">
-          <h2 className="text-sm font-semibold text-gray-200">パイプラインキュー</h2>
+          <QueueTabs
+            tab={tab}
+            onTabChange={handleTabChange}
+            waitCount={items.length}
+            doneCount={doneItems.length}
+          />
           <div className="flex-1" />
-          {isDev && (
+          {tab === "wait" && isDev && (
             <CreateButton
               onClick={() => {
                 setCreating(true);
@@ -207,14 +272,16 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
         </div>
         <div className="flex-1 overflow-y-auto dark-scrollbar p-4 pb-32 bg-gray-900">
           <QueueList
-            items={items}
+            items={currentItems}
             selected={selected}
             onSelect={(id) => {
               setSelected(id);
               pushQueueUrl(id);
             }}
-            onDelete={handleDelete}
+            onDelete={tab === "wait" ? handleDelete : undefined}
+            onRestore={tab === "done" && isDev ? handleRestore : undefined}
             isDev={isDev}
+            isDone={tab === "done"}
             isMobile
           />
         </div>
@@ -234,11 +301,16 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
       {/* Left: queue list */}
       <div className="w-72 flex flex-col border-r border-gray-700/50 shrink-0">
         <div className="flex items-center gap-2 px-4 bg-gray-800/50 border-b border-gray-700/50 shrink-0">
-          <span className="px-3 py-2.5 text-xs font-medium text-orange-400">
-            パイプラインキュー
-          </span>
+          <div className="py-1.5">
+            <QueueTabs
+              tab={tab}
+              onTabChange={handleTabChange}
+              waitCount={items.length}
+              doneCount={doneItems.length}
+            />
+          </div>
           <div className="flex-1" />
-          {isDev && (
+          {tab === "wait" && isDev && (
             <CreateButton
               onClick={() => {
                 setCreating(true);
@@ -252,22 +324,24 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
         </div>
         <div className="flex-1 overflow-y-auto dark-scrollbar p-3 bg-gray-900">
           <QueueList
-            items={items}
+            items={currentItems}
             selected={selected}
             onSelect={(id) => {
               setSelected(id);
               setCreating(false);
               pushQueueUrl(id);
             }}
-            onDelete={handleDelete}
+            onDelete={tab === "wait" ? handleDelete : undefined}
+            onRestore={tab === "done" && isDev ? handleRestore : undefined}
             isDev={isDev}
+            isDone={tab === "done"}
           />
         </div>
       </div>
 
-      {/* Right: edit form */}
+      {/* Right: detail / form */}
       <div className="flex-1 flex flex-col min-w-0">
-        {creating ? (
+        {tab === "wait" && creating ? (
           <QueueForm
             key="__new__"
             onSubmit={handleCreate}
@@ -276,7 +350,7 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
               pushQueueUrl(null);
             }}
           />
-        ) : selectedItem ? (
+        ) : tab === "wait" && selectedItem ? (
           <QueueForm
             key={selectedItem.id}
             item={selectedItem}
@@ -287,11 +361,24 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
             }}
             onExecute={isDev ? () => handleExecute(selectedItem.id) : undefined}
           />
+        ) : tab === "done" && selectedItem ? (
+          <QueueDetailView
+            item={selectedItem}
+            onBack={() => {
+              setSelected(null);
+              pushQueueUrl(null);
+            }}
+            onRestore={isDev ? () => handleRestore(selectedItem.id) : undefined}
+          />
         ) : (
           <div className="flex h-full items-center justify-center text-gray-500 text-sm">
-            {items.length === 0
-              ? "キューにアイデアを追加して、定期実行で要件を自動生成しましょう"
-              : "キューアイテムを選択してください"}
+            {tab === "wait"
+              ? items.length === 0
+                ? "キューにアイデアを追加して、定期実行で要件を自動生成しましょう"
+                : "キューアイテムを選択してください"
+              : doneItems.length === 0
+                ? "完了済みのアイテムはありません"
+                : "完了済みアイテムを選択してください"}
           </div>
         )}
       </div>
@@ -300,19 +387,62 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
   );
 }
 
+function QueueTabs({
+  tab,
+  onTabChange,
+  waitCount,
+  doneCount,
+}: {
+  tab: QueueTab;
+  onTabChange: (tab: QueueTab) => void;
+  waitCount: number;
+  doneCount: number;
+}) {
+  return (
+    <div className="flex gap-1 shrink-0">
+      <button
+        type="button"
+        className={`px-2.5 py-1.5 text-xs font-medium rounded-lg transition-colors ${
+          tab === "wait"
+            ? "bg-orange-500/15 text-orange-400"
+            : "text-gray-500 hover:text-gray-300 hover:bg-white/[0.04]"
+        }`}
+        onClick={() => onTabChange("wait")}
+      >
+        WAIT{waitCount > 0 && ` (${waitCount})`}
+      </button>
+      <button
+        type="button"
+        className={`px-2.5 py-1.5 text-xs font-medium rounded-lg transition-colors ${
+          tab === "done"
+            ? "bg-emerald-500/15 text-emerald-400"
+            : "text-gray-500 hover:text-gray-300 hover:bg-white/[0.04]"
+        }`}
+        onClick={() => onTabChange("done")}
+      >
+        DONE{doneCount > 0 && ` (${doneCount})`}
+      </button>
+    </div>
+  );
+}
+
 function QueueList({
   items,
   selected,
   onSelect,
   onDelete,
+  onRestore,
   isDev,
+  isDone,
   isMobile,
 }: {
   items: QueueItem[];
   selected: string | null;
   onSelect: (id: string) => void;
-  onDelete: (id: string) => void;
+  onDelete?: (id: string) => void;
+  onRestore?: (id: string) => void;
   isDev: boolean;
+  isDone?: boolean;
   isMobile?: boolean;
 }) {
   if (items.length === 0) {
@@ -334,11 +464,20 @@ function QueueList({
             />
           </svg>
         }
-        message="キューは空です"
-        submessage="アプリのアイデアを追加して定期実行に備えましょう"
+        message={isDone ? "完了済みのアイテムはありません" : "キューは空です"}
+        submessage={
+          isDone
+            ? "パイプライン実行が完了するとここに表示されます"
+            : "アプリのアイデアを追加して定期実行に備えましょう"
+        }
       />
     );
   }
+
+  const selectedColor = isDone
+    ? "bg-emerald-500/15 text-emerald-400"
+    : "bg-orange-500/15 text-orange-400";
+  const selectedIconColor = isDone ? "text-emerald-400" : "text-orange-400";
 
   return (
     <div className="space-y-1">
@@ -348,31 +487,61 @@ function QueueList({
           key={item.id}
           className={`
             group w-full flex items-center gap-2 px-3 py-2.5 rounded-xl cursor-pointer transition-colors
-            ${selected === item.id ? "bg-orange-500/15 text-orange-400" : "text-gray-400 hover:bg-white/[0.04] hover:text-gray-200"}
+            ${selected === item.id ? selectedColor : "text-gray-400 hover:bg-white/[0.04] hover:text-gray-200"}
           `}
           onClick={() => onSelect(item.id)}
         >
-          <svg
-            aria-hidden="true"
-            className={`size-4 shrink-0 ${selected === item.id ? "text-orange-400" : "text-gray-600"}`}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.5}
-              d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z"
-            />
-          </svg>
+          {isDone ? (
+            <svg
+              aria-hidden="true"
+              className={`size-4 shrink-0 ${selected === item.id ? selectedIconColor : "text-gray-600"}`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+              />
+            </svg>
+          ) : (
+            <svg
+              aria-hidden="true"
+              className={`size-4 shrink-0 ${selected === item.id ? selectedIconColor : "text-gray-600"}`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z"
+              />
+            </svg>
+          )}
           <div className="flex-1 min-w-0">
             <p className="text-[14px] font-medium truncate">{item.title}</p>
             <p className="text-[11px] text-gray-600 truncate">
               {new Date(item.createdAt).toLocaleDateString("ja-JP")}
             </p>
           </div>
-          {isDev && (
+          {isDev && onRestore && (
+            <button
+              type="button"
+              className={`p-1.5 rounded-lg text-gray-700 hover:text-orange-400 hover:bg-orange-400/10 transition-all shrink-0 ${isMobile ? "opacity-100" : "opacity-0 group-hover:opacity-100"}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onRestore(item.id);
+              }}
+              title="WAITに復元"
+            >
+              <RestoreIcon className="size-4" />
+            </button>
+          )}
+          {isDev && onDelete && (
             <button
               type="button"
               className={`p-1.5 rounded-lg text-gray-700 hover:text-red-400 hover:bg-red-400/10 transition-all shrink-0 ${isMobile ? "opacity-100" : "opacity-0 group-hover:opacity-100"}`}
@@ -477,6 +646,66 @@ function QueueForm({
             value={content}
             onChange={(e) => setContent(e.target.value)}
           />
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+function QueueDetailView({
+  item,
+  onBack,
+  onRestore,
+  isMobile,
+}: {
+  item: QueueItem;
+  onBack: () => void;
+  onRestore?: () => void;
+  isMobile?: boolean;
+}) {
+  return (
+    <motion.div
+      className="flex flex-col h-full"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2 }}
+    >
+      <div className="flex items-center gap-2 px-4 bg-gray-800/50 border-b border-gray-700/50 shrink-0">
+        {isMobile && <BackButton onClick={onBack} />}
+        <span className="px-3 py-2.5 text-xs font-medium text-emerald-400">完了済みアイテム</span>
+        <div className="flex-1" />
+        {onRestore && (
+          <button
+            type="button"
+            className="px-3 py-1.5 my-1 text-xs font-medium rounded-lg transition-colors bg-orange-600 text-white hover:bg-orange-500 flex items-center gap-1.5"
+            onClick={onRestore}
+            title="WAITキューに復元"
+          >
+            <RestoreIcon className="size-3.5" />
+            WAITに復元
+          </button>
+        )}
+      </div>
+      <div
+        className={`flex-1 flex flex-col overflow-hidden p-6 ${isMobile ? "pb-32" : ""} bg-gray-900 gap-4`}
+      >
+        <div className="shrink-0">
+          <span className="block text-[11px] font-medium text-gray-500 mb-1.5">タイトル</span>
+          <p className="px-3 py-2 text-sm bg-gray-800/50 border border-gray-700/30 rounded-lg text-gray-300">
+            {item.title}
+          </p>
+        </div>
+        <div className="flex-1 flex flex-col min-h-0">
+          <span className="block text-[11px] font-medium text-gray-500 mb-1.5 shrink-0">内容</span>
+          <div className="flex-1 px-3 py-2 text-sm bg-gray-800/50 border border-gray-700/30 rounded-lg text-gray-300 overflow-y-auto dark-scrollbar whitespace-pre-wrap">
+            {item.content}
+          </div>
+        </div>
+        <div className="shrink-0">
+          <span className="block text-[11px] font-medium text-gray-500 mb-1">作成日時</span>
+          <p className="text-xs text-gray-400">
+            {new Date(item.createdAt).toLocaleString("ja-JP")}
+          </p>
         </div>
       </div>
     </motion.div>

--- a/viewer/src/components/QueueManager.tsx
+++ b/viewer/src/components/QueueManager.tsx
@@ -20,9 +20,16 @@ import { MessageToast } from "./shared/MessageToast";
 
 type QueueTab = "wait" | "done";
 
-function pushQueueUrl(queueItem?: string | null) {
+function pushQueueUrl(queueItem?: string | null, queueTab?: QueueTab | null) {
   const url = new URL(window.location.href);
   url.searchParams.set("view", "queue");
+  // queueTab が明示的に渡された場合はそれを使い、渡されなかったら現在のURLから保持
+  const effectiveTab = queueTab !== undefined ? queueTab : getQueueTabFromUrl();
+  if (effectiveTab && effectiveTab !== "wait") {
+    url.searchParams.set("queueTab", effectiveTab);
+  } else {
+    url.searchParams.delete("queueTab");
+  }
   if (queueItem) {
     url.searchParams.set("queueItem", queueItem);
   } else {
@@ -35,13 +42,18 @@ function getQueueItemFromUrl(): string | null {
   return new URLSearchParams(window.location.search).get("queueItem");
 }
 
+function getQueueTabFromUrl(): QueueTab {
+  const t = new URLSearchParams(window.location.search).get("queueTab");
+  return t === "done" ? "done" : "wait";
+}
+
 export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: boolean }) {
   const [items, setItems] = useState<QueueItem[]>([]);
   const [doneItems, setDoneItems] = useState<QueueItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [selected, setSelected] = useState<string | null>(() => getQueueItemFromUrl());
   const [creating, setCreating] = useState(false);
-  const [tab, setTab] = useState<QueueTab>("wait");
+  const [tab, setTab] = useState<QueueTab>(() => getQueueTabFromUrl());
   const { message, showMessage } = useMessageToast();
 
   const reload = useCallback(() => {
@@ -62,6 +74,7 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
     const handlePopState = () => {
       const params = new URLSearchParams(window.location.search);
       if (params.get("view") !== "queue") return;
+      setTab(getQueueTabFromUrl());
       const queueItem = params.get("queueItem");
       if (queueItem === "__new__") {
         setCreating(true);
@@ -167,7 +180,7 @@ export function QueueManager({ isMobile, isDev }: { isMobile: boolean; isDev: bo
     setTab(newTab);
     setSelected(null);
     setCreating(false);
-    pushQueueUrl(null);
+    pushQueueUrl(null, newTab);
   }, []);
 
   if (loading) {

--- a/viewer/src/components/shared/Icons.tsx
+++ b/viewer/src/components/shared/Icons.tsx
@@ -67,6 +67,26 @@ export function DownloadIcon({ className = "size-4" }: IconProps) {
   );
 }
 
+/** 復元アイコン */
+export function RestoreIcon({ className = "size-3.5" }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3"
+      />
+    </svg>
+  );
+}
+
 /** ゴミ箱（削除）アイコン */
 export function TrashIcon({ className = "size-3.5" }: IconProps) {
   return (


### PR DESCRIPTION
## Summary

パイプラインキュー画面にWAIT/DONEタブを追加し、処理完了済みのキューアイテムをViewerから閲覧可能にした。

Closes #138

## Changes

- `GET /api/queue/done` エンドポイント追加（pipeline_queue_done配下の完了済みアイテム取得）
- `POST /api/queue/done/:id/restore` エンドポイント追加（DONE→WAITへ復元、元ファイル削除＋新ID作成）
- フロントAPI関数 `fetchDoneQueueItems()` / `restoreQueueItem()` 追加
- QueueManagerにWAIT/DONEタブ切替UI実装
- DONEアイテムは読み取り専用の詳細ビュー（QueueDetailView）で表示
- 復元ボタンで確認ダイアログ→WAITキューに復元
- RestoreIcon（戻る矢印）を共有アイコンに追加

## Test plan

- [ ] WAITタブ: 既存のキュー操作（作成・編集・実行・削除）が従来通り動作すること
- [ ] DONEタブ: pipeline_queue_done配下のアイテムが一覧表示されること
- [ ] DONEタブ: アイテム選択で読み取り専用の詳細ビューが表示されること（編集フォーム非表示）
- [ ] DONEタブ: 復元ボタンでWAITキューに新規作成され、DONEから削除されること
- [ ] モバイル表示: タブ切替・DONEアイテム表示・復元が正常に動作すること
- [ ] dev mode OFF時: 復元ボタンが非表示であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)